### PR TITLE
SCOUT-23 Hl7LogExtractor orchestration can ingest "yesterday"'s logs on a scheduled run

### DIFF
--- a/helm/orchestration/temporal-java.values.yaml
+++ b/helm/orchestration/temporal-java.values.yaml
@@ -7,6 +7,9 @@ envFrom:
       name: s3-secret
   - configMapRef:
       name: s3-env
+env:
+  - name: TZ
+    value: "US/Central"
 volumes:
   - name: hl7logs
     hostPath:

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
@@ -13,6 +13,8 @@ import edu.washu.tag.temporal.model.TransformSplitHl7LogInput;
 import edu.washu.tag.temporal.model.TransformSplitHl7LogOutput;
 import io.temporal.activity.ActivityOptions;
 import io.temporal.common.RetryOptions;
+import io.temporal.common.SearchAttributeKey;
+import io.temporal.failure.ApplicationFailure;
 import io.temporal.spring.boot.WorkflowImpl;
 import io.temporal.workflow.ActivityStub;
 import io.temporal.workflow.Async;
@@ -22,12 +24,20 @@ import io.temporal.workflow.WorkflowInfo;
 import org.slf4j.Logger;
 
 import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
 @WorkflowImpl(taskQueues = "ingest-hl7-log")
 public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
     private static final Logger logger = Workflow.getLogger(IngestHl7LogWorkflowImpl.class);
+
+    private static final SearchAttributeKey<OffsetDateTime> SCHEDULED_START_TIME =
+            SearchAttributeKey.forOffsetDateTime("TemporalScheduledStartTime");
+    private static final DateTimeFormatter YYYYMMDD_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     private final SplitHl7LogActivity hl7LogActivity =
             Workflow.newActivityStub(SplitHl7LogActivity.class,
@@ -49,12 +59,20 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
     @Override
     public IngestHl7LogWorkflowOutput ingestHl7Log(IngestHl7LogWorkflowInput input) {
         WorkflowInfo workflowInfo = Workflow.getInfo();
-        logger.info("Ingesting HL7 log for workflowId {}", workflowInfo.getWorkflowId());
+        logger.info("Beginning workflow {} workflowId {}", this.getClass().getSimpleName(), workflowInfo.getWorkflowId());
+
+        // Log input values
+        logger.debug("Input: {}", input);
+
+        // Determine date
+        String date = determineDate(input.date());
+
+        // Validate input
+        throwOnInvalidInput(input, date);
 
         String scratchDir = input.scratchSpaceRootPath() + (input.scratchSpaceRootPath().endsWith("/") ? "" : "/") + workflowInfo.getWorkflowId();
 
         // Find log file by date
-        String date = input.date().replace("-", "");
         FindHl7LogFileInput findHl7LogFileInput = new FindHl7LogFileInput(date, input.logsRootPath());
         FindHl7LogFileOutput findHl7LogFileOutput = hl7LogActivity.findHl7LogFile(findHl7LogFileInput);
 
@@ -90,5 +108,72 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
         );
 
         return new IngestHl7LogWorkflowOutput();
+    }
+
+    private static void throwOnInvalidInput(IngestHl7LogWorkflowInput input, String date) {
+        boolean hasLogsRootPath = input.logsRootPath() != null && !input.logsRootPath().isBlank();
+        boolean hasScratchSpaceRootPath = input.scratchSpaceRootPath() != null && !input.scratchSpaceRootPath().isBlank();
+        boolean hasHl7OutputPath = input.hl7OutputPath() != null && !input.hl7OutputPath().isBlank();
+        boolean hasDeltaLakePath = input.deltaLakePath() != null && !input.deltaLakePath().isBlank();
+        boolean hasDate = date != null;
+
+        if (!(hasLogsRootPath && hasScratchSpaceRootPath && hasHl7OutputPath && hasDeltaLakePath && hasDate)) {
+            // We know something is missing
+            List<String> missingInputs = new ArrayList<>();
+            if (!hasLogsRootPath) {
+                missingInputs.add("logsRootPath");
+            }
+            if (!hasScratchSpaceRootPath) {
+                missingInputs.add("scratchSpaceRootPath");
+            }
+            if (!hasHl7OutputPath) {
+                missingInputs.add("hl7OutputPath");
+            }
+            if (!hasDeltaLakePath) {
+                missingInputs.add("deltaLakePath");
+            }
+            if (!hasDate) {
+                missingInputs.add("date");
+            }
+            String plural = missingInputs.size() == 1 ? "" : "s";
+            String missingInputsStr = String.join(", ", missingInputs);
+            throw ApplicationFailure.newNonRetryableFailure("Missing required input" + plural + ": " + missingInputsStr, "type");
+        }
+    }
+
+    /**
+     * Determine the date to use for the workflow.
+     * If the input date is null, use the scheduled start time of the workflow minus one day—i.e. "yesterday".
+     * @param dateInput The date value from the workflow inputs
+     * @return Date to use for the workflow
+     */
+    private static String determineDate(String dateInput) {
+        String date;
+        if (dateInput == null) {
+            // Get the date from the time the workflow was scheduled to start
+            // Note that there isn't a good API for this in the SDK. We have to use a
+            //  search attribute.
+            // See https://docs.temporal.io/workflows#action for docs on the search attribute.
+            // See also https://github.com/temporalio/features/issues/243 where someone asks
+            //  for a better API for this in the SDK.
+            OffsetDateTime scheduledTimeUtc = Workflow.getTypedSearchAttributes().get(SCHEDULED_START_TIME);
+
+            if (scheduledTimeUtc == null) {
+                logger.debug("No date input, and scheduled start time not found in search attributes.");
+                date = null;
+            } else {
+                // Ingest logs from "yesterday" which we define as the day before the scheduled time in the local timezone
+                ZoneId localTz = ZoneOffset.systemDefault();
+                OffsetDateTime scheduledTimeLocal = scheduledTimeUtc.atZoneSameInstant(localTz).toOffsetDateTime();
+                OffsetDateTime yesterday = scheduledTimeLocal.minusDays(1);
+                date = yesterday.format(YYYYMMDD_FORMAT);
+                logger.debug("Using date {} from scheduled workflow start time {} ({} in TZ {}) minus one day", date, scheduledTimeUtc, scheduledTimeLocal, localTz);
+            }
+        } else {
+            // Use the input date, removing any hyphens
+            date = dateInput.replace("-", "");
+            logger.debug("Using date {} from input value {}", date, dateInput);
+        }
+        return date;
     }
 }


