### PR TITLE
Add python worker health check for spark

### DIFF
--- a/helm/orchestration/temporal-python.values.yaml
+++ b/helm/orchestration/temporal-python.values.yaml
@@ -22,3 +22,11 @@ volumeMounts:
   - name: data
     mountPath: /data
     readOnly: true
+ports:
+  - containerPort: 8000
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8000
+  initialDelaySeconds: 30
+  periodSeconds: 30

--- a/helm/orchestration/temporal-worker/templates/deployment.yaml
+++ b/helm/orchestration/temporal-worker/templates/deployment.yaml
@@ -40,6 +40,14 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.ports }}
+          ports:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/helm/orchestration/temporal-worker/values.yaml
+++ b/helm/orchestration/temporal-worker/values.yaml
@@ -56,6 +56,15 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
+ports: []
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  {}
+  # httpGet:
+  #   path: /
+  #   port: http
+
 resources:
   {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/orchestration/temporal-python/pyproject.toml
+++ b/orchestration/temporal-python/pyproject.toml
@@ -20,6 +20,8 @@ classifiers = [
 requires-python = ">= 3.8"  # Lower limit is a guess
 dependencies = [
     "delta-spark",
+    "fastapi",
     "pyspark==3.5.4",
     "temporalio",
+    "uvicorn",
 ]

--- a/orchestration/temporal-python/src/temporalpy/activities/ingesthl7.py
+++ b/orchestration/temporal-python/src/temporalpy/activities/ingesthl7.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 from temporalio import activity
@@ -30,9 +31,11 @@ class IngestHl7FilesActivity:
     """
 
     default_modality_map_path: str
+    health_file: Path
 
-    def __init__(self, default_modality_map_path: str):
+    def __init__(self, default_modality_map_path: str, health_file: Path):
         self.default_modality_map_path = default_modality_map_path
+        self.health_file = health_file
 
     @activity.defn(name=ACTIVITY_NAME)
     def ingest_hl7_files_to_delta_lake(
@@ -50,6 +53,7 @@ class IngestHl7FilesActivity:
             activity_input.deltaTable,
             activity_input.hl7ManifestFilePath,
             modality_map_path,
+            self.health_file,
         )
 
         return IngestHl7FilesToDeltaLakeActivityOutput(num_hl7_ingested)

--- a/orchestration/temporal-python/src/temporalpy/healthapi.py
+++ b/orchestration/temporal-python/src/temporalpy/healthapi.py
@@ -30,12 +30,13 @@ async def healthz():
 
         # Read the contents of the temporary file
         contents = SPARK_HEALTH_TEMP_FILE.read_text()
-        if contents != HEALTHY:
-            log.warning("Health check file reports failure: %s", contents)
-            return unhealthy_json_response(f"Spark reported status: {contents}")
+        if not contents:
+            # No health information available. Assume healthy.
+            log.debug("No health information available (assume healthy)")
+            return HEALTHY_JSON_RESPONSE
 
-        log.info("Health check succeeded")
-        return HEALTHY_JSON_RESPONSE
+        log.warning('Health check file reports failure: "%s"', contents)
+        return unhealthy_json_response(f"Spark reported status: {contents}")
     except Exception as e:
         log.error("Health check failed with exception", e)
         return unhealthy_json_response(str(e))

--- a/orchestration/temporal-python/src/temporalpy/healthapi.py
+++ b/orchestration/temporal-python/src/temporalpy/healthapi.py
@@ -34,17 +34,22 @@ async def healthz():
             # No health information available. Assume healthy.
             log.debug("No health information available (assume healthy)")
             return HEALTHY_JSON_RESPONSE
+        messages = [line for line in contents.splitlines() if line]
+        reason = messages[0] if messages else "unknown"
 
-        log.warning('Health check file reports failure: "%s"', contents)
-        return unhealthy_json_response(f"Spark reported status: {contents}")
+        log.warning('Health check file reports failure: "%s"', reason)
+        return unhealthy_json_response(reason, messages)
     except Exception as e:
         log.error("Health check failed with exception", e)
         return unhealthy_json_response(str(e))
 
 
-def unhealthy_json_response(reason: str) -> JSONResponse:
+def unhealthy_json_response(
+    reason: str, messages: list[str] | None = None
+) -> JSONResponse:
     return JSONResponse(
-        status_code=503, content={"status": UNHEALTHY, "reason": reason}
+        status_code=503,
+        content={"status": UNHEALTHY, "reason": reason, "messages": messages or []},
     )
 
 

--- a/orchestration/temporal-python/src/temporalpy/healthapi.py
+++ b/orchestration/temporal-python/src/temporalpy/healthapi.py
@@ -10,7 +10,7 @@ from fastapi.responses import JSONResponse
 log = logging.getLogger(__name__)
 
 # Temporary file for Spark health check
-SPARK_HEALTH_TEMP_FILE = Path(tempfile.gettempdir()) / "spark_health_check"
+SPARK_HEALTH_TEMP_FILE = Path(tempfile.mkstemp()[1])
 HEALTHY = "healthy"
 UNHEALTHY = "unhealthy"
 HEALTHY_JSON_RESPONSE = JSONResponse(status_code=200, content={"status": HEALTHY})
@@ -51,9 +51,3 @@ async def start_spark_health_check_server():
     config = uvicorn.Config(app, host="0.0.0.0", port=8000, log_level="warning")
     server = uvicorn.Server(config)
     await server.serve()
-
-
-def report_unhealthy(content: str):
-    """Report an unhealthy status by writing to the temporary file."""
-    SPARK_HEALTH_TEMP_FILE.write_text(content)
-    log.info("Reported unhealthy status: %s", content)

--- a/orchestration/temporal-python/src/temporalpy/healthapi.py
+++ b/orchestration/temporal-python/src/temporalpy/healthapi.py
@@ -1,0 +1,59 @@
+import logging
+import tempfile
+from pathlib import Path
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+
+log = logging.getLogger(__name__)
+
+# Temporary file for Spark health check
+SPARK_HEALTH_TEMP_FILE = Path(tempfile.gettempdir()) / "spark_health_check"
+HEALTHY = "healthy"
+UNHEALTHY = "unhealthy"
+HEALTHY_JSON_RESPONSE = JSONResponse(status_code=200, content={"status": HEALTHY})
+
+
+app = FastAPI()
+
+
+@app.get("/healthz")
+async def healthz():
+    try:
+        log.debug("Running health check")
+        if not SPARK_HEALTH_TEMP_FILE.exists():
+            # No health information available. Assume healthy.
+            log.debug("No health information available (assume healthy)")
+            return HEALTHY_JSON_RESPONSE
+
+        # Read the contents of the temporary file
+        contents = SPARK_HEALTH_TEMP_FILE.read_text()
+        if contents != HEALTHY:
+            log.warning("Health check file reports failure: %s", contents)
+            return unhealthy_json_response(f"Spark reported status: {contents}")
+
+        log.info("Health check succeeded")
+        return HEALTHY_JSON_RESPONSE
+    except Exception as e:
+        log.error("Health check failed with exception", e)
+        return unhealthy_json_response(str(e))
+
+
+def unhealthy_json_response(reason: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=503, content={"status": UNHEALTHY, "reason": reason}
+    )
+
+
+async def start_spark_health_check_server():
+    config = uvicorn.Config(app, host="0.0.0.0", port=8000, log_level="warning")
+    server = uvicorn.Server(config)
+    await server.serve()
+
+
+def report_unhealthy(content: str):
+    """Report an unhealthy status by writing to the temporary file."""
+    SPARK_HEALTH_TEMP_FILE.write_text(content)
+    log.info("Reported unhealthy status: %s", content)

--- a/orchestration/temporal-python/src/temporalpy/hl7extractor/deltalake.py
+++ b/orchestration/temporal-python/src/temporalpy/hl7extractor/deltalake.py
@@ -285,8 +285,8 @@ def import_hl7_files_to_deltalake(
             .execute()
         )
     except (Py4JError, ConnectionError) as e:
-        activity.logger.exception(
-            "Spark error ingesting HL7 files to Delta Lake", exc_info=e
+        activity.logger.error(
+            "Spark error ingesting HL7 files to Delta Lake. Marking pod unhealthy."
         )
         try:
             message = str(e)
@@ -294,7 +294,8 @@ def import_hl7_files_to_deltalake(
             message = "Unknown error"
 
         # Write the error message to the health file
-        health_file.write_text(message)
+        with health_file.open("a") as f:
+            f.write(message + "\n")
         raise
     except Exception as e:
         activity.logger.exception("Error ingesting HL7 files to Delta Lake", exc_info=e)

--- a/orchestration/temporal-python/src/temporalpy/hl7extractor/deltalake.py
+++ b/orchestration/temporal-python/src/temporalpy/hl7extractor/deltalake.py
@@ -284,7 +284,7 @@ def import_hl7_files_to_deltalake(
             .whenNotMatchedInsertAll()
             .execute()
         )
-    except Py4JError | ConnectionError as e:
+    except (Py4JError, ConnectionError) as e:
         activity.logger.exception(
             "Spark error ingesting HL7 files to Delta Lake", exc_info=e
         )

--- a/orchestration/temporal-python/src/temporalpy/hl7extractor/deltalake.py
+++ b/orchestration/temporal-python/src/temporalpy/hl7extractor/deltalake.py
@@ -2,10 +2,13 @@ import os
 
 from delta import configure_spark_with_delta_pip
 from delta.tables import DeltaTable
+from py4j.protocol import Py4JError
 from pyspark.sql import Column, SparkSession
 from pyspark.sql import functions as F
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
+
+from temporalpy.healthapi import report_unhealthy
 
 DATE_FORMAT = "yyyyMMdd"
 DT_FORMAT = "yyyyMMddHHmmss"
@@ -57,221 +60,248 @@ def import_hl7_files_to_deltalake(
     if not s3a_endpoint or not s3a_access_key or not s3a_secret_key:
         raise ApplicationError("S3 endpoint, access key, and secret key required")
 
-    activity.logger.info("Creating Spark session")
-    extra_packages = ["org.apache.hadoop:hadoop-aws:3.2.2"]
-    spark_builder = (
-        SparkSession.builder.appName("IngestHL7ToDeltaLake")
-        # .config("spark.jars", "/opt/spark/jars/*.jar")
-        .config("spark.jars", "/opt/spark/jars/smolder_2.12-0.1.0-SNAPSHOT.jar")
-        .config("spark.databricks.delta.schema.autoMerge.enabled", "true")
-        .config("spark.databricks.delta.merge.repartitionBeforeWrite.enabled", "true")
-        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-        .config(
-            "spark.sql.catalog.spark_catalog",
-            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
-        )
-        .config("spark.hadoop.fs.s3a.access.key", s3a_access_key)
-        .config("spark.hadoop.fs.s3a.secret.key", s3a_secret_key)
-        .config("spark.hadoop.fs.s3a.endpoint", s3a_endpoint)
-        .config("spark.hadoop.fs.s3a.endpoint.region", s3a_region)
-        .config("spark.hadoop.fs.s3a.path.style.access", "true")
-        .config(
-            "spark.hadoop.fs.s3a.aws.credentials.provider",
-            "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-        )
-        .config("spark.driver.extraJavaOptions", "-Divy.cache.dir=/tmp -Divy.home=/tmp")
-    )
-
-    if spark_executor_memory:
-        spark_builder.config("spark.executor.memory", spark_executor_memory)
-        spark_builder.config("spark.driver.memory", spark_executor_memory)
-    spark = configure_spark_with_delta_pip(
-        spark_builder, extra_packages=extra_packages
-    ).getOrCreate()
-
-    activity.logger.info("Reading HL7 manifest file %s", hl7_manifest_file_path)
-    hl7_manifest_file_path = hl7_manifest_file_path.replace("s3://", "s3a://")
-    file_path_file_df = spark.read.text(hl7_manifest_file_path)
-
-    # I wish I could just have spark read these directly without collecting first but I can't figure out how
-    hl7_file_paths_from_spark = [
-        row.value.replace("s3://", "s3a://") for row in file_path_file_df.collect()
-    ]
-    if not hl7_file_paths_from_spark:
-        raise ApplicationError("No HL7 files found in HL7 file path files")
-
-    activity.logger.info("Reading %d HL7 messages", len(hl7_file_paths_from_spark))
-    df = (
-        spark.read.format("hl7")
-        .load(hl7_file_paths_from_spark)
-        .withColumn("source_file", F.input_file_name())
-    )
-
-    if df.isEmpty():
-        raise ApplicationError("No data extracted from HL7 messages")
-
-    num_hl7 = df.count()
-    activity.logger.info("Extracted data from %d HL7 messages", num_hl7)
-
-    # Read modality map
-    modality_map_csv_path = modality_map_csv_path.replace("s3://", "s3a://")
-    activity.logger.info("Reading modality map from %s", modality_map_csv_path)
-    modality_map = (
-        spark.read.option("header", True)
-        .csv(modality_map_csv_path)
-        .select(
-            F.col("Exam Code").alias("service_identifier"),
-            F.col("Modality").alias("modality"),
-        )
-    )
-
-    activity.logger.info("Creating report df")
-    report_df = (
-        df.select(
-            "source_file",
-            # Get all OBX segments and explode into separate rows, keeping the index as "pos" column
-            F.posexplode(F.filter("segments", lambda s: s["id"] == "OBX")),
-        )
-        .select(
-            "source_file",
-            # "pos" holds the index of the OBX segment
-            "pos",
-            # "col" holds the OBX segment data
-            F.when(
-                # TX data type has a ~ delimiter, replace with newline
-                F.col("col").getField("fields").getItem(1) == "TX",
-                F.regexp_replace(F.col("col").getField("fields").getItem(4), "~", "\n"),
+    spark = None
+    try:
+        activity.logger.info("Creating Spark session")
+        extra_packages = ["org.apache.hadoop:hadoop-aws:3.2.2"]
+        spark_builder = (
+            SparkSession.builder.appName("IngestHL7ToDeltaLake")
+            # .config("spark.jars", "/opt/spark/jars/*.jar")
+            .config("spark.jars", "/opt/spark/jars/smolder_2.12-0.1.0-SNAPSHOT.jar")
+            .config("spark.databricks.delta.schema.autoMerge.enabled", "true")
+            .config(
+                "spark.databricks.delta.merge.repartitionBeforeWrite.enabled", "true"
             )
-            # Other data types are a single line as the value
-            .otherwise(F.col("col").getField("fields").getItem(4)).alias("obx-5"),
-            F.col("col").getField("fields").getItem(10).alias("obx-11"),
-        )
-        .groupby("source_file")
-        .agg(
-            # Join all lines of report text into one string
-            F.concat_ws("\n", F.collect_list("obx-5")).alias("report_text"),
-            # Assume report statuses are the same, pick first
-            F.first("obx-11").alias("report_status"),
-        )
-    )
-
-    activity.logger.info("Extracting patient id columns")
-    exploded_patient_id_df = df.select(
-        "source_file",
-        F.explode(
-            F.split(
-                F.filter("segments", lambda s: s["id"] == "PID")
-                .getItem(0)
-                .getField("fields")
-                .getItem(2),
-                "~",
+            .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+            .config(
+                "spark.sql.catalog.spark_catalog",
+                "org.apache.spark.sql.delta.catalog.DeltaCatalog",
             )
-        ).alias("pid"),
-    ).select(
-        "source_file",
-        F.split("pid", "\\^").getItem(0).alias("id_number"),
-        F.split("pid", "\\^").getItem(3).alias("assigning_authority"),
-        F.split("pid", "\\^").getItem(4).alias("identifier_type_code"),
-    )
-
-    patient_id_df = (
-        # Filter out patient ids with missing fields
-        exploded_patient_id_df.filter(EMPTY_FILTER)
-        .select(
-            "source_file",
-            "id_number",
-            F.concat_ws(
-                "_",
-                F.lower("assigning_authority"),
-                F.lower("identifier_type_code"),
-            ).alias("patient_id_col_name"),
-        )
-        .groupBy("source_file")
-        # Turn the patient_id_col_name values into columns
-        .pivot("patient_id_col_name")
-        # Assume they only have one patient id for each type
-        .agg(F.first("id_number"))
-    )
-    # Note that we do not filter out any patient ids here, so they are all available in the JSON
-    patient_id_json_df = exploded_patient_id_df.groupBy("source_file").agg(
-        F.to_json(
-            F.collect_list(
-                F.struct("id_number", "assigning_authority", "identifier_type_code")
+            .config("spark.hadoop.fs.s3a.access.key", s3a_access_key)
+            .config("spark.hadoop.fs.s3a.secret.key", s3a_secret_key)
+            .config("spark.hadoop.fs.s3a.endpoint", s3a_endpoint)
+            .config("spark.hadoop.fs.s3a.endpoint.region", s3a_region)
+            .config("spark.hadoop.fs.s3a.path.style.access", "true")
+            .config(
+                "spark.hadoop.fs.s3a.aws.credentials.provider",
+                "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
             )
-        ).alias("patient_id_json")
-    )
+            .config(
+                "spark.driver.extraJavaOptions", "-Divy.cache.dir=/tmp -Divy.home=/tmp"
+            )
+        )
 
-    activity.logger.info("Joining data into report df")
-    df = (
-        df.select(
-            segment_field("MSH", 10).alias("message_control_id"),
-            segment_field("MSH", 4).alias("sending_facility"),
-            segment_field("MSH", 12).alias("version_id"),
-            parse_timestamp_col(segment_field("MSH", 7)).alias("message_dt"),
-            F.to_date(F.substring(segment_field("PID", 7), 1, 8), DATE_FORMAT).alias(
-                "birth_date"
-            ),
-            segment_field("PID", 8).alias("sex"),
-            segment_field("PID", 10).alias("race"),
-            segment_field("PID", 11, 5).alias("zip_or_postal_code"),
-            segment_field("PID", 11, 6).alias("country"),
-            segment_field("PID", 22).alias("ethnic_group"),
-            segment_field("ORC", 2).alias("orc_2_placer_order_number"),
-            segment_field("OBR", 2).alias("obr_2_placer_order_number"),
-            segment_field("ORC", 3).alias("orc_3_filler_order_number"),
-            segment_field("OBR", 3).alias("obr_3_filler_order_number"),
-            segment_field("OBR", 4, 1).alias("service_identifier"),
-            segment_field("OBR", 4, 2).alias("service_name"),
-            segment_field("OBR", 4, 3).alias("service_coding_system"),
-            parse_timestamp_col(segment_field("OBR", 6)).alias("requested_dt"),
-            parse_timestamp_col(segment_field("OBR", 7)).alias("observation_dt"),
-            parse_timestamp_col(segment_field("OBR", 8)).alias("observation_end_dt"),
-            parse_timestamp_col(segment_field("OBR", 22)).alias(
-                "results_report_status_change_dt"
-            ),
-            segment_field("OBR", 24).alias("diagnostic_service_id"),
-            segment_field("DG1", 3, 1).alias("diagnosis_code"),
-            segment_field("DG1", 3, 2).alias("diagnosis_code_text"),
-            segment_field("DG1", 3, 3).alias("diagnosis_code_coding_system"),
-            segment_field("ZDS", 1).alias("study_instance_uid"),
+        if spark_executor_memory:
+            spark_builder.config("spark.executor.memory", spark_executor_memory)
+            spark_builder.config("spark.driver.memory", spark_executor_memory)
+        spark = configure_spark_with_delta_pip(
+            spark_builder, extra_packages=extra_packages
+        ).getOrCreate()
+
+        activity.logger.info("Reading HL7 manifest file %s", hl7_manifest_file_path)
+        hl7_manifest_file_path = hl7_manifest_file_path.replace("s3://", "s3a://")
+        file_path_file_df = spark.read.text(hl7_manifest_file_path)
+
+        # I wish I could just have spark read these directly without collecting first but I can't figure out how
+        hl7_file_paths_from_spark = [
+            row.value.replace("s3://", "s3a://") for row in file_path_file_df.collect()
+        ]
+        if not hl7_file_paths_from_spark:
+            raise ApplicationError("No HL7 files found in HL7 file path files")
+
+        activity.logger.info("Reading %d HL7 messages", len(hl7_file_paths_from_spark))
+        df = (
+            spark.read.format("hl7")
+            .load(hl7_file_paths_from_spark)
+            .withColumn("source_file", F.input_file_name())
+        )
+
+        if df.isEmpty():
+            raise ApplicationError("No data extracted from HL7 messages")
+
+        num_hl7 = df.count()
+        activity.logger.info("Extracted data from %d HL7 messages", num_hl7)
+
+        # Read modality map
+        modality_map_csv_path = modality_map_csv_path.replace("s3://", "s3a://")
+        activity.logger.info("Reading modality map from %s", modality_map_csv_path)
+        modality_map = (
+            spark.read.option("header", True)
+            .csv(modality_map_csv_path)
+            .select(
+                F.col("Exam Code").alias("service_identifier"),
+                F.col("Modality").alias("modality"),
+            )
+        )
+
+        activity.logger.info("Creating report df")
+        report_df = (
+            df.select(
+                "source_file",
+                # Get all OBX segments and explode into separate rows, keeping the index as "pos" column
+                F.posexplode(F.filter("segments", lambda s: s["id"] == "OBX")),
+            )
+            .select(
+                "source_file",
+                # "pos" holds the index of the OBX segment
+                "pos",
+                # "col" holds the OBX segment data
+                F.when(
+                    # TX data type has a ~ delimiter, replace with newline
+                    F.col("col").getField("fields").getItem(1) == "TX",
+                    F.regexp_replace(
+                        F.col("col").getField("fields").getItem(4), "~", "\n"
+                    ),
+                )
+                # Other data types are a single line as the value
+                .otherwise(F.col("col").getField("fields").getItem(4)).alias("obx-5"),
+                F.col("col").getField("fields").getItem(10).alias("obx-11"),
+            )
+            .groupby("source_file")
+            .agg(
+                # Join all lines of report text into one string
+                F.concat_ws("\n", F.collect_list("obx-5")).alias("report_text"),
+                # Assume report statuses are the same, pick first
+                F.first("obx-11").alias("report_status"),
+            )
+        )
+
+        activity.logger.info("Extracting patient id columns")
+        exploded_patient_id_df = df.select(
             "source_file",
+            F.explode(
+                F.split(
+                    F.filter("segments", lambda s: s["id"] == "PID")
+                    .getItem(0)
+                    .getField("fields")
+                    .getItem(2),
+                    "~",
+                )
+            ).alias("pid"),
+        ).select(
+            "source_file",
+            F.split("pid", "\\^").getItem(0).alias("id_number"),
+            F.split("pid", "\\^").getItem(3).alias("assigning_authority"),
+            F.split("pid", "\\^").getItem(4).alias("identifier_type_code"),
         )
-        .join(report_df, "source_file", "left")
-        .join(patient_id_df, "source_file", "left")
-        .join(patient_id_json_df, "source_file", "left")
-        .join(modality_map, "service_identifier", "left")
-        .withColumn("year", F.year("message_dt"))
-        .withColumn("updated", F.current_timestamp())
-    )
 
-    # Create table if it doesn't yet exist
-    delta_table = delta_table.replace("s3://", "s3a://")
-
-    activity.logger.info(
-        "Creating Delta Lake table %s if it does not exist", delta_table
-    )
-    dt = (
-        DeltaTable.createIfNotExists(spark)
-        .location(delta_table)
-        .addColumns(df.schema)
-        .partitionedBy("year")
-        .execute()
-    )
-
-    activity.logger.info("Writing data to Delta Lake table %s", delta_table)
-    (
-        dt.alias("s")
-        .merge(
-            df.alias("t"),
-            "s.source_file = t.source_file AND s.year = t.year",
+        patient_id_df = (
+            # Filter out patient ids with missing fields
+            exploded_patient_id_df.filter(EMPTY_FILTER)
+            .select(
+                "source_file",
+                "id_number",
+                F.concat_ws(
+                    "_",
+                    F.lower("assigning_authority"),
+                    F.lower("identifier_type_code"),
+                ).alias("patient_id_col_name"),
+            )
+            .groupBy("source_file")
+            # Turn the patient_id_col_name values into columns
+            .pivot("patient_id_col_name")
+            # Assume they only have one patient id for each type
+            .agg(F.first("id_number"))
         )
-        .whenMatchedUpdateAll()
-        .whenNotMatchedInsertAll()
-        .execute()
-    )
+        # Note that we do not filter out any patient ids here, so they are all available in the JSON
+        patient_id_json_df = exploded_patient_id_df.groupBy("source_file").agg(
+            F.to_json(
+                F.collect_list(
+                    F.struct("id_number", "assigning_authority", "identifier_type_code")
+                )
+            ).alias("patient_id_json")
+        )
 
-    activity.logger.info("Stopping spark")
-    spark.stop()
+        activity.logger.info("Joining data into report df")
+        df = (
+            df.select(
+                segment_field("MSH", 10).alias("message_control_id"),
+                segment_field("MSH", 4).alias("sending_facility"),
+                segment_field("MSH", 12).alias("version_id"),
+                parse_timestamp_col(segment_field("MSH", 7)).alias("message_dt"),
+                F.to_date(
+                    F.substring(segment_field("PID", 7), 1, 8), DATE_FORMAT
+                ).alias("birth_date"),
+                segment_field("PID", 8).alias("sex"),
+                segment_field("PID", 10).alias("race"),
+                segment_field("PID", 11, 5).alias("zip_or_postal_code"),
+                segment_field("PID", 11, 6).alias("country"),
+                segment_field("PID", 22).alias("ethnic_group"),
+                segment_field("ORC", 2).alias("orc_2_placer_order_number"),
+                segment_field("OBR", 2).alias("obr_2_placer_order_number"),
+                segment_field("ORC", 3).alias("orc_3_filler_order_number"),
+                segment_field("OBR", 3).alias("obr_3_filler_order_number"),
+                segment_field("OBR", 4, 1).alias("service_identifier"),
+                segment_field("OBR", 4, 2).alias("service_name"),
+                segment_field("OBR", 4, 3).alias("service_coding_system"),
+                parse_timestamp_col(segment_field("OBR", 6)).alias("requested_dt"),
+                parse_timestamp_col(segment_field("OBR", 7)).alias("observation_dt"),
+                parse_timestamp_col(segment_field("OBR", 8)).alias(
+                    "observation_end_dt"
+                ),
+                parse_timestamp_col(segment_field("OBR", 22)).alias(
+                    "results_report_status_change_dt"
+                ),
+                segment_field("OBR", 24).alias("diagnostic_service_id"),
+                segment_field("DG1", 3, 1).alias("diagnosis_code"),
+                segment_field("DG1", 3, 2).alias("diagnosis_code_text"),
+                segment_field("DG1", 3, 3).alias("diagnosis_code_coding_system"),
+                segment_field("ZDS", 1).alias("study_instance_uid"),
+                "source_file",
+            )
+            .join(report_df, "source_file", "left")
+            .join(patient_id_df, "source_file", "left")
+            .join(patient_id_json_df, "source_file", "left")
+            .join(modality_map, "service_identifier", "left")
+            .withColumn("year", F.year("message_dt"))
+            .withColumn("updated", F.current_timestamp())
+        )
+
+        # Create table if it doesn't yet exist
+        delta_table = delta_table.replace("s3://", "s3a://")
+
+        activity.logger.info(
+            "Creating Delta Lake table %s if it does not exist", delta_table
+        )
+        dt = (
+            DeltaTable.createIfNotExists(spark)
+            .location(delta_table)
+            .addColumns(df.schema)
+            .partitionedBy("year")
+            .execute()
+        )
+
+        activity.logger.info("Writing data to Delta Lake table %s", delta_table)
+        (
+            dt.alias("s")
+            .merge(
+                df.alias("t"),
+                "s.source_file = t.source_file AND s.year = t.year",
+            )
+            .whenMatchedUpdateAll()
+            .whenNotMatchedInsertAll()
+            .execute()
+        )
+    except Py4JError | ConnectionError as e:
+        activity.logger.exception(
+            "Spark error ingesting HL7 files to Delta Lake", exc_info=e
+        )
+        try:
+            message = str(e)
+        except:
+            message = "Unknown error"
+        report_unhealthy(message)
+        raise
+    except Exception as e:
+        activity.logger.exception("Error ingesting HL7 files to Delta Lake", exc_info=e)
+        raise
+    finally:
+        if spark is not None:
+            activity.logger.info("Stopping spark")
+            try:
+                spark.stop()
+            except:
+                pass
 
     activity.logger.info("Finished")
     return num_hl7

--- a/orchestration/temporal-python/src/temporalpy/ingesthl7worker.py
+++ b/orchestration/temporal-python/src/temporalpy/ingesthl7worker.py
@@ -13,6 +13,7 @@ from temporalpy.activities.ingesthl7 import (
     TASK_QUEUE_NAME,
     IngestHl7FilesActivity,
 )
+from temporalpy.healthapi import start_spark_health_check_server
 
 log = logging.getLogger("workflow_worker")
 
@@ -71,7 +72,12 @@ async def main(argv=None):
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 
-    await run_worker(temporal_address, temporal_namespace, modality_map_path)
+    health_check_task = asyncio.create_task(start_spark_health_check_server())
+    worker_task = asyncio.create_task(
+        run_worker(temporal_address, temporal_namespace, modality_map_path)
+    )
+
+    await asyncio.gather(health_check_task, worker_task)
 
 
 if __name__ == "__main__":

--- a/orchestration/temporal-python/src/temporalpy/ingesthl7worker.py
+++ b/orchestration/temporal-python/src/temporalpy/ingesthl7worker.py
@@ -5,6 +5,7 @@ import logging
 import multiprocessing
 import os
 import sys
+from pathlib import Path
 
 from temporalio.client import Client
 from temporalio.worker import Worker, SharedStateManager
@@ -13,16 +14,16 @@ from temporalpy.activities.ingesthl7 import (
     TASK_QUEUE_NAME,
     IngestHl7FilesActivity,
 )
-from temporalpy.healthapi import start_spark_health_check_server
+from temporalpy.healthapi import start_spark_health_check_server, SPARK_HEALTH_TEMP_FILE
 
 log = logging.getLogger("workflow_worker")
 
 
 async def run_worker(
-    temporal_address: str, namespace: str, mapping_file_path: str
+    temporal_address: str, namespace: str, mapping_file_path: str, health_file: Path
 ) -> None:
     client = await Client.connect(temporal_address, namespace=namespace)
-    ingest_hl7_files_activity = IngestHl7FilesActivity(mapping_file_path)
+    ingest_hl7_files_activity = IngestHl7FilesActivity(mapping_file_path, health_file)
     with concurrent.futures.ProcessPoolExecutor(1) as pool:
         worker = Worker(
             client,
@@ -74,7 +75,12 @@ async def main(argv=None):
 
     health_check_task = asyncio.create_task(start_spark_health_check_server())
     worker_task = asyncio.create_task(
-        run_worker(temporal_address, temporal_namespace, modality_map_path)
+        run_worker(
+            temporal_address,
+            temporal_namespace,
+            modality_map_path,
+            SPARK_HEALTH_TEMP_FILE,
+        )
     )
 
     await asyncio.gather(health_check_task, worker_task)


### PR DESCRIPTION

## Type of change
- [ ] Work behind a feature flag
- [X] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

This adds a health check to the python worker, so that if spark dies or whatever we can signal to kubernetes that it needs to restart the pod.

There are two main pieces
1. Add a small FastAPI server with a `/healthz` API endpoint. When the API is hit it checks the contents of a temp file; if there is anything in the file it reports that the pod is unhealthy. We configure the helm chart so kubernetes will periodically check this API for health.
2. In the main worker code, if certain spark-y exceptions are caught, write the error message to the health check temp file.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
I don't think there are any security implications here.
- I did initially hard-code the path to the temp health check file, but I thought that might open some kind of attack (though I'm not sure how it would actually work). I switched to using the `tempfile.mkstemp` function ([docs](https://docs.python.org/3.10/library/tempfile.html#tempfile.mkstemp)) to create the file, which should be more secure.
- The `/healthz` API is open, but it is a fairly cheap operation.

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
I deployed this to a local k8s cluster and manually tested a couple scenarios.
- Manually write a message to the health check temp file (using a dev API that I did not check in)
- While a workflow was running, manually exec to the container and kill the spark process
In both cases the `/healthz` endpoint did report the pod was unhealthy and it was restarted.

I haven't been able to reproduce the error case where spark is OOM killed, but I suspect it would be similar to my "kill spark" test case.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
