### PR TITLE
SCOUT-52 Add bulk HL7 log extraction + improve race conditions

### DIFF
--- a/orchestration/temporal-java/build.gradle
+++ b/orchestration/temporal-java/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation "io.temporal:temporal-sdk:${temporalVersion}"
     implementation "io.temporal:temporal-spring-boot-starter:${temporalVersion}"
 	implementation "software.amazon.awssdk:s3:${s3Version}"
+	implementation "org.apache.commons:commons-lang3"
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/activity/SplitHl7LogActivityImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/activity/SplitHl7LogActivityImpl.java
@@ -75,7 +75,7 @@ public class SplitHl7LogActivityImpl implements SplitHl7LogActivity {
             throw ApplicationFailure.newFailure("Expected exactly one file with date " + input.date() + " in " + input.logsDir() + ". Found " + (logFiles == null ? 0 : logFiles.length), "type");
         }
 
-        return new FindHl7LogFileOutput(logFiles[0].getAbsolutePath());
+        return new FindHl7LogFileOutput(input.date(), logFiles[0].getAbsolutePath());
     }
 
     @Override
@@ -109,7 +109,7 @@ public class SplitHl7LogActivityImpl implements SplitHl7LogActivity {
             logger.warn("Failed to delete temp dir {}", tempdir);
         }
 
-        return new SplitHl7LogActivityOutput(input.rootOutputPath(), destinationPaths);
+        return new SplitHl7LogActivityOutput(input.date(), input.rootOutputPath(), destinationPaths);
     }
 
     @Override
@@ -150,6 +150,6 @@ public class SplitHl7LogActivityImpl implements SplitHl7LogActivity {
         } catch (IOException ignored) {
             logger.warn("Failed to delete temp dir {}", tempdir);
         }
-        return new TransformSplitHl7LogOutput(input.rootOutputPath(), destinationPath);
+        return new TransformSplitHl7LogOutput(input.date(), input.rootOutputPath(), destinationPath);
     }
 }

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/FindHl7LogFileOutput.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/FindHl7LogFileOutput.java
@@ -1,3 +1,3 @@
 package edu.washu.tag.temporal.model;
 
-public record FindHl7LogFileOutput(String logFileAbsPath) { }
+public record FindHl7LogFileOutput(String date, String logFileAbsPath) { }

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/SplitHl7LogActivityInput.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/SplitHl7LogActivityInput.java
@@ -1,3 +1,3 @@
 package edu.washu.tag.temporal.model;
 
-public record SplitHl7LogActivityInput(String logFilePath, String rootOutputPath) { }
+public record SplitHl7LogActivityInput(String date, String logFilePath, String rootOutputPath) { }

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/SplitHl7LogActivityOutput.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/SplitHl7LogActivityOutput.java
@@ -2,4 +2,4 @@ package edu.washu.tag.temporal.model;
 
 import java.util.List;
 
-public record SplitHl7LogActivityOutput(String rootPath, List<String> relativePaths) { }
+public record SplitHl7LogActivityOutput(String date, String rootPath, List<String> relativePaths) { }

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/TransformSplitHl7LogInput.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/TransformSplitHl7LogInput.java
@@ -1,3 +1,3 @@
 package edu.washu.tag.temporal.model;
 
-public record TransformSplitHl7LogInput(String splitLogFile, String rootOutputPath) { }
+public record TransformSplitHl7LogInput(String date, String splitLogFile, String rootOutputPath) { }

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/TransformSplitHl7LogOutput.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/TransformSplitHl7LogOutput.java
@@ -1,3 +1,3 @@
 package edu.washu.tag.temporal.model;
 
-public record TransformSplitHl7LogOutput(String rootPath, String relativePath) { }
+public record TransformSplitHl7LogOutput(String date, String rootPath, String relativePath) { }

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
@@ -117,7 +117,7 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
         // Partition hl7 paths by year, so it can avoid race conditions on writing the files
         final Map<String, List<String>> hl7AbsolutePathsByYear = transformSplitHl7LogOutputPromises.stream()
                 .map(Promise::get)
