### PR TITLE
JupyterHub Dummy Auth

### DIFF
--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -21,19 +21,17 @@ k3s_cluster:
     slack_token: $(echo $SLACK_TOKEN | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     slack_channel_id: $(echo $SLACK_CHANNEL | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     kubeconfig_group: '<name of the linux group that should be able to run kubectl>'
-    postgres_user: 'scout'
-    postgres_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
-    postgres_superuser_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
-    superset_secret: $(openssl rand -base64 42 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
-
-    # JupyterHub variables
     jupyter_auth_class: dummy # dummy or github
     github_client_id: $(echo $CLIENT_ID | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     github_client_secret: $(echo $CLIENT_SECRET | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     github_organization: 'org'
-    jupyter_metrics_api_token: $(openssl rand -hex 32  | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     jupyter_dummy_password: $(echo $JH_DUMMY_PASSWORD | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     jupyter_allowed_users: [] # empty list means all users can log in
+    jupyter_metrics_api_token: $(openssl rand -hex 32  | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    postgres_user: 'scout'
+    postgres_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    postgres_superuser_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    superset_secret: $(openssl rand -base64 42 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
 
     # Namespaces that can be changed
     hive_namespace: hive

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -21,14 +21,19 @@ k3s_cluster:
     slack_token: $(echo $SLACK_TOKEN | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     slack_channel_id: $(echo $SLACK_CHANNEL | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     kubeconfig_group: '<name of the linux group that should be able to run kubectl>'
-    github_client_id: $(echo $CLIENT_ID | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
-    github_client_secret: $(echo $CLIENT_SECRET | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
-    github_organization: 'org'
-    jupyter_metrics_api_token: $(openssl rand -hex 32  | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     postgres_user: 'scout'
     postgres_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     postgres_superuser_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     superset_secret: $(openssl rand -base64 42 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+
+    # JupyterHub variables
+    jupyter_auth_class: dummy # dummy or github
+    github_client_id: $(echo $CLIENT_ID | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    github_client_secret: $(echo $CLIENT_SECRET | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    github_organization: 'org'
+    jupyter_metrics_api_token: $(openssl rand -hex 32  | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    jupyter_dummy_password: $(echo $JH_DUMMY_PASSWORD | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    jupyter_allowed_users: [] # empty list means all users can log in
 
     # Namespaces that can be changed
     hive_namespace: hive

--- a/ansible/playbooks/jupyter.yaml
+++ b/ansible/playbooks/jupyter.yaml
@@ -53,10 +53,19 @@
         spark_defaults_configmap_namespace: jupyter
         spark_memory: '{{ jupyter_spark_memory }}'
 
-    - name: Load values file
+    - name: Load base JupyterHub values
       ansible.builtin.include_vars:
         file: vars/jupyter.values.yaml
-        name: jupyter_values
+        name: jupyter_base_values
+
+    - name: Load authentication-specific JupyterHub values
+      ansible.builtin.include_vars:
+        file: vars/jupyter.auth.{{ jupyter_auth_class }}.values.yaml
+        name: jupyter_auth_values
+
+    - name: Merge base and authentication-specific JupyterHub values
+      set_fact:
+        jupyter_values: '{{ jupyter_base_values | combine(jupyter_auth_values, recursive=True) }}'
 
     - name: Install JupyterHub using Helm
       kubernetes.core.helm:

--- a/ansible/playbooks/vars/jupyter.auth.dummy.values.yaml
+++ b/ansible/playbooks/vars/jupyter.auth.dummy.values.yaml
@@ -1,0 +1,4 @@
+hub:
+  config:
+    DummyAuthenticator:
+      password: '{{ jupyter_dummy_password }}'

--- a/ansible/playbooks/vars/jupyter.auth.github.values.yaml
+++ b/ansible/playbooks/vars/jupyter.auth.github.values.yaml
@@ -1,0 +1,12 @@
+hub:
+  config:
+    Authenticator:
+      auto_login: true
+    GitHubOAuthenticator:
+      client_id: '{{ github_client_id }}'
+      client_secret: '{{ github_client_secret }}'
+      oauth_callback_url: 'https://{{ server_hostname }}/jupyter/hub/oauth_callback'
+      allowed_organizations:
+        - '{{ github_organization }}'
+      scope:
+        - read:org

--- a/ansible/playbooks/vars/jupyter.values.yaml
+++ b/ansible/playbooks/vars/jupyter.values.yaml
@@ -27,17 +27,9 @@ hub:
       storageClassName: jupyter-hub-storage
   config:
     Authenticator:
-      auto_login: true
-    GitHubOAuthenticator:
-      client_id: '{{ github_client_id }}'
-      client_secret: '{{ github_client_secret }}'
-      oauth_callback_url: 'https://{{ server_hostname }}/jupyter/hub/oauth_callback'
-      allowed_organizations:
-        - '{{ github_organization }}'
-      scope:
-        - read:org
+      allowed_users: '{{ (jupyter_allowed_users | default([])) }}'
     JupyterHub:
-      authenticator_class: github
+      authenticator_class: '{{ jupyter_auth_class | default("dummy") }}'
 
 ingress:
   enabled: true
@@ -84,7 +76,7 @@ singleuser:
     type: static
     static:
       pvcName: jupyter-singleuser-pvc
-      subPath: '{% raw %} {username} {% endraw %}'
+      subPath: '{username}'
     capacity: 10Gi
     extraVolumes:
       - name: spark-defaults


### PR DESCRIPTION
# JupyterHub Dummy Auth

## Type of change
- [ ] Work behind a feature flag
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product / Technical
- JupyterHub can now be deployed with dummy authentication in addition to GitHub authentication
- Adds ability to restrict access to JupyterHub by username

## Impact

### Security 

##### Authorization / Appsec
Less secure than GitHub but is needed as a stopgap until we can configure DNS and WashU Key.

### Performance
N/A

### Data
N/A

### Backward compatibility
The username JupyterHub uses for storing user notebooks is not associated with the authentication source. As long as we use our WashU keys for dummy auth we will be able to easily migrate.

## Testing
Tested dummy and GH auth. Also tested migrating from dummy to GH auth using my GH username.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