### PR DESCRIPTION

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description
Update Temporal workflow `IngestHl7LogWorkflow` input handling so that if no `"date"` input arg is passed, we run the workflow with yesterday's date. This will let us schedule daily workflow runs to ingest the newest HL7 log file.

### Product
No user-facing changes

### Technical
This changes how the `"date"` input arg is handled in the `IngestHl7LogWorkflow` Temporal workflow.
- If a date is passed, we use it. This is the previous behavior.
- If a date is not passed we use the Temporal SDK to read a workflow [search attribute](https://docs.temporal.io/workflows#action) `TemporalScheduledStartTime`.
- If this attribute is empty, then the `date` is left as `null`. (Side note: I also added handling for any of the input values being `null` or empty, which we treat as a non-retryable error for this workflow run.)
- If the `TemporalScheduledStartTime` is not empty, use it to find "yesterday"'s date.
    - Convert from UTC to local time zone, using system's default time zone. See note below.
    - Subtract one day

I gave some consideration to time zones and the meaning of "yesterday". Temporal times are reported in UTC. I assumed that we would be scheduling the workflow runs according to local time zones, and would want "yesterday" to be defined locally as well. In the code I convert the UTC date time from Temporal into a local date time using the system's default time zone, assuming that this will be set to a local time.

I did have to change the configuration of the helm deploy to set the time zone within the worker container by setting the environment variable `TZ="US/Central"`. If this local time zone handling becomes a problem in the future we could always add the time zone as an input parameter, but I don't think it will be an issue.  

## Impact

### Security 
N/A

### Performance
N/A

### Data
This does raise the question of what happens when no log file exists corresponding to the date.
The current behavior is for the activity that finds the log file to fail in a retryable way.
I think this is probably not the right behavior, but
1. I don't know what the correct behavior is, and
2. It's a bit outside the scope of this change. 

I intend to tackle this in the future.

### Backward compatibility
Yes

## Testing
Manual testing. Scheduled a workflow in Temporal UI with no `"date"` input and verified that workflow continued execution with yesterday's date.
- Ran the Temporal worker through IntelliJ on my laptop, connected to Temporal server via port forward.
- Ran worker on big03 k8s deployed with helm.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
