### PR TITLE
SCOUT-44 Enabling unit tests in GHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,9 +45,20 @@ jobs:
         with:
           subproject: orchestration/temporal-python
           image-name: temporal-python
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.1
+      - uses: actions/setup-java@v4
+        with:
+          distribution: ${{ ENV.JAVA_DIST }}
+          java-version: ${{ ENV.JAVA_VERSION }}
+      - name: 'Unit tests: temporal-java'
+        shell: bash
+        run: cd orchestration/temporal-java && ./gradlew test
   deploy-and-test:
     runs-on: ubuntu-latest
-    needs: [lint, build-and-upload-artifact]
+    needs: [lint, build-and-upload-artifact, unit-test]
     steps:
       - name: Checkout GitHub Action
         uses: actions/checkout@v4.2.1 # TODO: the rest

--- a/orchestration/temporal-java/src/test/resources/application.yaml
+++ b/orchestration/temporal-java/src/test/resources/application.yaml
@@ -1,0 +1,17 @@
+spring:
+  application:
+    name: temporal-java
+  temporal:
+    connection:
+      target: 127.0.0.1:7233
+      target.namespace: default
+    start-workers: true
+    workers-auto-discovery:
+      packages:
+        - edu.washu.tag.temporal.activity
+        - edu.washu.tag.temporal.workflow
+    test-server:
+      enabled: true
+s3:
+  endpoint: 'http://minio.minio:9000'
+  region: us-east-1


### PR DESCRIPTION
# SCOUT-44 Enabling unit tests in GHA

## Type of change
- [ ] Work behind a feature flag
- [X] New feature
- [ ] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [X] Test update

## Description

### Product
This adds an `application.yaml` in the temporal-java test resources to use temporal's test server. Additionally, I added it as a job in github actions so we can have it running automatically.

### Technical
The new `unit-test` job runs in parallel with linting and the build+upload job. All 3 are required to pass before integration tests launch.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
It works on my machine. Making this PR should trigger a test run on github actions as another 👍 

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added or updated user documentation, if appropriate.
- [X] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
