### PR TITLE
Update JupyterHub Notebook Image Pull Policies

### DIFF
--- a/ansible/playbooks/vars/jupyter.values.yaml
+++ b/ansible/playbooks/vars/jupyter.values.yaml
@@ -45,10 +45,15 @@ ingress:
           port:
             name: http
 
+prePuller:
+  hook:
+    enabled: true
+
 singleuser:
   image:
     name: ghcr.io/washu-tag/pyspark-notebook
     tag: latest
+    pullPolicy: Never
   cmd: null
   lifecycleHooks:
     postStart:


### PR DESCRIPTION
# Update JupyterHub Notebook Image Pull Policies

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
- Fixes login failure issue in air-gapped environments where external network access is restricted

### Technical
- JupyterHub was attempting to verify latest notebook image availability during user login, failing when internet access was unavailable
- Updated the notebook image pull policy to "Never" to prevent runtime image verification attempts at user login
- Explicitly configured image pulling to occur only during helm upgrade/install. This documents the expected behavior in our configuration files rather than relying on JupyterHub defaults

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
- Tested on tagdev-big-02 by simulating air-gapped environment using iptables rules to block external network traffic
- Verified successful login and notebook startup under restricted network conditions
- Confirmed image pull behavior during helm upgrade process remains functional

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
