### PR TITLE
Cache docker build artifacts to reduce build times

### DIFF
--- a/.github/actions/docker-build-cache/action.yaml
+++ b/.github/actions/docker-build-cache/action.yaml
@@ -22,6 +22,8 @@ runs:
         context: ${{ inputs.subproject }}
         tags: ${{ ENV.REGISTRY }}/washu-tag/${{ inputs.image-name }}:${{ steps.derive-version.outputs.version }}
         outputs: type=docker,dest=${{ runner.temp }}/${{ inputs.image-name }}.tar
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
N/A

### Technical
Cache docker build artifacts in GitHub CI. This should reduce image build times when setup steps aren't changed.

See https://docs.docker.com/build/cache/backends/gha/

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
None yet. Need to open this PR for the action to run.

## Note for reviewers
I'm not 100% certain but fairly confident that we can manage the cached artifacts manually in the GH UI or CLI if for whatever reason we need to purge the cache and build fresh.

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
