### PR TITLE
Update Jupyter single user notebook egress to minio

### DIFF
--- a/helm/jupyter/hub/hub-values.yaml
+++ b/helm/jupyter/hub/hub-values.yaml
@@ -52,6 +52,6 @@ singleuser:
       - to:
           - namespaceSelector:
               matchLabels:
-                kubernetes.io/metadata.name: minio
+                kubernetes.io/metadata.name: minio-scout
         ports:
-          - port: 9000
+          - port: 80


### PR DESCRIPTION
# Update Jupyter single user notebook egress to minio

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product/Technical
- Jupyter single user notebooks need explicit egress configuration to Minio. We had changed the Minio namespace and port without updating this egress. 

## Impact

### Security 

##### Authorization

##### Appsec


### Performance


### Data
- Can't access data without egress to Minio

### Backward compatibility
- N/A

## Testing
- Still having other Spark notebook issues, but pretty sure we need this.

## Note for reviewers


## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added or updated user documentation, if appropriate.
- [x]  I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
