### PR TITLE
Add alert for high inode usage

### DIFF
--- a/helm/grafana/alerts/alert-rules/high-node-mount-inode-usage-alert.json
+++ b/helm/grafana/alerts/alert-rules/high-node-mount-inode-usage-alert.json
@@ -1,0 +1,88 @@
+{
+  "apiVersion": 1,
+  "groups": [
+    {
+      "orgId": 1,
+      "name": "1m-evaluations",
+      "folder": "Scout",
+      "interval": "1m",
+      "rules": [
+        {
+          "uid": "high_node_mount_inode_usage_alert_01",
+          "title": "High Inode Usage on Node Mountpoint",
+          "condition": "B",
+          "data": [
+            {
+              "refId": "A",
+              "relativeTimeRange": {
+                "from": 600,
+                "to": 0
+              },
+              "datasourceUid": "prometheus_datasource_01",
+              "model": {
+                "editorMode": "code",
+                "expr": "(1 - (node_filesystem_files_free{device!~'rootfs', fstype!~\"tmpfs|ceph\"} / node_filesystem_files{device!~'rootfs', fstype!~\"tmpfs|ceph\"})) * 100",
+                "instant": true,
+                "intervalMs": 1000,
+                "legendFormat": "__auto",
+                "maxDataPoints": 43200,
+                "range": false,
+                "refId": "A"
+              }
+            },
+            {
+              "refId": "B",
+              "relativeTimeRange": {
+                "from": 0,
+                "to": 0
+              },
+              "datasourceUid": "__expr__",
+              "model": {
+                "conditions": [
+                  {
+                    "evaluator": {
+                      "params": [90],
+                      "type": "gt"
+                    },
+                    "operator": {
+                      "type": "and"
+                    },
+                    "query": {
+                      "params": []
+                    },
+                    "reducer": {
+                      "params": [],
+                      "type": "avg"
+                    },
+                    "type": "query"
+                  }
+                ],
+                "datasource": {
+                  "type": "__expr__",
+                  "uid": "__expr__"
+                },
+                "expression": "A",
+                "intervalMs": 1000,
+                "maxDataPoints": 43200,
+                "refId": "B",
+                "type": "threshold"
+              }
+            }
+          ],
+          "noDataState": "KeepLast",
+          "execErrState": "KeepLast",
+          "for": "10m",
+          "annotations": {
+            "summary": "Node {{ $labels.node }} has high inode usage on mountpoint {{ $labels.mountpoint }}",
+            "description": "Inode usage is above 90% on node {{ $labels.node }} for mountpoint {{ $labels.mountpoint }}. Current usage: {{ printf \"%.3f\" $values.A.Value }}%"
+          },
+          "labels": {},
+          "isPaused": false,
+          "notification_settings": {
+            "receiver": "slack-scout"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/helm/grafana/kustomization.yaml
+++ b/helm/grafana/kustomization.yaml
@@ -70,6 +70,12 @@ configMapGenerator:
       labels:
         grafana_alert: "1"
 
+  - name: high-node-mount-inode-usage-alert
+    files: [ alerts/alert-rules/high-node-mount-inode-usage-alert.json ]
+    options:
+      labels:
+        grafana_alert: "1"
+
   - name: slack-notification-template
     files: [ alerts/notification-templates/slack-notification-template.json ]
     options:


### PR DESCRIPTION
# Add alert for high inode usage

## Type of change
- [ ] Work behind a feature flag
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product / Technical
-  Introduces a new alert for monitoring high inode usage on node mount points. Users will be notified when inode usage exceeds 90% on a mount (/, /scout/data, /scout/persistence, ...).

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
- Removed ceph filesystem type from promql query, we are not storing data there and inodes free is not appearing correctly. Even `df -i` does not show IFree for the /ceph/tag/home mount

### Backward compatibility
- Yes

## Testing
Reviewed the alert on big-02.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