-                .map(output -> Pair.of(output.date().substring(0, 3), hl7RootPath + "/" + output.relativePath()))
+                .map(output -> Pair.of(output.date().substring(0, 4), hl7RootPath + "/" + output.relativePath()))
                 .collect(
                         Collectors.groupingBy(
                                 Pair::getLeft,

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
@@ -21,6 +21,7 @@ import io.temporal.workflow.Async;
 import io.temporal.workflow.Promise;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInfo;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -29,7 +30,11 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @WorkflowImpl(taskQueues = "ingest-hl7-log")
 public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
@@ -64,60 +69,86 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
         // Log input values
         logger.debug("Input: {}", input);
 
-        // Determine date
-        String date = determineDate(input.date());
+        // Determine dates
+        List<String> dates = determineDate(input.date());
 
         // Validate input
-        throwOnInvalidInput(input, date);
+        throwOnInvalidInput(input, dates);
 
         String scratchDir = input.scratchSpaceRootPath() + (input.scratchSpaceRootPath().endsWith("/") ? "" : "/") + workflowInfo.getWorkflowId();
 
         // Find log file by date
-        FindHl7LogFileInput findHl7LogFileInput = new FindHl7LogFileInput(date, input.logsRootPath());
-        FindHl7LogFileOutput findHl7LogFileOutput = hl7LogActivity.findHl7LogFile(findHl7LogFileInput);
+        List<Promise<FindHl7LogFileOutput>> findHl7LogFileOutputPromises = dates.stream()
+                .map(date -> Async.function(hl7LogActivity::findHl7LogFile, new FindHl7LogFileInput(date, input.logsRootPath())))
+                .toList();
+        // Collect async results
+        List<FindHl7LogFileOutput> findHl7LogFileOutputs = findHl7LogFileOutputPromises.stream()
+                .map(Promise::get)
+                .toList();
 
         // Split log file
         String splitLogFileOutputPath = scratchDir + "/split";
-        SplitHl7LogActivityInput splitHl7LogInput = new SplitHl7LogActivityInput(findHl7LogFileOutput.logFileAbsPath(), splitLogFileOutputPath);
-        SplitHl7LogActivityOutput splitHl7LogOutput = hl7LogActivity.splitHl7Log(splitHl7LogInput);
+        List<Promise<SplitHl7LogActivityOutput>> splitHl7LogOutputPromises = findHl7LogFileOutputs.stream()
+                .map(findHl7LogFileOutput -> Async.function(
+                        hl7LogActivity::splitHl7Log,
+                        new SplitHl7LogActivityInput(findHl7LogFileOutput.date(), findHl7LogFileOutput.logFileAbsPath(), splitLogFileOutputPath)
+                ))
+                .toList();
+        // Collect async results
+        List<SplitHl7LogActivityOutput> splitHl7LogOutputs = splitHl7LogOutputPromises.stream()
+                .map(Promise::get)
+                .toList();
 
-        // Fan out
+        // Transform split logs into proper hl7 files
         String hl7RootPath = input.hl7OutputPath().endsWith("/") ? input.hl7OutputPath().substring(0, input.hl7OutputPath().length() - 1) : input.hl7OutputPath();
         List<Promise<TransformSplitHl7LogOutput>> transformSplitHl7LogOutputPromises = new ArrayList<>();
-        for (String splitLogFileRelativePath : splitHl7LogOutput.relativePaths()) {
-            // Async call to transform split log file into HL7
-            String splitLogFilePath = splitHl7LogOutput.rootPath() + "/" + splitLogFileRelativePath;
-            TransformSplitHl7LogInput transformSplitHl7LogInput = new TransformSplitHl7LogInput(splitLogFilePath, hl7RootPath);
-            Promise<TransformSplitHl7LogOutput> transformSplitHl7LogOutputPromise =
-                    Async.function(hl7LogActivity::transformSplitHl7Log, transformSplitHl7LogInput);
-            transformSplitHl7LogOutputPromises.add(transformSplitHl7LogOutputPromise);
+        for (SplitHl7LogActivityOutput splitHl7LogOutput : splitHl7LogOutputs) {
+            String date = splitHl7LogOutput.date();
+            for (String splitLogFileRelativePath : splitHl7LogOutput.relativePaths()) {
+                // Async call to transform a single split log file into HL7
+                String splitLogFilePath = splitHl7LogOutput.rootPath() + "/" + splitLogFileRelativePath;
+                TransformSplitHl7LogInput transformSplitHl7LogInput = new TransformSplitHl7LogInput(date, splitLogFilePath, hl7RootPath);
+                Promise<TransformSplitHl7LogOutput> transformSplitHl7LogOutputPromise =
+                        Async.function(hl7LogActivity::transformSplitHl7Log, transformSplitHl7LogInput);
+                transformSplitHl7LogOutputPromises.add(transformSplitHl7LogOutputPromise);
+            }
         }
         // Collect async results
-        final List<String> hl7AbsolutePaths = transformSplitHl7LogOutputPromises.stream()
+        // Partition hl7 paths by year, so it can avoid race conditions on writing the files
+        final Map<String, List<String>> hl7AbsolutePathsByYear = transformSplitHl7LogOutputPromises.stream()
                 .map(Promise::get)
-                .map(TransformSplitHl7LogOutput::relativePath)
-                .map(relativePath -> hl7RootPath + "/" + relativePath)
-                .toList();
+                .map(output -> Pair.of(output.date().substring(0, 3), hl7RootPath + "/" + output.relativePath()))
+                .collect(
+                        Collectors.groupingBy(
+                                Pair::getLeft,
+                                Collectors.mapping(Pair::getRight, Collectors.toList())
+                        )
+                );
 
         // Ingest HL7 into delta lake
         // We execute the activity using the untyped stub because the activity is implemented in a different language
-        IngestHl7FilesToDeltaLakeOutput ingestHl7LogWorkflowOutput = ingestActivity.execute(
-                INGEST_ACTIVITY_NAME,
-                IngestHl7FilesToDeltaLakeOutput.class,
-                new IngestHl7FilesToDeltaLakeInput(input.deltaLakePath(), hl7AbsolutePaths)
-        );
+        for (Map.Entry<String, List<String>> hl7AbsolutePathsEntry : hl7AbsolutePathsByYear.entrySet()) {
+            List<String> hl7AbsolutePaths = hl7AbsolutePathsEntry.getValue();
+            logger.info("Launching activity to ingest {} HL7 files for year {}",
+                    hl7AbsolutePaths.size(), hl7AbsolutePathsEntry.getKey());
+            IngestHl7FilesToDeltaLakeOutput ingestHl7LogWorkflowOutput = ingestActivity.execute(
+                    INGEST_ACTIVITY_NAME,
+                    IngestHl7FilesToDeltaLakeOutput.class,
+                    new IngestHl7FilesToDeltaLakeInput(input.deltaLakePath(), hl7AbsolutePaths)
+            );
+        }
 
         return new IngestHl7LogWorkflowOutput();
     }
 
-    private static void throwOnInvalidInput(IngestHl7LogWorkflowInput input, String date) {
+    private static void throwOnInvalidInput(IngestHl7LogWorkflowInput input, List<String> dates) {
         boolean hasLogsRootPath = input.logsRootPath() != null && !input.logsRootPath().isBlank();
         boolean hasScratchSpaceRootPath = input.scratchSpaceRootPath() != null && !input.scratchSpaceRootPath().isBlank();
         boolean hasHl7OutputPath = input.hl7OutputPath() != null && !input.hl7OutputPath().isBlank();
         boolean hasDeltaLakePath = input.deltaLakePath() != null && !input.deltaLakePath().isBlank();
-        boolean hasDate = date != null;
+        boolean hasDates = dates != null && !dates.isEmpty();
 
-        if (!(hasLogsRootPath && hasScratchSpaceRootPath && hasHl7OutputPath && hasDeltaLakePath && hasDate)) {
+        if (!(hasLogsRootPath && hasScratchSpaceRootPath && hasHl7OutputPath && hasDeltaLakePath && hasDates)) {
             // We know something is missing
             List<String> missingInputs = new ArrayList<>();
             if (!hasLogsRootPath) {
@@ -132,7 +163,7 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
             if (!hasDeltaLakePath) {
                 missingInputs.add("deltaLakePath");
             }
-            if (!hasDate) {
+            if (!hasDates) {
                 missingInputs.add("date");
             }
             String plural = missingInputs.size() == 1 ? "" : "s";
@@ -147,8 +178,8 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
      * @param dateInput The date value from the workflow inputs
      * @return Date to use for the workflow
      */
-    private static String determineDate(String dateInput) {
-        String date;
+    private static List<String> determineDate(String dateInput) {
+        List<String> dates;
         if (dateInput == null) {
             // Get the date from the time the workflow was scheduled to start
             // Note that there isn't a good API for this in the SDK. We have to use a
@@ -160,20 +191,22 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
 
             if (scheduledTimeUtc == null) {
                 logger.debug("No date input, and scheduled start time not found in search attributes.");
-                date = null;
+                dates = Collections.emptyList();
             } else {
                 // Ingest logs from "yesterday" which we define as the day before the scheduled time in the local timezone
                 ZoneId localTz = ZoneOffset.systemDefault();
                 OffsetDateTime scheduledTimeLocal = scheduledTimeUtc.atZoneSameInstant(localTz).toOffsetDateTime();
                 OffsetDateTime yesterday = scheduledTimeLocal.minusDays(1);
-                date = yesterday.format(YYYYMMDD_FORMAT);
+                String date = yesterday.format(YYYYMMDD_FORMAT);
                 logger.debug("Using date {} from scheduled workflow start time {} ({} in TZ {}) minus one day", date, scheduledTimeUtc, scheduledTimeLocal, localTz);
+                dates = List.of(date);
             }
         } else {
-            // Use the input date, removing any hyphens
-            date = dateInput.replace("-", "");
-            logger.debug("Using date {} from input value {}", date, dateInput);
+            dates = Arrays.stream(dateInput.split(","))
+                    .map(date -> date.replace("-", ""))
+                    .toList();
+            logger.debug("Using dates {} from input value {}", dates, dateInput);
         }
-        return date;
+        return dates;
     }
 }


### PR DESCRIPTION
## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
The HL7 log ingest workflow can now accept multiple dates for its input. These are specified using the same `"date"` input parameter, the value of which can now be interpreted as a comma-separated string of dates. So `"20000101"` is valid, as is `"2000-01-01"`, as is `"20000101,20221231,1994-03-15"`, etc.

### Technical
The workflow has been refactored with the idea that its input will be a list of dates. All the subsequent steps and actions are looped over the input dates.

At the final step, which is sent from the java workflow/actions over to the python action, the files to ingest are aggregated into groups by year. This is to minimize the potential for multiple concurrent processes attempting to write to the same files, which are partitioned by year.

## Impact

### Security 
N/A
##### Authorization
N/A
##### Appsec
N/A
### Performance
This does and will have performance implications, but they have not been exercised.
- In the ongoing daily intake scenario, nothing will change. A single workflow instance will run on a single day of data just as before.
- In a bulk ingest or testing scenario, this provides a new method for launching. Rather than launching many workflows each over a single day, we can launch one or a small number of workflows each of which ingests many days.
  - The java side of the workflow activities should be able to handle this. It fans out the activities over the days in the input so that each one runs more or less as before. The amount of memory taken will scale with the number of HL7 messages that are split out across all the days, since it does keep track of the paths of all the files that are written.
  - The python side may have additional memory pressure depending on the amount of data being ingested. It reads in all the HL7 files that are passed to it by the java side (though these file lists are chunked into years, which limits the total amount to be read at once). 

### Data
I believe there are no changes to data considerations. In particular, the "bug"—or poorly designed feature—still exists where a date with no log file will continue launching and failing its activity forever.

### Backward compatibility
N/A

## Testing
Charlie ran the automated orchestration tests on this code copied to his fork. They should run again on this PR.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
