### PR TITLE
Improve HL7 workflow stability

### DIFF
--- a/orchestration/temporal-java/build.gradle
+++ b/orchestration/temporal-java/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation "io.temporal:temporal-sdk:${temporalVersion}"
     implementation "io.temporal:temporal-spring-boot-starter:${temporalVersion}"
 	implementation "software.amazon.awssdk:s3:${s3Version}"
+	implementation "software.amazon.awssdk:apache-client:${s3Version}"
 	implementation "org.apache.commons:commons-lang3"
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/orchestration/temporal-java/scripts/transform-split-hl7-log.sh
+++ b/orchestration/temporal-java/scripts/transform-split-hl7-log.sh
@@ -11,10 +11,19 @@ fi
 # Read header from file to get 18-digit timestamp
 # Format: %Y%m%d%H%M%S%f in python strftime notation
 timestamp=$(head -c 24 $f | tr -C -d \[:digit:\])
+if [ -z "$timestamp" ]; then
+    echo "Could not read timestamp from $f" >&2
+    exit 1
+fi
+# We expect 18 digits of timestamp, but at minimum we need 14 (year, month, day, hour, minute, second)
+if [[ ${#timestamp} -lt 14 ]]; then
+    echo "Timestamp \"${timestamp}\" from $f is not long enough. Minimum length 14, expected length 18." >&2
+    exit 1
+fi
 
 # Make a directory to store the file, of the format year/month/day/hour
 directory=${timestamp:0:4}/${timestamp:4:2}/${timestamp:6:2}/${timestamp:8:2}
-mkdir -p $directory
+mkdir -p $directory || exit 1
 
 dest="$directory/$timestamp.hl7"
 

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/config/S3Config.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/config/S3Config.java
@@ -4,11 +4,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
 
 import java.net.URI;
+import java.time.Duration;
 
 @Configuration
 public class S3Config {
@@ -28,6 +30,9 @@ public class S3Config {
                 .serviceConfiguration(S3Configuration.builder()
                         .pathStyleAccessEnabled(true)
                         .build())
+                .httpClientBuilder(ApacheHttpClient.builder()
+                        .maxConnections(100)
+                        .connectionTimeout(Duration.ofSeconds(5)))
                 .build();
     }
 }

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
@@ -15,6 +15,7 @@ import io.temporal.activity.ActivityOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.common.SearchAttributeKey;
 import io.temporal.failure.ApplicationFailure;
+import io.temporal.failure.TemporalFailure;
 import io.temporal.spring.boot.WorkflowImpl;
 import io.temporal.workflow.ActivityStub;
 import io.temporal.workflow.Async;
@@ -32,8 +33,12 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 @WorkflowImpl(taskQueues = "ingest-hl7-log")
@@ -81,30 +86,26 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
         String scratchDir = input.scratchSpaceRootPath() + (input.scratchSpaceRootPath().endsWith("/") ? "" : "/") + workflowInfo.getWorkflowId();
 
         // Find log file by date
-        List<Promise<FindHl7LogFileOutput>> findHl7LogFileOutputPromises = dates.stream()
+        Deque<Promise<FindHl7LogFileOutput>> findHl7LogFileOutputPromises = dates.stream()
                 .map(date -> Async.function(hl7LogActivity::findHl7LogFile, new FindHl7LogFileInput(date, input.logsRootPath())))
-                .toList();
+                .collect(Collectors.toCollection(LinkedList::new));
         // Collect async results
-        List<FindHl7LogFileOutput> findHl7LogFileOutputs = findHl7LogFileOutputPromises.stream()
-                .map(Promise::get)
-                .toList();
+        List<FindHl7LogFileOutput> findHl7LogFileOutputs = getSuccessfulResults(findHl7LogFileOutputPromises);
 
         // Split log file
         String splitLogFileOutputPath = scratchDir + "/split";
-        List<Promise<SplitHl7LogActivityOutput>> splitHl7LogOutputPromises = findHl7LogFileOutputs.stream()
+        Deque<Promise<SplitHl7LogActivityOutput>> splitHl7LogOutputPromises = findHl7LogFileOutputs.stream()
                 .map(findHl7LogFileOutput -> Async.function(
                         hl7LogActivity::splitHl7Log,
                         new SplitHl7LogActivityInput(findHl7LogFileOutput.date(), findHl7LogFileOutput.logFileAbsPath(), splitLogFileOutputPath)
                 ))
-                .toList();
+                .collect(Collectors.toCollection(LinkedList::new));
         // Collect async results
-        List<SplitHl7LogActivityOutput> splitHl7LogOutputs = splitHl7LogOutputPromises.stream()
-                .map(Promise::get)
-                .toList();
+        List<SplitHl7LogActivityOutput> splitHl7LogOutputs = getSuccessfulResults(splitHl7LogOutputPromises);
 
         // Transform split logs into proper hl7 files
         String hl7RootPath = input.hl7OutputPath().endsWith("/") ? input.hl7OutputPath().substring(0, input.hl7OutputPath().length() - 1) : input.hl7OutputPath();
-        List<Promise<TransformSplitHl7LogOutput>> transformSplitHl7LogOutputPromises = new ArrayList<>();
+        Deque<Promise<TransformSplitHl7LogOutput>> transformSplitHl7LogOutputPromises = new LinkedList<>();
         for (SplitHl7LogActivityOutput splitHl7LogOutput : splitHl7LogOutputs) {
             String date = splitHl7LogOutput.date();
             for (String splitLogFileRelativePath : splitHl7LogOutput.relativePaths()) {
@@ -117,9 +118,10 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
             }
         }
         // Collect async results
+        List<TransformSplitHl7LogOutput> transformSplitHl7LogOutputs = getSuccessfulResults(transformSplitHl7LogOutputPromises);
+
         // Partition hl7 paths by year, so it can avoid race conditions on writing the files
-        final Map<String, List<String>> hl7AbsolutePathsByYear = transformSplitHl7LogOutputPromises.stream()
-                .map(Promise::get)
+        final Map<String, List<String>> hl7AbsolutePathsByYear = transformSplitHl7LogOutputs.stream()
                 .map(output -> Pair.of(output.date().substring(0, 4), hl7RootPath + "/" + output.relativePath()))
                 .collect(
                         Collectors.groupingBy(
@@ -211,5 +213,35 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
             logger.debug("Using dates {} from input value {}", dates, dateInput);
         }
         return dates;
+    }
+
+    /**
+     * Collect the results of a list of promises, waiting for each to complete.
+     * If one of the activities has failed with a TemporalFailure, it will be logged and ignored.
+     * If one of the activities has failed with another exception, it will be rethrown.
+     * @param promises List of promises to collect results from
+     * @return List of results from the promises that succeeded
+     * @param <T> Type of the results
+     * @throws RuntimeException If one of the activities failed with an exception other than TemporalFailure
+     */
+    private static <T> List<T> getSuccessfulResults(Deque<Promise<T>> promises) throws RuntimeException {
+        // Collect async results
+        List<T> results = new ArrayList<>(promises.size());
+        while (!promises.isEmpty()) {
+            Promise<T> promise = promises.poll();
+            try {
+                results.add(promise.get(10, TimeUnit.MILLISECONDS));
+            } catch (TimeoutException ignored) {
+                // This is benign, it just means the activity hasn't completed yet
+                // Back to the queue
+                promises.add(promise);
+            } catch (TemporalFailure exception) {
+                logger.warn("An activity failed, but we ignore it. The workflow continues.", exception);
+            } catch (Exception exception) {
+                logger.error("An activity failed and the workflow will fail too.", exception);
+                throw exception;
+            }
+        }
+        return results;
     }
 }

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
@@ -52,11 +52,10 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
     private final SplitHl7LogActivity hl7LogActivity =
             Workflow.newActivityStub(SplitHl7LogActivity.class,
                     ActivityOptions.newBuilder()
-                            .setStartToCloseTimeout(Duration.ofSeconds(10))
+                            .setStartToCloseTimeout(Duration.ofSeconds(30))
                             .setRetryOptions(RetryOptions.newBuilder()
-                                    .setInitialInterval(Duration.ofMillis(10))
                                     .setMaximumInterval(Duration.ofSeconds(1))
-                                    .setMaximumAttempts(10)
+                                    .setMaximumAttempts(5)
                                     .build())
                             .build());
 
@@ -67,7 +66,8 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
                     .setTaskQueue("ingest-hl7-delta-lake")
                     .setStartToCloseTimeout(Duration.ofSeconds(30))
                     .setRetryOptions(RetryOptions.newBuilder()
-                            .setMaximumAttempts(5)
+                            .setMaximumInterval(Duration.ofSeconds(1))
+                            .setMaximumAttempts(10)
                             .build())
                     .build());
 

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
@@ -47,7 +47,10 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
     private final SplitHl7LogActivity hl7LogActivity =
             Workflow.newActivityStub(SplitHl7LogActivity.class,
                     ActivityOptions.newBuilder()
-                            .setStartToCloseTimeout(Duration.ofSeconds(10))
+                            .setStartToCloseTimeout(Duration.ofSeconds(5))
+                            .setRetryOptions(RetryOptions.newBuilder()
+                                    .setMaximumAttempts(5)
+                                    .build())
                             .build());
 
     private static final String INGEST_ACTIVITY_NAME = "ingest_hl7_files_to_delta_lake_activity";

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
@@ -47,7 +47,7 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
     private final SplitHl7LogActivity hl7LogActivity =
             Workflow.newActivityStub(SplitHl7LogActivity.class,
                     ActivityOptions.newBuilder()
-                            .setStartToCloseTimeout(Duration.ofSeconds(5))
+                            .setStartToCloseTimeout(Duration.ofSeconds(10))
                             .setRetryOptions(RetryOptions.newBuilder()
                                     .setMaximumAttempts(5)
                                     .build())

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
@@ -54,6 +54,8 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
                     ActivityOptions.newBuilder()
                             .setStartToCloseTimeout(Duration.ofSeconds(10))
                             .setRetryOptions(RetryOptions.newBuilder()
+                                    .setInitialInterval(Duration.ofMillis(10))
+                                    .setMaximumInterval(Duration.ofSeconds(1))
                                     .setMaximumAttempts(5)
                                     .build())
                             .build());

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
@@ -56,7 +56,7 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
                             .setRetryOptions(RetryOptions.newBuilder()
                                     .setInitialInterval(Duration.ofMillis(10))
                                     .setMaximumInterval(Duration.ofSeconds(1))
-                                    .setMaximumAttempts(5)
+                                    .setMaximumAttempts(10)
                                     .build())
                             .build());
 


### PR DESCRIPTION
## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
Ingest HL7 Logs workflow should be more stable with fewer activity timeouts and better error catching.

### Technical
- Detect "bad files" which aren't proper HL7 logs after splitting and produce an informative error
- In fan-out steps, let individual activities fail without failing the whole workflow. Unless they all failed, then do fail the workflow.
- Tweak activity timeouts and retries
- Increase size of connection pool in Apache HTTP client underlying S3 client

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
The performance should either be the same or better. I expect fewer failures which lead to fewer retries which means higher overall throughput.

### Data
Better handling for bad data flies that are not actually hl7 logs.

### Backward compatibility
N/A

## Testing
Manually tested with large numbers of dates, with and without a single bad file.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
