### PR TITLE
Fix Single-User Jupyter Notebook Pod PV/PVC Binding Issue

### DIFF
--- a/ansible/playbooks/jupyter.yaml
+++ b/ansible/playbooks/jupyter.yaml
@@ -10,34 +10,17 @@
       include_tasks: tasks/storage_setup.yaml
       vars:
         storage_definitions:
-          - name: jupyter
+          - name: jupyter-hub
             size: '15Gi'
             path: '{{ jupyter_dir }}/hub'
 
-    - name: Create single-user storage directory
-      file:
-        path: '{{ jupyter_dir }}/singleuser'
-        state: directory
-        mode: '0777'
-
-    - name: Create PersistentVolume for single-user storage
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: v1
-          kind: PersistentVolume
-          metadata:
-            name: jupyter-singleuser-pv
-            namespace: jupyter
-          spec:
-            capacity:
-              storage: 250Gi
-            accessModes:
-              - ReadWriteOnce
-            persistentVolumeReclaimPolicy: Retain
-            storageClassName: manual
-            hostPath:
-              path: '{{ jupyter_dir }}/singleuser'
+    - name: Setup single-user storage for Jupyter
+      include_tasks: tasks/storage_setup.yaml
+      vars:
+        storage_definitions:
+          - name: jupyter-singleuser
+            size: '250Gi'
+            path: '{{ jupyter_dir }}/singleuser'
 
     - name: Create PersistentVolumeClaim for Jupyter single-user storage
       kubernetes.core.k8s:
@@ -54,7 +37,7 @@
             resources:
               requests:
                 storage: 250Gi
-            storageClassName: manual
+            storageClassName: jupyter-singleuser-storage
 
     - name: Add JupyterHub Helm repository
       kubernetes.core.helm_repository:

--- a/ansible/playbooks/jupyter.yaml
+++ b/ansible/playbooks/jupyter.yaml
@@ -6,7 +6,7 @@
     HELM_PLUGINS: '{{ helm_plugins_dir }}'
     KUBECONFIG: '{{ kubeconfig_yaml }}'
   tasks:
-    - name: Setup JupyterHub storage
+    - name: Setup storage
       include_tasks: tasks/storage_setup.yaml
       vars:
         storage_definitions:

--- a/ansible/playbooks/jupyter.yaml
+++ b/ansible/playbooks/jupyter.yaml
@@ -13,11 +13,6 @@
           - name: jupyter-hub
             size: '15Gi'
             path: '{{ jupyter_dir }}/hub'
-
-    - name: Setup single-user storage for Jupyter
-      include_tasks: tasks/storage_setup.yaml
-      vars:
-        storage_definitions:
           - name: jupyter-singleuser
             size: '250Gi'
             path: '{{ jupyter_dir }}/singleuser'

--- a/ansible/playbooks/jupyter.yaml
+++ b/ansible/playbooks/jupyter.yaml
@@ -6,13 +6,55 @@
     HELM_PLUGINS: '{{ helm_plugins_dir }}'
     KUBECONFIG: '{{ kubeconfig_yaml }}'
   tasks:
-    - name: Setup storage
+    - name: Setup JupyterHub storage
       include_tasks: tasks/storage_setup.yaml
       vars:
         storage_definitions:
           - name: jupyter
-            size: '250Gi'
-            path: '{{ jupyter_dir }}'
+            size: '15Gi'
+            path: '{{ jupyter_dir }}/hub'
+
+    - name: Create single-user storage directory
+      file:
+        path: '{{ jupyter_dir }}/singleuser'
+        state: directory
+        mode: '0777'
+
+    - name: Create PersistentVolume for single-user storage
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: PersistentVolume
+          metadata:
+            name: jupyter-singleuser-pv
+            namespace: jupyter
+          spec:
+            capacity:
+              storage: 250Gi
+            accessModes:
+              - ReadWriteOnce
+            persistentVolumeReclaimPolicy: Retain
+            storageClassName: manual
+            hostPath:
+              path: '{{ jupyter_dir }}/singleuser'
+
+    - name: Create PersistentVolumeClaim for Jupyter single-user storage
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: jupyter-singleuser-pvc
+            namespace: jupyter
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 250Gi
+            storageClassName: manual
 
     - name: Add JupyterHub Helm repository
       kubernetes.core.helm_repository:
@@ -55,3 +97,10 @@
                   - read:org
               JupyterHub:
                 authenticator_class: github
+          singleuser:
+            storage:
+              type: static
+              static:
+                pvcName: jupyter-singleuser-pvc
+                subPath: '{username}'
+              capacity: 10Gi

--- a/ansible/playbooks/jupyter.yaml
+++ b/ansible/playbooks/jupyter.yaml
@@ -75,10 +75,3 @@
                   - read:org
               JupyterHub:
                 authenticator_class: github
-          singleuser:
-            storage:
-              type: static
-              static:
-                pvcName: jupyter-singleuser-pvc
-                subPath: '{username}'
-              capacity: 10Gi

--- a/helm/jupyter/hub/hub-values.yaml
+++ b/helm/jupyter/hub/hub-values.yaml
@@ -24,7 +24,7 @@ hub:
       services: [prometheus]
   db:
     pvc:
-      storageClassName: jupyter-storage
+      storageClassName: jupyter-hub-storage
 
 ingress:
   enabled: true

--- a/helm/jupyter/hub/hub-values.yaml
+++ b/helm/jupyter/hub/hub-values.yaml
@@ -50,13 +50,12 @@ singleuser:
   memory:
     limit: 16G
     guarantee: 2G
-  singleuser:
-    storage:
-      type: static
-      static:
-        pvcName: jupyter-singleuser-pvc
-        subPath: '{username}'
-      capacity: 10Gi
+  storage:
+    type: static
+    static:
+      pvcName: jupyter-singleuser-pvc
+      subPath: '{username}'
+    capacity: 10Gi
   networkPolicy:
     egress:
       - to:

--- a/helm/jupyter/hub/hub-values.yaml
+++ b/helm/jupyter/hub/hub-values.yaml
@@ -50,9 +50,6 @@ singleuser:
   memory:
     limit: 16G
     guarantee: 2G
-  storage:
-    dynamic:
-      storageClass: jupyter-storage
   networkPolicy:
     egress:
       - to:

--- a/helm/jupyter/hub/hub-values.yaml
+++ b/helm/jupyter/hub/hub-values.yaml
@@ -50,6 +50,13 @@ singleuser:
   memory:
     limit: 16G
     guarantee: 2G
+  singleuser:
+    storage:
+      type: static
+      static:
+        pvcName: jupyter-singleuser-pvc
+        subPath: '{username}'
+      capacity: 10Gi
   networkPolicy:
     egress:
       - to:


### PR DESCRIPTION
# Fix Single-User Jupyter Notebook Pod PV/PVC Binding Issue

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
- Fix issue with single-user notebook storage.

### Technical
When [updating storage classes and PVs](https://github.com/washu-tag/scout/pull/50), the single-user pods are unable to bind to the pv/pvc shared with the Hub. But single-user pods probably shouldn't share a pv/pvcC with the Hub. This gives the hub one pv/pvc and all single-user pods share a pv/pvc.

## Impact

### Backward compatibility
Fixes issue introduced in https://github.com/washu-tag/scout/pull/50. The behavior is the same from a user perspective, but instead of each single-user pod getting it's own pv/pvc, all single-user pods share a pv/pvc. I tried to setup a rancher/local-path-provisioner specifically for Jupyter pods but was not able to do so quickly. This unblocks Jupyter and is okay for now

## Testing
Tested on big-02. I was able to log out/in and my notebooks were persisted.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
