### PR TITLE
Allow lint and image builds in parallel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,6 @@ jobs:
       contents: read
       attestations: write
       id-token: write
-    needs: [lint]
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -48,7 +47,7 @@ jobs:
           image-name: temporal-python
   deploy-and-test:
     runs-on: ubuntu-latest
-    needs: [build-and-upload-artifact]
+    needs: [lint, build-and-upload-artifact]
     steps:
       - name: Checkout GitHub Action
         uses: actions/checkout@v4.2.1 # TODO: the rest


### PR DESCRIPTION
# Allow lint and image builds in parallel

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer. 

For all other change types, the developer should attempt to provide as much detail as is reasonable.

## Description

### Product
N/A

### Technical
Linting and building the images do not actually depend on each other, so we can speed up the action by allowing them to run in parallel.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
N/A

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added or updated user documentation, if appropriate.
- [X] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
