### PR TITLE
SCOUT-62 Read log file with encoding ISO-8859-1 when splitting, not transforming

### DIFF
--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/util/Hl7LogSplitter.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/util/Hl7LogSplitter.java
@@ -2,6 +2,7 @@ package edu.washu.tag.temporal.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -44,7 +45,7 @@ public class Hl7LogSplitter {
 
     private static List<Path> splitLogFile(Path logFilePath, String outputPrefix, Path outputDirectory) throws IOException {
         List<Path> outputFiles = new ArrayList<>();
-        try (BufferedReader reader = Files.newBufferedReader(logFilePath)) {
+        try (BufferedReader reader = Files.newBufferedReader(logFilePath, StandardCharsets.ISO_8859_1)) {
             StringBuilder currentContent = new StringBuilder();
             String line;
             int fileCounter = 0;
@@ -56,7 +57,7 @@ public class Hl7LogSplitter {
                     if (!currentContent.isEmpty()) {
                         String outputFileName = String.format("%s.%05d", outputPrefix, fileCounter++);
                         Path outputPath = outputDirectory.resolve(outputFileName);
-                        Files.writeString(outputPath, currentContent.toString());
+                        Files.writeString(outputPath, currentContent.toString(), StandardCharsets.UTF_8);
                         outputFiles.add(outputPath);
                         currentContent.setLength(0); // Clear buffer
                     }

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/util/Hl7LogTransformer.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/util/Hl7LogTransformer.java
@@ -2,7 +2,6 @@ package edu.washu.tag.temporal.util;
 
 import edu.washu.tag.temporal.exception.FileFormatException;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -91,7 +90,7 @@ public class Hl7LogTransformer {
             }
         }
 
-        String headerStr = new String(header, StandardCharsets.ISO_8859_1);
+        String headerStr = new String(header);
         return parseAndValidateTimestamp(headerStr, file.toString());
     }
 
@@ -156,7 +155,7 @@ public class Hl7LogTransformer {
         // Read the file content
         List<String> lines;
         try {
-            lines = Files.readAllLines(sourceFile, StandardCharsets.ISO_8859_1);
+            lines = Files.readAllLines(sourceFile);
         } catch (IOException e) {
             throw new IOException("Failed to read source file " + sourceFile, e);
         }
@@ -174,7 +173,7 @@ public class Hl7LogTransformer {
 
         // Write to destination file
         try {
-            Files.writeString(destinationPath, processedContent, StandardCharsets.UTF_8);
+            Files.writeString(destinationPath, processedContent);
         } catch (IOException e) {
             throw new IOException("Failed to write destination file " + destinationPath, e);
         }


### PR DESCRIPTION

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
N/A

### Technical
I tested the workflow on the identified sample data. It failed to split files with non-ASCII characters.

```
{
  "message": "Activity task failed",
  "cause": {
    "message": "Failed to split log file /data/<some file>.log",
    "source": "JavaSDK",
    "stackTrace": "io.temporal.failure.ApplicationFailure.newFailureWithCause(ApplicationFailure.java:95)
edu.washu.tag.temporal.activity.SplitHl7LogActivityImpl.splitHl7Log(SplitHl7LogActivityImpl.java:68)
java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
java.base/java.lang.reflect.Method.invoke(Method.java:580)
io.temporal.internal.activity.RootActivityInboundCallsInterceptor$POJOActivityInboundCallsInterceptor.executeActivity(RootActivityInboundCallsInterceptor.java:64)
io.temporal.internal.activity.RootActivityInboundCallsInterceptor.execute(RootActivityInboundCallsInterceptor.java:43)
io.temporal.internal.activity.ActivityTaskExecutors$BaseActivityTaskExecutor.execute(ActivityTaskExecutors.java:107)
io.temporal.internal.activity.ActivityTaskHandlerImpl.handle(ActivityTaskHandlerImpl.java:124)
io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handleActivity(ActivityWorker.java:291)
io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handle(ActivityWorker.java:255)
io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handle(ActivityWorker.java:218)
io.temporal.internal.worker.PollTaskExecutor.lambda$process$1(PollTaskExecutor.java:106)
java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
java.base/java.lang.Thread.run(Thread.java:1583)
",
    "cause": {
      "message": "Input length = 1",
      "source": "JavaSDK",
      "stackTrace": "java.base/java.nio.charset.CoderResult.throwException(CoderResult.java:279)
java.base/sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:405)
java.base/sun.nio.cs.StreamDecoder.lockedRead(StreamDecoder.java:217)
java.base/sun.nio.cs.StreamDecoder.read(StreamDecoder.java:171)
java.base/java.io.InputStreamReader.read(InputStreamReader.java:188)
java.base/java.io.BufferedReader.fill(BufferedReader.java:160)
java.base/java.io.BufferedReader.implReadLine(BufferedReader.java:370)
java.base/java.io.BufferedReader.readLine(BufferedReader.java:347)
java.base/java.io.BufferedReader.readLine(BufferedReader.java:436)
edu.washu.tag.temporal.util.Hl7LogSplitter.splitLogFile(Hl7LogSplitter.java:52)
edu.washu.tag.temporal.util.Hl7LogSplitter.splitLogFile(Hl7LogSplitter.java:42)
edu.washu.tag.temporal.activity.SplitHl7LogActivityImpl.splitHl7Log(SplitHl7LogActivityImpl.java:66)
java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
java.base/java.lang.reflect.Method.invoke(Method.java:580)
io.temporal.internal.activity.RootActivityInboundCallsInterceptor$POJOActivityInboundCallsInterceptor.executeActivity(RootActivityInboundCallsInterceptor.java:64)
io.temporal.internal.activity.RootActivityInboundCallsInterceptor.execute(RootActivityInboundCallsInterceptor.java:43)
io.temporal.internal.activity.ActivityTaskExecutors$BaseActivityTaskExecutor.execute(ActivityTaskExecutors.java:107)
io.temporal.internal.activity.ActivityTaskHandlerImpl.handle(ActivityTaskHandlerImpl.java:124)
io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handleActivity(ActivityWorker.java:291)
io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handle(ActivityWorker.java:255)
io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handle(ActivityWorker.java:218)
io.temporal.internal.worker.PollTaskExecutor.lambda$process$1(PollTaskExecutor.java:106)
java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
java.base/java.lang.Thread.run(Thread.java:1583)
",
      "applicationFailureInfo": {
        "type": "java.nio.charset.MalformedInputException"
      }
    },
    "applicationFailureInfo": {
      "type": "type"
    }
  },
  "activityFailureInfo": {
    "scheduledEventId": "5",
    "startedEventId": "6",
    "identity": "1@temporal-java-6dffccfb7f-wgchh",
    "activityType": {
      "name": "SplitHl7Log"
    },
    "activityId": "bc18b1c8-b504-37e8-b871-fd6540711c19",
    "retryState": "RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED"
  }
}
```

Both before and after this change files with all ASCII characters split fine.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
Fixes data encoding conformance

### Backward compatibility
N/A

## Testing
Manually tested on identified sample data

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
