### PR TITLE
Parallel docker builds

### DIFF
--- a/.github/actions/docker-build-cache/action.yaml
+++ b/.github/actions/docker-build-cache/action.yaml
@@ -13,9 +13,6 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Checkout GitHub Action
-      uses: actions/checkout@v4.2.1
-
     - name: 'Derive version'
       id: derive-version
       uses: ./.github/actions/derive-version

--- a/.github/actions/docker-build-cache/action.yaml
+++ b/.github/actions/docker-build-cache/action.yaml
@@ -13,6 +13,9 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    - name: Checkout GitHub Action
+      uses: actions/checkout@v4.2.1
+
     - name: 'Derive version'
       id: derive-version
       uses: ./.github/actions/derive-version

--- a/.github/actions/docker-build-cache/action.yaml
+++ b/.github/actions/docker-build-cache/action.yaml
@@ -10,6 +10,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Checkout GitHub Action
+      uses: actions/checkout@v4.2.1
+
     - name: 'Derive version'
       id: derive-version
       uses: ./.github/actions/derive-version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: 'Build/Cache Image - pyspark-notebook'
         uses: ./.github/actions/docker-build-cache
         with:
-          subproject: orchestration/pyspark-notebook
+          subproject: helm/jupyter/notebook
           image-name: pyspark-notebook
   build-and-upload-explorer:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
       attestations: write
       id-token: write
     steps:
+      - uses: actions/checkout@v4.2.1
       - name: 'Build/Cache Image - temporal-java'
         uses: ./.github/actions/docker-build-cache
         with:
@@ -43,6 +44,7 @@ jobs:
       attestations: write
       id-token: write
     steps:
+      - uses: actions/checkout@v4.2.1
       - name: 'Build/Cache Image - temporal-python'
         uses: ./.github/actions/docker-build-cache
         with:
@@ -55,6 +57,7 @@ jobs:
       attestations: write
       id-token: write
     steps:
+      - uses: actions/checkout@v4.2.1
       - name: 'Build/Cache Image - pyspark-notebook'
         uses: ./.github/actions/docker-build-cache
         with:
@@ -67,6 +70,7 @@ jobs:
       attestations: write
       id-token: write
     steps:
+      - uses: actions/checkout@v4.2.1
       - name: 'Build/Cache Image - explorer'
         uses: ./.github/actions/docker-build-cache
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
   push:
-    branches: [main, parallel-docker]
+    branches: [main]
 
 env:
   JAVA_DIST: 'zulu'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
   push:
-    branches: [main]
+    branches: [main, parallel-docker]
 
 env:
   JAVA_DIST: 'zulu'
@@ -24,32 +24,49 @@ jobs:
           distribution: ${{ ENV.JAVA_DIST }}
           java-version: ${{ ENV.JAVA_VERSION }}
       - uses: pre-commit/action@v3.0.1
-  build-and-upload-artifact:
+  build-and-upload-temporal-java:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       attestations: write
       id-token: write
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Checkout GitHub Action
-        uses: actions/checkout@v4.2.1
       - name: 'Build/Cache Image - temporal-java'
         uses: ./.github/actions/docker-build-cache
         with:
           subproject: orchestration/temporal-java
           image-name: temporal-java
+  build-and-upload-temporal-python:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
       - name: 'Build/Cache Image - temporal-python'
         uses: ./.github/actions/docker-build-cache
         with:
           subproject: orchestration/temporal-python
           image-name: temporal-python
+  build-and-upload-pyspark-notebook:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
       - name: 'Build/Cache Image - pyspark-notebook'
         uses: ./.github/actions/docker-build-cache
         with:
-          subproject: helm/jupyter/notebook
+          subproject: orchestration/pyspark-notebook
           image-name: pyspark-notebook
+  build-and-upload-explorer:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
       - name: 'Build/Cache Image - explorer'
         uses: ./.github/actions/docker-build-cache
         with:
@@ -68,7 +85,13 @@ jobs:
         run: cd orchestration/temporal-java && ./gradlew test
   deploy-and-test:
     runs-on: ubuntu-latest
-    needs: [lint, build-and-upload-artifact, unit-test]
+    needs:
+      - lint
+      - build-and-upload-temporal-java
+      - build-and-upload-temporal-python
+      - build-and-upload-temporal-pyspark-notebook
+      - build-and-upload-temporal-explorer
+      - unit-test
     env:
       KUBECONFIG: /etc/rancher/k3s/k3s.yaml
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,8 +89,8 @@ jobs:
       - lint
       - build-and-upload-temporal-java
       - build-and-upload-temporal-python
-      - build-and-upload-temporal-pyspark-notebook
-      - build-and-upload-temporal-explorer
+      - build-and-upload-pyspark-notebook
+      - build-and-upload-explorer
       - unit-test
     env:
       KUBECONFIG: /etc/rancher/k3s/k3s.yaml


### PR DESCRIPTION
# Parallel docker builds

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
N/A

### Technical
This change breaks up building and uploading the docker images as artifacts from 1 job to `n`. _Technically_, it is a bit less efficient in terms of compute resources because each job will need to call the checkout/setup steps, but the benefit (which I'm pretty confident outweighs the cost until/if we start needing to be more judicious with github runners) is that the docker builds can all run in parallel, which significantly cuts down on the total time of the CI workflow.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
CI workflow still passing after changes.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
