### PR TITLE
Set max attempts = 5 on java activities

### DIFF
--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
@@ -47,7 +47,10 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
     private final SplitHl7LogActivity hl7LogActivity =
             Workflow.newActivityStub(SplitHl7LogActivity.class,
                     ActivityOptions.newBuilder()
-                            .setStartToCloseTimeout(Duration.ofSeconds(10))
+                            .setStartToCloseTimeout(Duration.ofSeconds(5))
+                            .setRetryOptions(RetryOptions.newBuilder()
+                                    .setMaximumAttempts(5)
+                                    .build())
                             .build());
 
     private static final String INGEST_ACTIVITY_NAME = "ingest_hl7_files_to_delta_lake_activity";


### PR DESCRIPTION
## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
Cap the number of times the java temporal worker retries its activities to 5. This should prevent a failed activity from retrying forever and hanging the workflow.

### Technical
In the java workflow implementation, set an activity option that caps at 5 the number of times the java activities will be attempted.
This is currently hard-coded. In the future we could consider reading this from the application properties which would make it adjustable at deploy time.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
This will hopefully have no performance impact, or perhaps positive in that an activity won't be able to retry and fail forever. But I haven't tested it.

### Data
This should improve edge case handling.

### Backward compatibility
N/A

## Testing
None

## Note for reviewers


## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
