### PR TITLE
Run ci workflow when PR edited/synchronize

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Post-Commit Tasks
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, edited, synchronize]
   push:
     branches: [main]
 


### PR DESCRIPTION
# Run ci workflow when PR edited/synchronize

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
N/A

### Technical
Andy had a PR recently that couldn't merge, presumably because the branch protection was seeing the workflow was out of date. With some extra triggers, we can hopefully pre-emptively launch the workflow again to avoid that.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
N/A

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added or updated user documentation, if appropriate.
- [X] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
