### PR TITLE
SCOUT-61 Continue as new

### DIFF
--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/activity/FindHl7LogsActivity.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/activity/FindHl7LogsActivity.java
@@ -1,5 +1,6 @@
 package edu.washu.tag.temporal.activity;
 
+import edu.washu.tag.temporal.model.ContinueIngestWorkflow;
 import edu.washu.tag.temporal.model.FindHl7LogFileInput;
 import edu.washu.tag.temporal.model.FindHl7LogFileOutput;
 import io.temporal.activity.ActivityInterface;
@@ -9,4 +10,7 @@ import io.temporal.activity.ActivityMethod;
 public interface FindHl7LogsActivity {
     @ActivityMethod
     FindHl7LogFileOutput findHl7LogFiles(FindHl7LogFileInput input);
+
+    @ActivityMethod
+    FindHl7LogFileOutput continueIngestHl7LogWorkflow(ContinueIngestWorkflow input);
 }

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/activity/FindHl7LogsActivityImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/activity/FindHl7LogsActivityImpl.java
@@ -112,8 +112,13 @@ public class FindHl7LogsActivityImpl implements FindHl7LogsActivity {
         // Do we continue again or are we at the end?
         ContinueIngestWorkflow continued = null;
         int nextIndex = input.nextIndex() + maxChildWorkflows;
-        if (nextIndex < logFiles.size()) {
-            continued = new ContinueIngestWorkflow(manifestFilePath, logFiles.size(), nextIndex);
+        if (nextIndex < input.numLogFiles()) {
+            logger.info("WorkflowId {} ActivityId {} - We will continue the workflow as new starting with index {}",
+                activityInfo.getWorkflowId(), activityInfo.getActivityId(), nextIndex);
+            continued = new ContinueIngestWorkflow(manifestFilePath, input.numLogFiles(), nextIndex);
+        } else {
+            logger.info("WorkflowId {} ActivityId {} - nextIndex {} >= numLogFiles {}. This batch is the end of the log files.",
+                activityInfo.getWorkflowId(), activityInfo.getActivityId(), nextIndex, input.numLogFiles());
         }
         return new FindHl7LogFileOutput(logFiles, continued);
     }

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/activity/FindHl7LogsActivityImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/activity/FindHl7LogsActivityImpl.java
@@ -3,7 +3,6 @@ package edu.washu.tag.temporal.activity;
 import edu.washu.tag.temporal.model.ContinueIngestWorkflow;
 import edu.washu.tag.temporal.model.FindHl7LogFileInput;
 import edu.washu.tag.temporal.model.FindHl7LogFileOutput;
-import edu.washu.tag.temporal.util.Constants;
 import edu.washu.tag.temporal.util.FileHandler;
 import io.temporal.activity.Activity;
 import io.temporal.activity.ActivityInfo;

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/ContinueIngestWorkflow.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/ContinueIngestWorkflow.java
@@ -1,0 +1,3 @@
+package edu.washu.tag.temporal.model;
+
+public record ContinueIngestWorkflow(String manifestFilePath, int numLogFiles, int nextIndex) {}

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/FindHl7LogFileInput.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/FindHl7LogFileInput.java
@@ -2,4 +2,4 @@ package edu.washu.tag.temporal.model;
 
 import java.util.List;
 
-public record FindHl7LogFileInput(List<String> logPaths, String date, String logsRootPath) {}
+public record FindHl7LogFileInput(List<String> logPaths, String date, String logsRootPath, String manifestFilePath) {}

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/FindHl7LogFileOutput.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/FindHl7LogFileOutput.java
@@ -2,4 +2,10 @@ package edu.washu.tag.temporal.model;
 
 import java.util.List;
 
-public record FindHl7LogFileOutput(List<String> logFiles) {}
+/**
+ * Output for the FindHl7LogsActivity.
+ *
+ * @param logFiles List of log files to process in this workflow.
+ * @param continued If we need to continue the ingest workflow, this will be set.
+ */
+public record FindHl7LogFileOutput(List<String> logFiles, ContinueIngestWorkflow continued) {}

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/IngestHl7LogWorkflowInput.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/model/IngestHl7LogWorkflowInput.java
@@ -1,5 +1,18 @@
 package edu.washu.tag.temporal.model;
 
+/**
+ * Input for the IngestHl7LogWorkflow.
+ *
+ * @param date Find a specific log file within the logsRootPath by date. Must also provide logsRootPath.
+ * @param logsRootPath Root path to search recursively for log files. Optional if specific logPaths are provided.
+ * @param logPaths List of specific log files to ingest. Can be absolute or, if logsRootPath is provided, relative to logsRootPath.
+ *                 If logsRootPath is provided and this is not, every .log file under logsRootPath will be used.
+ * @param scratchSpaceRootPath Root path to use for temporary files. Will be created if it does not exist.
+ * @param hl7OutputPath Path to write HL7 files.
+ * @param deltaLakePath Path to write Delta Lake files.
+ * @param modalityMapPath Path to read modality map file, which is the source of the modality column in Delta Lake table.
+ * @param continued Do not set this on initial workflow run. Parameters needed to resume when workflow is Continued As New.
+ */
 public record IngestHl7LogWorkflowInput(
         String date,
         String logsRootPath,
@@ -7,5 +20,6 @@ public record IngestHl7LogWorkflowInput(
         String scratchSpaceRootPath,
         String hl7OutputPath,
         String deltaLakePath,
-        String modalityMapPath
+        String modalityMapPath,
+        ContinueIngestWorkflow continued
 ) {}

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/util/AllOfPromiseOnlySuccesses.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/util/AllOfPromiseOnlySuccesses.java
@@ -62,7 +62,7 @@ public class AllOfPromiseOnlySuccesses<T> implements Promise<List<T>> {
                     if (e != null) {
                         logger.warn("Promise {} failed", f, e);
                     } else {
-                        logger.info("Promise {} succeeded", f);
+                        logger.debug("Promise {} succeeded", f);
                         this.results.add(r);
                     }
 

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/util/Constants.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/util/Constants.java
@@ -5,6 +5,4 @@ public class Constants {
     public static final String CHILD_QUEUE = "split-transform-hl7-log";
     public static final String PYTHON_ACTIVITY = "ingest_hl7_files_to_delta_lake_activity";
     public static final String PYTHON_QUEUE = "ingest-hl7-delta-lake";
-
-    public static final int RETURN_LOG_LIST_SIZE_LIMIT = 2000;
 }

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/util/Constants.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/util/Constants.java
@@ -5,4 +5,6 @@ public class Constants {
     public static final String CHILD_QUEUE = "split-transform-hl7-log";
     public static final String PYTHON_ACTIVITY = "ingest_hl7_files_to_delta_lake_activity";
     public static final String PYTHON_QUEUE = "ingest-hl7-delta-lake";
+
+    public static final int RETURN_LOG_LIST_SIZE_LIMIT = 2000;
 }

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/util/FileHandler.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/util/FileHandler.java
@@ -14,11 +14,17 @@ public interface FileHandler {
     @Retryable(maxAttempts = 5, backoff = @Backoff(delay = 1000, multiplier = 2))
     String putWithRetry(byte[] data, String relativePath, URI destination) throws IOException;
 
+    @Retryable(maxAttempts = 5, backoff = @Backoff(delay = 1000, multiplier = 2))
+    String putWithRetry(byte[] data, URI destination) throws IOException;
+
     String put(Path filePath, Path filePathsRoot, URI destination) throws IOException;
 
     List<String> put(List<Path> filePaths, Path filePathsRoot, URI destination) throws IOException;
 
     Path get(URI source, Path destination) throws IOException;
+
+    @Retryable(maxAttempts = 5, backoff = @Backoff(delay = 1000, multiplier = 2))
+    byte[] read(URI source) throws IOException;
 
     void deleteDir(Path dir) throws IOException;
 }

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
@@ -1,6 +1,7 @@
 package edu.washu.tag.temporal.workflow;
 
 import edu.washu.tag.temporal.activity.FindHl7LogsActivity;
+import edu.washu.tag.temporal.model.ContinueIngestWorkflow;
 import edu.washu.tag.temporal.model.FindHl7LogFileInput;
 import edu.washu.tag.temporal.model.FindHl7LogFileOutput;
 import edu.washu.tag.temporal.model.Hl7FromHl7LogWorkflowInput;
@@ -82,12 +83,29 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
         WorkflowInfo workflowInfo = Workflow.getInfo();
         logger.info("Beginning workflow {} workflowId {}", this.getClass().getSimpleName(), workflowInfo.getWorkflowId());
 
-        // Parse / validate input
-        ParsedLogInput parsedLogInput = parseInput(input);
+        // Determine if we are starting a new workflow or resuming from a manifest file
+        FindHl7LogFileOutput findHl7LogFileOutput;
+        if (input.continued() == null) {
+            logger.info("WorkflowId {} - Starting new workflow", workflowInfo.getWorkflowId());
+            // Parse / validate input
+            ParsedLogInput parsedLogInput = parseInput(input);
 
-        // Get final list of log paths
-        FindHl7LogFileInput findHl7LogFileInput = new FindHl7LogFileInput(parsedLogInput.logPaths(), parsedLogInput.yesterday(), input.logsRootPath());
-        FindHl7LogFileOutput findHl7LogFileOutput = findHl7LogsActivity.findHl7LogFiles(findHl7LogFileInput);
+            // Construct a path for a new manifest file
+            String scratchDir = input.scratchSpaceRootPath() + (input.scratchSpaceRootPath().endsWith("/") ? "" : "/") + workflowInfo.getWorkflowId();
+            String manifestFilePath = scratchDir + "/log_manifest_" + workflowInfo.getWorkflowId() + ".txt";
+
+            // Get list of log paths to process
+            FindHl7LogFileInput findHl7LogFileInput = new FindHl7LogFileInput(
+                parsedLogInput.logPaths(), parsedLogInput.yesterday(), input.logsRootPath(), scratchDir
+            );
+            findHl7LogFileOutput = findHl7LogsActivity.findHl7LogFiles(findHl7LogFileInput);
+        } else {
+            logger.info("WorkflowId {} - Resuming from continued {}", workflowInfo.getWorkflowId(), input.continued());
+            findHl7LogFileOutput = findHl7LogsActivity.continueIngestHl7LogWorkflow(input.continued());
+        }
+
+        // At this point we have a list of file paths to process.
+        // We may have a manifest file and a next offset into that file; if so we will continue as new at the end.
 
         // Launch child workflow for each log file
         logger.info("WorkflowId {} - Launching {} child workflows", workflowInfo.getWorkflowId(), findHl7LogFileOutput.logFiles().size());
@@ -127,6 +145,24 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
         );
 
         logger.info("Completed workflow {} workflowId {}", this.getClass().getSimpleName(), workflowInfo.getWorkflowId());
+
+        // If we have a non-null continuation object, we will continue as new with the next index
+        ContinueIngestWorkflow nextContinued = findHl7LogFileOutput.continued();
+        if (nextContinued != null) {
+            logger.info("WorkflowId {} Continuing as new workflow - nextContinued {}", workflowInfo.getWorkflowId(), nextContinued);
+            Workflow.continueAsNew(
+                new IngestHl7LogWorkflowInput(
+                    input.date(),
+                    input.logsRootPath(),
+                    input.logPaths(),
+                    input.scratchSpaceRootPath(),
+                    input.hl7OutputPath(),
+                    input.deltaLakePath(),
+                    input.modalityMapPath(),
+                    nextContinued
+                )
+            );
+        }
         return new IngestHl7LogWorkflowOutput();
     }
 

--- a/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
+++ b/orchestration/temporal-java/src/main/java/edu/washu/tag/temporal/workflow/IngestHl7LogWorkflowImpl.java
@@ -92,11 +92,11 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
 
             // Construct a path for a new manifest file
             String scratchDir = input.scratchSpaceRootPath() + (input.scratchSpaceRootPath().endsWith("/") ? "" : "/") + workflowInfo.getWorkflowId();
-            String manifestFilePath = scratchDir + "/log_manifest_" + workflowInfo.getWorkflowId() + ".txt";
+            String manifestFilePath = scratchDir + "/manifest.txt";
 
             // Get list of log paths to process
             FindHl7LogFileInput findHl7LogFileInput = new FindHl7LogFileInput(
-                parsedLogInput.logPaths(), parsedLogInput.yesterday(), input.logsRootPath(), scratchDir
+                parsedLogInput.logPaths(), parsedLogInput.yesterday(), input.logsRootPath(), manifestFilePath
             );
             findHl7LogFileOutput = findHl7LogsActivity.findHl7LogFiles(findHl7LogFileInput);
         } else {

--- a/orchestration/temporal-java/src/main/resources/application.yaml
+++ b/orchestration/temporal-java/src/main/resources/application.yaml
@@ -13,3 +13,5 @@ spring:
 s3:
   endpoint: 'http://minio.minio:9000'
   region: us-east-1
+scout:
+  max-child-workflows: 2000

--- a/orchestration/temporal-java/src/test/resources/application.yaml
+++ b/orchestration/temporal-java/src/test/resources/application.yaml
@@ -15,3 +15,5 @@ spring:
 s3:
   endpoint: 'http://minio.minio:9000'
   region: us-east-1
+scout:
+  max-child-workflows: 100


### PR DESCRIPTION
## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
Large ingest workflows will be split into smaller batches.

### Technical
The ingest workflow will ingest only a certain (configurable) number of log files before starting a new workflow using the Continue-As-New mechanism which will continue processing the rest.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
The intent of this change is to enable the temporal ingest workflow to run larger ingests without running into temporal limits. Performance should be similar to before, except that what would have been a single large workflow before will be batched into smaller workflows.

### Data
N/A

### Backward compatibility
N/A

## Testing
I set an artificially low limit on the number of child workflows (50) and ran the test dataset. Verified that it correctly chunks the log files and continues a new workflow.

I ran other data sets as well, and they seemed to also work fine, but they took much longer as I'm running tests locally and performance is an issue.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
