### PR TITLE
Reconfigure no data and error options handling for Grafana alert instances

### DIFF
--- a/helm/grafana/alerts/alert-rules/high-node-cpu-iowait-usage-alert.json
+++ b/helm/grafana/alerts/alert-rules/high-node-cpu-iowait-usage-alert.json
@@ -69,8 +69,8 @@
               }
             }
           ],
-          "noDataState": "NoData",
-          "execErrState": "Error",
+          "noDataState": "KeepLast",
+          "execErrState": "KeepLast",
           "for": "10m",
           "annotations": {
             "summary": "Node {{ $labels.node }} has high IOwait CPU usage",

--- a/helm/grafana/alerts/alert-rules/high-node-cpu-usage-alert.json
+++ b/helm/grafana/alerts/alert-rules/high-node-cpu-usage-alert.json
@@ -69,8 +69,8 @@
               }
             }
           ],
-          "noDataState": "NoData",
-          "execErrState": "Error",
+          "noDataState": "KeepLast",
+          "execErrState": "KeepLast",
           "for": "10m",
           "annotations": {
             "summary": "Node {{ $labels.node }} has high CPU usage",

--- a/helm/grafana/alerts/alert-rules/high-node-disk-usage-alert.json
+++ b/helm/grafana/alerts/alert-rules/high-node-disk-usage-alert.json
@@ -69,8 +69,8 @@
               }
             }
           ],
-          "noDataState": "NoData",
-          "execErrState": "Error",
+          "noDataState": "KeepLast",
+          "execErrState": "KeepLast",
           "for": "10m",
           "annotations": {
             "summary": "Node {{ $labels.node }} has high disk usage",

--- a/helm/grafana/alerts/alert-rules/high-node-memory-usage-alert.json
+++ b/helm/grafana/alerts/alert-rules/high-node-memory-usage-alert.json
@@ -69,8 +69,8 @@
               }
             }
           ],
-          "noDataState": "NoData",
-          "execErrState": "Error",
+          "noDataState": "KeepLast",
+          "execErrState": "KeepLast",
           "for": "10m",
           "annotations": {
             "summary": "Node {{ $labels.node }} has high memory usage",

--- a/helm/grafana/alerts/alert-rules/high-node-system-load-alert.json
+++ b/helm/grafana/alerts/alert-rules/high-node-system-load-alert.json
@@ -69,8 +69,8 @@
               }
             }
           ],
-          "noDataState": "NoData",
-          "execErrState": "Error",
+          "noDataState": "KeepLast",
+          "execErrState": "KeepLast",
           "for": "10m",
           "annotations": {
             "summary": "Node {{ $labels.node }} has high system load",


### PR DESCRIPTION
# Reconfigure no data and error handling options for Grafana alert instances

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product / Technical
- Reconfigure Grafana alerts to keep their last state (Normal/Error) in the event of no data, execution errors, or timeouts. 
- The prometheus kube state metrics exporter restarts occasionally resulting in data source errors being thrown which aren't helpful and make the slack channel too noisy.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
Tested by restarting the kube state metrics deployment on big-02 and did not see errors in grafana or slack.

## Note for reviewers

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
