### PR TITLE
Handle python/spark activity failure

### DIFF
--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/activity/FindHl7Files.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/activity/FindHl7Files.java
@@ -2,6 +2,8 @@ package edu.washu.tag.extractor.hl7log.activity;
 
 import edu.washu.tag.extractor.hl7log.model.FindHl7FilesInput;
 import edu.washu.tag.extractor.hl7log.model.FindHl7FilesOutput;
+import edu.washu.tag.extractor.hl7log.model.WriteHl7FilesErrorStatusToDbInput;
+import edu.washu.tag.extractor.hl7log.model.WriteHl7FilesErrorStatusToDbOutput;
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
 
@@ -9,4 +11,7 @@ import io.temporal.activity.ActivityMethod;
 public interface FindHl7Files {
     @ActivityMethod
     FindHl7FilesOutput findHl7FilesAndWriteManifest(FindHl7FilesInput input);
+
+    @ActivityMethod
+    WriteHl7FilesErrorStatusToDbOutput writeHl7FilesErrorStatusToDb(WriteHl7FilesErrorStatusToDbInput input);
 }

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/activity/SplitHl7LogActivityImpl.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/activity/SplitHl7LogActivityImpl.java
@@ -27,7 +27,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -85,7 +84,7 @@ public class SplitHl7LogActivityImpl implements SplitHl7LogActivity {
         List<String> hl7Paths = segmentResults.stream()
             .filter(Hl7File::isSuccess)
             .map(Hl7File::filePath)
-            .collect(Collectors.toList());
+            .toList();
         if (segmentResults.isEmpty() || hl7Paths.isEmpty()) {
             // All the transforms/uploads failed, fail the activity
             logger.error("WorkflowId {} ActivityId {} - All transform and upload jobs failed for log {}", activityInfo.getWorkflowId(),

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/db/Hl7File.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/db/Hl7File.java
@@ -18,6 +18,10 @@ public record Hl7File(
         return new Hl7File(logFilePath, segmentNumber, null, DbUtils.FAILED, error, workflowId, activityId);
     }
 
+    public static Hl7File error(String logFilePath, int segmentNumber, String hl7FilePath, String error, String workflowId, String activityId) {
+        return new Hl7File(logFilePath, segmentNumber, hl7FilePath, DbUtils.FAILED, error, workflowId, activityId);
+    }
+
     public boolean isSuccess() {
         return DbUtils.SUCCEEDED.equals(status);
     }

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/db/Hl7FileLogFileSegmentNumber.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/db/Hl7FileLogFileSegmentNumber.java
@@ -1,0 +1,7 @@
+package edu.washu.tag.extractor.hl7log.db;
+
+public record Hl7FileLogFileSegmentNumber(
+    String hl7FilePath,
+    String logFilePath,
+    int segmentNumber
+) {}

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/db/IngestDbService.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/db/IngestDbService.java
@@ -5,4 +5,5 @@ import java.util.List;
 public interface IngestDbService {
     void insertLogFile(LogFile logFile);
     void batchInsertHl7Files(List<Hl7File> hl7Files);
+    List<Hl7FileLogFileSegmentNumber> queryHl7FileLogFileSegmentNumbers(List<String> hl7FilePath);
 }

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/WriteHl7FilesErrorStatusToDbInput.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/WriteHl7FilesErrorStatusToDbInput.java
@@ -1,0 +1,3 @@
+package edu.washu.tag.extractor.hl7log.model;
+
+public record WriteHl7FilesErrorStatusToDbInput(String manifestFilePath, String errorMessage) {}

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/WriteHl7FilesErrorStatusToDbOutput.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/WriteHl7FilesErrorStatusToDbOutput.java
@@ -1,0 +1,3 @@
+package edu.washu.tag.extractor.hl7log.model;
+
+public record WriteHl7FilesErrorStatusToDbOutput() {}


### PR DESCRIPTION

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
If python activity fails even after all its retries, we assume that none of the HL7 files that it was supposed to ingest into delta lake made it successfully and write an error status into the database for all of them.

### Technical
- Switch the python activity invocation from sync to async
- If it failed, catch the exception and execute a new activity
- In this activity we read the manifest file to get all the HL7 files that were supposed to be ingested. We do a query to find their log files and segment numbers, and write error statuses for all of them.

## Impact

### Performance
This shouldn't be a problem. The size of the manifest file is constrained by the same setting that constrains the size of the spark jobs, so I don't think we need to worry about any of our db operations getting too big.

### Data
I don't like having to do a two-step "first query, then write" operation. But the way I designed these table schemas means that to write a status for an HL7 file I also need to know its log file and segment number. 

#### Alternatives
I tried switching the manifest file from a list of HL7 paths to a CSV of log file path, segment number, and HL7 path. The python activity ignored the log path and segment number. When I needed this info to write to the database, it was already there. The problem was that while we have all this info when writing the manifest file in the parent workflow, if someone were to run the delta lake ingest workflow on a bunch of HL7 files we no longer have all this info about their source log files. So one way or the other we'd need to query the table for it.

We could also change up the hl7 files table to not need the log file info every time we write a status. But I'm not sure how we would do that, since I do want to have this association somewhere.

### Backward compatibility
N/A

## Testing
Deployed to big-03 and triggered a python activity failure by manually killing the spark process. Sample from the logs:
```
2025-04-30T13:31:46.688-05:00  WARN 1 --- [log-extractor] [4f-8165dd4673e0] t.e.h.w.IngestHl7ToDeltaLakeWorkflowImpl : WorkflowId b88dc1e5-432f-3377-beab-63bb0ae6aae0 - Ingest HL7 files activity failed. Marking all HL7 files as "failed" status.
2025-04-30T13:31:46.699-05:00  INFO 1 --- [log-extractor] [ce="default": 4] e.w.t.e.h.activity.FindHl7FilesImpl      : WorkflowId b88dc1e5-432f-3377-beab-63bb0ae6aae0 ActivityId ad49e9d3-8376-3ddd-87a6-98c8cd26dac1 - Reading HL7 file manifest s3://lake/scratch/04fd8363-f58e-4b5c-96f7-99b08ab82baa/e45efc6e-5100-4e8d-ae41-1591b5b29348_hl7-manifest.txt
2025-04-30T13:31:46.702-05:00  INFO 1 --- [log-extractor] [ce="default": 4] e.w.t.e.h.activity.FindHl7FilesImpl      : WorkflowId b88dc1e5-432f-3377-beab-63bb0ae6aae0 ActivityId ad49e9d3-8376-3ddd-87a6-98c8cd26dac1 - Found 20 HL7 file paths in manifest file
2025-04-30T13:31:46.704-05:00  INFO 1 --- [log-extractor] [ce="default": 4] e.w.t.e.h.activity.FindHl7FilesImpl      : WorkflowId b88dc1e5-432f-3377-beab-63bb0ae6aae0 ActivityId ad49e9d3-8376-3ddd-87a6-98c8cd26dac1 - Writing 20 HL7 file error statuses to database
```
And I verified that the error statuses made it to the db
```
ingest=> select status, count(status) from recent_hl7_files where workflow_id = 'b88dc1e5-432f-3377-beab-63bb0ae6aae0' group by status;
 status | count
--------+-------
 failed |    20
```

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
