### PR TITLE
Set up separate users and permissions for postgres databases and minio buckets

### DIFF
--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -76,7 +76,7 @@ k3s_cluster:
 
     # computed values, used across playbooks
     s3_endpoint: 'http://minio.{{ minio_tenant_namespace }}'
-    hive_warehouse: s3a://lake/hive # Hadoop requires the s3a prefix, it is used just like s3://
+    hive_warehouse: s3a://lake/delta # Hadoop requires the s3a prefix, it is used just like s3://
     hive_metastore_endpoint: 'thrift://hive-metastore.{{ hive_namespace }}:9083'
     server_hostname: '{{ hostvars[groups["server"][0]].external_url | default(groups["server"][0]) }}'
     # End do not change

--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -8,19 +8,34 @@ k3s_cluster:
           ansible_python_interpreter: /usr/bin/python3
           k3s_control_node: true
   vars:
-    s3_username: minio
-    s3_password: minio123
-    s3_region: us-east-1
-    k3s_token: K3S_TOKEN
-    slack_token:
-    slack_channel_id:
-    kubeconfig_group: root
     hl7log_extractor_image: docker.io/local/washu-tag/hl7log-extractor
     hl7_transformer_image: docker.io/local/washu-tag/hl7-transformer
     explorer_image: docker.io/local/washu-tag/explorer
+
+    # K3s config
+    k3s_version: v1.32.3+k3s1 # Leave blank for latest stable
+    k3s_token: K3S_TOKEN
+    kubeconfig_group: root
+
+    # Minio config, ensure passwords meet complexity requirements (must be >=8 characters)
+    s3_username: minio
+    s3_password: minio123
+    s3_region: us-east-1
+    s3_lake_reader: lake-reader
+    s3_lake_reader_secret: lakereader123
+    s3_lake_writer: lake-writer
+    s3_lake_writer_secret: lakewriter123
+    s3_loki_writer: loki-writer
+    s3_loki_writer_secret: lokiwriter123
+
+    # Postgres config
     postgres_user: scout
     postgres_password: scout123
     postgres_superuser_password: scout123
+    hive_postgres_user: hive
+    hive_postgres_password: hive123
+    superset_postgres_user: superset
+    superset_postgres_password: superset123
 
     # Namespaces that can be changed
     hive_namespace: hive

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,10 +149,6 @@ jobs:
         shell: bash
         run: |
           cd ansible && sudo -E /opt/pipx_bin/ansible-playbook -i inventory.yaml --diff playbooks/extractor.yaml
-      - name: 'Wait for minio'
-        shell: bash
-        run: |
-          sudo -E kubectl -n minio-scout wait --for=condition=ready --timeout=300s pod -l v1.min.io/tenant=minio-scout
       - name: 'Launch extraction'
         shell: bash
         run: sudo -E bash .github/ci_resources/launch_extraction.sh

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -40,6 +40,10 @@ k3s_cluster:
     # Postgres config
     postgres_user: scout
     postgres_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    hive_postgres_user: hive
+    hive_postgres_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    superset_postgres_user: superset
+    superset_postgres_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     postgres_superuser_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
 
     # Superset config

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -14,13 +14,21 @@ k3s_cluster:
           ansible_connection: local
           ansible_python_interpreter: /usr/bin/python3
   vars:
+    # K3s config
+    k3s_version: v1.32.3+k3s1 # Leave blank for latest stable
+    k3s_token: $(openssl rand -hex 16 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    kubeconfig_group: '<name of the linux group that should be able to run kubectl>'
+
+    # Minio config
     s3_username: minio
     s3_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     s3_region: us-east-1
-    k3s_token: $(openssl rand -hex 16 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+
+    # Grafana config
     slack_token: $(echo $SLACK_TOKEN | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     slack_channel_id: $(echo $SLACK_CHANNEL | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
-    kubeconfig_group: '<name of the linux group that should be able to run kubectl>'
+
+    # Jupyter config
     jupyter_auth_class: dummy # dummy or github
     github_client_id: $(echo $CLIENT_ID | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     github_client_secret: $(echo $CLIENT_SECRET | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
@@ -28,9 +36,13 @@ k3s_cluster:
     jupyter_dummy_password: $(echo $JH_DUMMY_PASSWORD | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     jupyter_allowed_users: [] # empty list means all users can log in
     jupyter_metrics_api_token: $(openssl rand -hex 32  | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+
+    # Postgres config
     postgres_user: scout
     postgres_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     postgres_superuser_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+
+    # Superset config
     superset_secret: $(openssl rand -base64 42 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
 
     # Namespaces that can be changed
@@ -58,10 +70,11 @@ k3s_cluster:
     temporal_cassandra_init_heap: 2G
     temporal_cassandra_max_heap: 8G
 
+    # BEGIN - DO NOT CHANGE
     # You probably don't want to change these unless you know these items will be
     # stored in different locations on your system
-    helm_plugins_dir: '/root/.local/share/helm/plugins'
-    kubeconfig_yaml: '/etc/rancher/k3s/k3s.yaml'
+    helm_plugins_dir: /root/.local/share/helm/plugins
+    kubeconfig_yaml: /etc/rancher/k3s/k3s.yaml
 
     # Do not change the values below, they are hard-coded various places
     extractor_namespace: extractor
@@ -75,4 +88,4 @@ k3s_cluster:
     hive_warehouse: 's3a://lake/hive' # Hadoop requires the s3a prefix, it is used just like s3://
     hive_metastore_endpoint: 'thrift://hive-metastore.{{ hive_namespace }}:9083'
     server_hostname: '{{ hostvars[groups["server"][0]].external_url | default(groups["server"][0]) }}'
-    # End do not change
+    # END - DO NOT CHANGE

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -95,7 +95,7 @@ k3s_cluster:
 
     # computed values, used across playbooks
     s3_endpoint: 'http://minio.{{ minio_tenant_namespace }}'
-    hive_warehouse: 's3a://lake/hive' # Hadoop requires the s3a prefix, it is used just like s3://
+    hive_warehouse: 's3a://lake/delta' # Hadoop requires the s3a prefix, it is used just like s3://
     hive_metastore_endpoint: 'thrift://hive-metastore.{{ hive_namespace }}:9083'
     server_hostname: '{{ hostvars[groups["server"][0]].external_url | default(groups["server"][0]) }}'
     # END - DO NOT CHANGE

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -19,7 +19,7 @@ k3s_cluster:
     k3s_token: $(openssl rand -hex 16 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     kubeconfig_group: '<name of the linux group that should be able to run kubectl>'
 
-    # Minio config
+    # Minio config, ensure passwords meet complexity requirements
     s3_username: minio
     s3_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     s3_region: us-east-1

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -23,6 +23,12 @@ k3s_cluster:
     s3_username: minio
     s3_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     s3_region: us-east-1
+    s3_lake_reader: lake-reader
+    s3_lake_reader_secret: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    s3_lake_writer: lake-writer
+    s3_lake_writer_secret: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    s3_loki_writer: loki-writer
+    s3_loki_writer_secret: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
 
     # Grafana config
     slack_token: $(echo $SLACK_TOKEN | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -94,7 +94,7 @@ k3s_cluster:
     temporal_namespace: temporal
 
     # computed values, used across playbooks
-    s3_endpoint: 'http://minio.{{ minio_tenant_namespace }}'
+    s3_endpoint: 'https://minio.{{ minio_tenant_namespace }}'
     hive_warehouse: 's3a://lake/hive' # Hadoop requires the s3a prefix, it is used just like s3://
     hive_metastore_endpoint: 'thrift://hive-metastore.{{ hive_namespace }}:9083'
     server_hostname: '{{ hostvars[groups["server"][0]].external_url | default(groups["server"][0]) }}'

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -19,7 +19,7 @@ k3s_cluster:
     k3s_token: $(openssl rand -hex 16 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     kubeconfig_group: '<name of the linux group that should be able to run kubectl>'
 
-    # Minio config, ensure passwords meet complexity requirements
+    # Minio config, ensure passwords meet complexity requirements (must be >=8 characters)
     s3_username: minio
     s3_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     s3_region: us-east-1
@@ -94,7 +94,7 @@ k3s_cluster:
     temporal_namespace: temporal
 
     # computed values, used across playbooks
-    s3_endpoint: 'https://minio.{{ minio_tenant_namespace }}'
+    s3_endpoint: 'http://minio.{{ minio_tenant_namespace }}'
     hive_warehouse: 's3a://lake/hive' # Hadoop requires the s3a prefix, it is used just like s3://
     hive_metastore_endpoint: 'thrift://hive-metastore.{{ hive_namespace }}:9083'
     server_hostname: '{{ hostvars[groups["server"][0]].external_url | default(groups["server"][0]) }}'

--- a/ansible/playbooks/extractor.yaml
+++ b/ansible/playbooks/extractor.yaml
@@ -41,8 +41,8 @@
             namespace: '{{ extractor_namespace }}'
           type: Opaque
           stringData:
-            AWS_ACCESS_KEY_ID: '{{ s3_username }}'
-            AWS_SECRET_ACCESS_KEY: '{{ s3_password }}'
+            AWS_ACCESS_KEY_ID: '{{ s3_lake_writer }}'
+            AWS_SECRET_ACCESS_KEY: '{{ s3_lake_writer_secret }}'
 
     - name: Create S3 configmap
       kubernetes.core.k8s:
@@ -80,6 +80,8 @@
         spark_defaults_configmap_name: spark-defaults
         spark_defaults_configmap_namespace: '{{ extractor_namespace }}'
         spark_memory: '{{ hl7_transformer_spark_memory }}'
+        spark_s3_username: '{{ s3_lake_writer }}'
+        spark_s3_password: '{{ s3_lake_writer_secret }}'
 
     - name: Load HL7 Transformer values file
       ansible.builtin.include_vars:

--- a/ansible/playbooks/orchestrator.yaml
+++ b/ansible/playbooks/orchestrator.yaml
@@ -84,7 +84,7 @@
                 max_heap_size: '{{ temporal_cassandra_max_heap | default("8G") }}'
 
     - name: Wait for Cassandra to be ready
-      command: 'kubectl -n {{ temporal_namespace }} wait --for=condition=Ready --timeout=300s cassandradatacenter/dc1'
+      command: 'kubectl -n {{ temporal_namespace }} wait --for=condition=Ready --timeout=600s cassandradatacenter/dc1'
       register: cassandra_ready
       changed_when: false
 

--- a/ansible/playbooks/postgres.yaml
+++ b/ansible/playbooks/postgres.yaml
@@ -91,10 +91,18 @@
                 secret:
                   name: postgres-user
                 postInitSQL: # This runs after initialization to create additional databases
-                  - CREATE DATABASE hive OWNER {{ postgres_user }};
-                  - CREATE DATABASE superset OWNER {{ postgres_user }};
-                  - GRANT ALL PRIVILEGES ON DATABASE hive TO {{ postgres_user }};
-                  - GRANT ALL PRIVILEGES ON DATABASE superset TO {{ postgres_user }};
+                  # Create users for hive and superset databases
+                  - CREATE USER {{ hive_postgres_user }} WITH PASSWORD '{{ hive_postgres_password }}';
+                  - CREATE USER {{ superset_postgres_user }} WITH PASSWORD '{{ superset_postgres_password }}';
+
+                  # Create databases
+                  - CREATE DATABASE hive OWNER {{ hive_postgres_user }};
+                  - CREATE DATABASE superset OWNER {{ superset_postgres_user }};
+
+                  # Implement least privilege security model
+                  - REVOKE CONNECT ON DATABASE ingest FROM PUBLIC;
+                  - REVOKE CONNECT ON DATABASE hive FROM PUBLIC;
+                  - REVOKE CONNECT ON DATABASE superset FROM PUBLIC;
 
     - name: Wait for Postgres to be ready
       command: 'kubectl -n {{ postgres_cluster_namespace }} wait --for=condition=Ready --timeout=300s cluster/postgresql-cluster'

--- a/ansible/playbooks/postgres.yaml
+++ b/ansible/playbooks/postgres.yaml
@@ -90,19 +90,13 @@
                 owner: '{{ postgres_user }}'
                 secret:
                   name: postgres-user
-                postInitSQL: # This runs after initialization to create additional databases
+                postInitSQL:
                   # Create users for hive and superset databases
                   - CREATE USER {{ hive_postgres_user }} WITH PASSWORD '{{ hive_postgres_password }}';
                   - CREATE USER {{ superset_postgres_user }} WITH PASSWORD '{{ superset_postgres_password }}';
-
                   # Create databases
                   - CREATE DATABASE hive OWNER {{ hive_postgres_user }};
                   - CREATE DATABASE superset OWNER {{ superset_postgres_user }};
-
-                  # Implement least privilege security model
-                  - REVOKE CONNECT ON DATABASE ingest FROM PUBLIC;
-                  - REVOKE CONNECT ON DATABASE hive FROM PUBLIC;
-                  - REVOKE CONNECT ON DATABASE superset FROM PUBLIC;
 
     - name: Wait for Postgres to be ready
       command: 'kubectl -n {{ postgres_cluster_namespace }} wait --for=condition=Ready --timeout=300s cluster/postgresql-cluster'

--- a/ansible/playbooks/services/grafana.yaml
+++ b/ansible/playbooks/services/grafana.yaml
@@ -32,8 +32,8 @@
         namespace: '{{ loki_namespace }}'
       type: Opaque
       stringData:
-        AWS_ACCESS_KEY_ID: '{{ s3_username }}'
-        AWS_SECRET_ACCESS_KEY: '{{ s3_password }}'
+        AWS_ACCESS_KEY_ID: '{{ s3_loki_writer }}'
+        AWS_SECRET_ACCESS_KEY: '{{ s3_loki_writer_secret }}'
 
 - name: Install Loki using Helm
   kubernetes.core.helm:

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -207,9 +207,30 @@
               kube-system-minio-add-trailing-slash@kubernetescrd,
               kube-system-minio-strip-prefix@kubernetescrd
 
-- name: Wait for MinIO to be ready
-  command: 'kubectl -n {{ minio_tenant_namespace }} wait --for=condition=Ready --timeout=300s statefulset/minio-scout-pool-0'
-  register: minio_ready
+- name: Wait for MinIO StatefulSet to exist
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: StatefulSet
+    name: 'minio-scout-pool-0'
+    namespace: '{{ minio_tenant_namespace }}'
+  register: minio_statefulset
+  until: minio_statefulset.resources | length > 0
+  retries: 60
+  delay: 5
+  changed_when: false
+
+- name: Wait for MinIO StatefulSet to be ready
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: StatefulSet
+    name: 'minio-scout-pool-0'
+    namespace: '{{ minio_tenant_namespace }}'
+  register: minio_statefulset
+  until:
+    - minio_statefulset.resources[0].status.readyReplicas is defined
+    - minio_statefulset.resources[0].status.readyReplicas == minio_statefulset.resources[0].status.replicas
+  retries: 60
+  delay: 5
   changed_when: false
 
 - name: Bootstrap MinIO IAM (policies + bindings)

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -23,23 +23,6 @@
     kind: Namespace
     state: present
 
-- name: Set up env secret
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: minio-scout-env-configuration
-        namespace: '{{ minio_tenant_namespace }}'
-      type: Opaque
-      stringData:
-        config.env: |
-          export MINIO_ROOT_USER={{ s3_username }}
-          export MINIO_ROOT_PASSWORD={{ s3_password }}
-          export MINIO_REGION_NAME={{ s3_region }}
-          export MINIO_REGION={{ s3_region }}
-
 - name: Create Traefik Middleware to add trailing slash that Minio needs
   kubernetes.core.k8s:
     state: present
@@ -76,6 +59,124 @@
       - name: minio
         size: '750Gi'
         path: '{{ minio_dir }}'
+
+- name: Set up env secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: minio-scout-env-configuration
+        namespace: '{{ minio_tenant_namespace }}'
+      type: Opaque
+      stringData:
+        config.env: |
+          export MINIO_ROOT_USER={{ s3_username }}
+          export MINIO_ROOT_PASSWORD={{ s3_password }}
+          export MINIO_REGION_NAME={{ s3_region }}
+          export MINIO_REGION={{ s3_region }}
+
+- name: Create MinIO IAM policies
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: minio.min.io/v2
+      kind: Policy
+      metadata:
+        name: "policy-{{ item.name }}"
+        namespace: '{{ minio_tenant_namespace }}'
+      spec:
+        name: "{{ item.name }}"
+        definition: |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": {{ item.actions | to_json }},
+                "Resource": {{ item.resources | to_json }}
+              }
+            ]
+          }
+  loop:
+    - name: lake-r
+      actions:
+        - s3:GetObject
+        - s3:ListBucket
+      resources:
+        - arn:aws:s3:::lake/*
+        - arn:aws:s3:::lake
+    - name: lake-rw
+      actions:
+        - s3:GetObject
+        - s3:ListBucket
+        - s3:PutObject
+        - s3:DeleteObject
+      resources:
+        - arn:aws:s3:::lake/*
+        - arn:aws:s3:::lake
+        - arn:aws:s3:::scratch/*
+        - arn:aws:s3:::scratch
+    - name: loki-rw
+      actions:
+        - s3:GetObject
+        - s3:ListBucket
+        - s3:PutObject
+        - s3:DeleteObject
+      resources:
+        - arn:aws:s3:::loki-chunks/*
+        - arn:aws:s3:::loki-chunks
+        - arn:aws:s3:::loki-ruler/*
+        - arn:aws:s3:::loki-ruler
+        - arn:aws:s3:::loki-admin/*
+        - arn:aws:s3:::loki-admin
+
+- name: Bind policies to users
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: minio.min.io/v2
+      kind: PolicyBinding
+      metadata:
+        name: "binding-{{ item.name }}"
+        namespace: '{{ minio_tenant_namespace }}'
+      spec:
+        policyName: "{{ item.policy_name }}"
+        userRef:
+          name: "{{ item.name }}"
+        tenant: minio-scout
+  loop:
+    - name: lake-reader
+      policy_name: lake-r
+    - name: lake-writer
+      policy_name: lake-rw
+    - name: loki-writer
+      policy_name: loki-rw
+
+- name: Create service account secrets for MinIO users
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ item.name }}-creds"
+        namespace: '{{ minio_tenant_namespace }}'
+      type: Opaque
+      stringData:
+        CONSOLE_ACCESS_KEY: "{{ item.access_key }}"
+        CONSOLE_SECRET_KEY: "{{ item.secret_key }}"
+  loop:
+    - name: lake-reader
+      access_key: "lake-reader"
+      secret_key: "{{ lake_reader_secret }}"
+    - name: lake-writer
+      access_key: "lake-writer"
+      secret_key: "{{ lake_writer_secret }}"
+    - name: loki-writer
+      access_key: "loki-writer"
+      secret_key: "{{ loki_writer_secret }}"
 
 - name: Install/Upgrade Minio Tenant
   kubernetes.core.helm:
@@ -116,6 +217,11 @@
           - name: loki-ruler
           - name: loki-admin
           - name: lake
+          - name: scratch
+        users:
+          - lake-reader-creds
+          - lake-writer-creds
+          - loki-writer-creds
       ingress:
         console:
           enabled: true

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -222,7 +222,8 @@
                     . /rootcreds/config.env
 
                     # Set up MinIO client
-                    mc alias set local http://{{ minio_tenant_name }}-hl.{{ minio_tenant_namespace }}:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" --insecure
+                    mc alias set local http://{{ minio_tenant_name }}-hl.{{ minio_tenant_namespace }}:9000 \
+                      "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" --insecure
 
                     # Apply policies and attach to users
                     {% for p in minio_policies %}

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -1,3 +1,6 @@
+- name: Include MinIO variables
+  include_vars: vars/minio.yml
+
 - name: Add Minio Helm repository
   kubernetes.core.helm_repository:
     name: minio-operator
@@ -7,67 +10,67 @@
   kubernetes.core.helm:
     name: minio-operator
     chart_ref: minio-operator/operator
-    chart_version: ~7.1.0
+    chart_version: "{{ minio_version | default('~7.1.0') }}"
     release_namespace: minio-operator
     create_namespace: true
     release_state: present
     update_repo_cache: true
     wait: true
-    wait_timeout: 1m
+    wait_timeout: "{{ minio_operator_wait_timeout | default('1m') }}"
     atomic: true
 
-- name: Create namespace
+- name: Create Traefik Middleware to add trailing slash
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: traefik.io/v1alpha1
+      kind: Middleware
+      metadata:
+        name: "{{ minio_trailing_slash_middleware | default('minio-add-trailing-slash') }}"
+        namespace: kube-system
+      spec:
+        redirectRegex:
+          regex: "(.*/{{ minio_path_prefix | default('minio') }}$)"
+          replacement: ${1}/
+          permanent: true
+
+- name: Create Traefik Middleware to strip prefix
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: traefik.io/v1alpha1
+      kind: Middleware
+      metadata:
+        name: "{{ minio_strip_prefix_middleware | default('minio-strip-prefix') }}"
+        namespace: kube-system
+      spec:
+        stripPrefix:
+          prefixes:
+            - "/{{ minio_path_prefix | default('minio') }}"
+
+- name: Create tenant namespace
   kubernetes.core.k8s:
     name: '{{ minio_tenant_namespace }}'
     api_version: v1
     kind: Namespace
     state: present
 
-- name: Create Traefik Middleware to add trailing slash that Minio needs
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: traefik.io/v1alpha1
-      kind: Middleware
-      metadata:
-        name: minio-add-trailing-slash
-        namespace: kube-system
-      spec:
-        redirectRegex:
-          regex: (.*/minio$)
-          replacement: ${1}/
-          permanent: true
-
-- name: Create Traefik Middleware to strip /minio prefix for internal traffic
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: traefik.io/v1alpha1
-      kind: Middleware
-      metadata:
-        name: minio-strip-prefix
-        namespace: kube-system
-      spec:
-        stripPrefix:
-          prefixes:
-            - /minio
-
-- name: Setup storage
-  include_tasks: tasks/storage_setup.yaml
+- name: Configure Storage for MinIO
+  include_tasks: tasks/storage_setup.yml
   vars:
     storage_definitions:
       - name: minio
-        size: '750Gi'
+        size: '{{ minio_storage_size }}'
         path: '{{ minio_dir }}'
 
-- name: Set up env secret
+- name: Set up environment secret
   kubernetes.core.k8s:
     state: present
     definition:
       apiVersion: v1
       kind: Secret
       metadata:
-        name: minio-scout-env-configuration
+        name: "{{ minio_env_secret_name | default('minio-env-configuration') }}"
         namespace: '{{ minio_tenant_namespace }}'
       type: Opaque
       stringData:
@@ -77,35 +80,80 @@
           export MINIO_REGION_NAME={{ s3_region }}
           export MINIO_REGION={{ s3_region }}
 
-- name: Define MinIO IAM policies
-  set_fact:
-    minio_policies:
-      - name: lake-r
-        actions:
-          - s3:GetObject
-          - s3:ListBucket
-          - s3:GetBucketLocation
-          - s3:ListBucketMultipartUploads
-        resources:
-          - arn:aws:s3:::lake
-          - arn:aws:s3:::lake/*
-        user: '{{ s3_lake_reader }}'
-      - name: lake-rw
-        actions:
-          - s3:*
-        resources:
-          - arn:aws:s3:::lake
-          - arn:aws:s3:::lake/*
-          - arn:aws:s3:::scratch
-          - arn:aws:s3:::scratch/*
-        user: '{{ s3_lake_writer }}'
-      - name: loki-rw
-        actions:
-          - s3:*
-        resources:
-          - arn:aws:s3:::loki-*
-          - arn:aws:s3:::loki-*/*
-        user: '{{ s3_loki_writer }}'
+- name: Install/Upgrade Minio Tenant
+  kubernetes.core.helm:
+    name: '{{ minio_tenant_namespace }}'
+    chart_ref: minio-operator/tenant
+    chart_version: "{{ minio_version | default('~7.1.0') }}"
+    release_namespace: '{{ minio_tenant_namespace }}'
+    release_state: present
+    update_repo_cache: true
+    wait: true
+    wait_timeout: "{{ minio_tenant_wait_timeout | default('5m') }}"
+    atomic: true
+    values:
+      tenant:
+        name: '{{ minio_tenant_name }}'
+        configSecret:
+          name: "{{ minio_env_secret_name | default('minio-env-configuration') }}"
+          existingSecret: true
+        env: '{{ minio_env_variables }}'
+        pools:
+          - servers: '{{ minio_server_count | default(1) }}'
+            name: pool-0
+            volumesPerServer: 1
+            size: '{{ minio_storage_size }}'
+            storageClassName: "{{ minio_storage_class | default('minio-storage') }}"
+        metrics:
+          enabled: true
+          port: 9000
+          protocol: http
+        certificate:
+          requestAutoCert: false
+        buckets: '{{ minio_buckets }}'
+        users: '{{ minio_credentials }}'
+      ingress: '{{ minio_ingress_config }}'
+
+- name: Wait for MinIO StatefulSet to exist
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: StatefulSet
+    name: '{{ minio_tenant_name }}-pool-0'
+    namespace: '{{ minio_tenant_namespace }}'
+  register: minio_statefulset
+  until: minio_statefulset.resources | length > 0
+  retries: '{{ minio_wait_retries | default(60) }}'
+  delay: '{{ minio_wait_delay | default(5) }}'
+  changed_when: false
+
+- name: Wait for MinIO StatefulSet to be ready
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: StatefulSet
+    name: '{{ minio_tenant_name }}-pool-0'
+    namespace: '{{ minio_tenant_namespace }}'
+  register: minio_statefulset
+  until:
+    - minio_statefulset.resources[0].status.readyReplicas is defined
+    - minio_statefulset.resources[0].status.readyReplicas == minio_statefulset.resources[0].status.replicas
+  retries: '{{ minio_wait_retries | default(60) }}'
+  delay: '{{ minio_wait_delay | default(5) }}'
+  changed_when: false
+
+- name: Create MinIO user credential secrets
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: '{{ item.access_key }}-creds'
+        namespace: '{{ minio_tenant_namespace }}'
+      type: Opaque
+      stringData:
+        CONSOLE_ACCESS_KEY: '{{ item.access_key }}'
+        CONSOLE_SECRET_KEY: '{{ item.secret_key }}'
+  loop: '{{ minio_users }}'
 
 - name: Create MinIO policy JSON ConfigMaps
   kubernetes.core.k8s:
@@ -130,109 +178,6 @@
           }
   loop: '{{ minio_policies }}'
 
-- name: Create MinIO user credential secrets
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: '{{ item.access_key }}-creds'
-        namespace: '{{ minio_tenant_namespace }}'
-      type: Opaque
-      stringData:
-        CONSOLE_ACCESS_KEY: '{{ item.access_key }}'
-        CONSOLE_SECRET_KEY: '{{ item.secret_key }}'
-  loop:
-    - access_key: '{{ s3_lake_reader }}'
-      secret_key: '{{ s3_lake_reader_secret }}'
-    - access_key: '{{ s3_lake_writer }}'
-      secret_key: '{{ s3_lake_writer_secret }}'
-    - access_key: '{{ s3_loki_writer }}'
-      secret_key: '{{ s3_loki_writer_secret }}'
-
-- name: Install/Upgrade Minio Tenant
-  kubernetes.core.helm:
-    name: '{{ minio_tenant_namespace }}'
-    chart_ref: minio-operator/tenant
-    chart_version: ~7.1.0
-    release_namespace: '{{ minio_tenant_namespace }}'
-    release_state: present
-    update_repo_cache: true
-    wait: true
-    wait_timeout: 5m
-    atomic: true
-    values:
-      tenant:
-        name: minio-scout
-        configSecret:
-          name: minio-scout-env-configuration
-          existingSecret: true
-        env:
-          - name: MINIO_BROWSER_REDIRECT_URL
-            value: 'https://{{ server_hostname }}/minio/'
-          - name: MINIO_PROMETHEUS_AUTH_TYPE
-            value: public
-        pools:
-          - servers: 1
-            name: pool-0
-            volumesPerServer: 1
-            size: 750Gi
-            storageClassName: minio-storage
-        metrics:
-          enabled: true
-          port: 9000
-          protocol: http
-        certificate:
-          requestAutoCert: false
-        buckets:
-          - name: loki-chunks
-          - name: loki-ruler
-          - name: loki-admin
-          - name: lake
-          - name: scratch
-        users:
-          - name: '{{ s3_lake_reader }}-creds'
-          - name: '{{ s3_lake_writer }}-creds'
-          - name: '{{ s3_loki_writer }}-creds'
-      ingress:
-        console:
-          enabled: true
-          ingressClassName: traefik
-          host: '{{ server_hostname }}'
-          path: /minio
-          pathType: Prefix
-          annotations:
-            traefik.ingress.kubernetes.io/router.middlewares: >
-              kube-system-minio-add-trailing-slash@kubernetescrd,
-              kube-system-minio-strip-prefix@kubernetescrd
-
-- name: Wait for MinIO StatefulSet to exist
-  kubernetes.core.k8s_info:
-    api_version: apps/v1
-    kind: StatefulSet
-    name: 'minio-scout-pool-0'
-    namespace: '{{ minio_tenant_namespace }}'
-  register: minio_statefulset
-  until: minio_statefulset.resources | length > 0
-  retries: 60
-  delay: 5
-  changed_when: false
-
-- name: Wait for MinIO StatefulSet to be ready
-  kubernetes.core.k8s_info:
-    api_version: apps/v1
-    kind: StatefulSet
-    name: 'minio-scout-pool-0'
-    namespace: '{{ minio_tenant_namespace }}'
-  register: minio_statefulset
-  until:
-    - minio_statefulset.resources[0].status.readyReplicas is defined
-    - minio_statefulset.resources[0].status.readyReplicas == minio_statefulset.resources[0].status.replicas
-  retries: 60
-  delay: 5
-  changed_when: false
-
 - name: Bootstrap MinIO IAM (policies + bindings)
   kubernetes.core.k8s:
     state: present
@@ -242,25 +187,42 @@
       metadata:
         name: bootstrap-minio-iam
         namespace: '{{ minio_tenant_namespace }}'
+        labels:
+          app: minio-bootstrap
+        # Add a unique value to force job recreation when policies change
+        annotations:
+          minio-iam-config-hash: "{{ minio_policies | to_json | hash('md5') }}"
       spec:
         ttlSecondsAfterFinished: 600
+        backoffLimit: 3
         template:
+          metadata:
+            labels:
+              app: minio-bootstrap
           spec:
             restartPolicy: Never
-            serviceAccountName: minio-scout-sa
+            serviceAccountName: '{{ minio_tenant_name }}-sa'
             containers:
               - name: mc
-                image: quay.io/minio/mc:RELEASE.2025-04-16T18-13-26Z
-                command: ["/bin/sh","-c"]
+                image: "{{ minio_client_image | default('quay.io/minio/mc:RELEASE.2025-04-16T18-13-26Z') }}"
+                command: ['/bin/sh', '-c']
                 args:
                   - |
                     set -euo pipefail
+                    # Source environment variables
                     . /rootcreds/config.env
-                    mc alias set local http://minio-scout-hl.{{ minio_tenant_namespace }}:9000  "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" --insecure
+
+                    # Set up MinIO client
+                    mc alias set local http://{{ minio_tenant_name }}-hl.{{ minio_tenant_namespace }}:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" --insecure
+
+                    # Apply policies and attach to users
                     {% for p in minio_policies %}
+                    echo "Creating policy {{ p.name }}..."
                     mc admin policy create local {{ p.name }} /policies/{{ p.name }}.json
                     mc admin policy attach local {{ p.name }} --user {{ p.user }}
                     {% endfor %}
+
+                    echo "MinIO IAM setup completed successfully"
                 volumeMounts:
                   - name: policies
                     mountPath: /policies
@@ -272,21 +234,29 @@
               - name: policies
                 projected:
                   defaultMode: 0644
-                  sources:
+                  sources: |
+                    {% for p in minio_policies %}
                     - configMap:
-                        name: policy-lake-r
-                    - configMap:
-                        name: policy-lake-rw
-                    - configMap:
-                        name: policy-loki-rw
+                        name: policy-{{ p.name }}
+                    {% endfor %}
               - name: rootcreds
                 secret:
-                  secretName: minio-scout-env-configuration
+                  secretName: "{{ minio_env_secret_name | default('minio-env-configuration') }}"
                   items:
                     - key: config.env
                       path: config.env
 
-- name: Wait for job to complete
-  command: 'kubectl -n {{ minio_tenant_namespace }} wait --for=condition=complete --timeout=300s job/bootstrap-minio-iam'
-  register: minio_bootstrap_complete
+- name: Wait for bootstrap job to complete
+  kubernetes.core.k8s_info:
+    api_version: batch/v1
+    kind: Job
+    name: bootstrap-minio-iam
+    namespace: '{{ minio_tenant_namespace }}'
+  register: minio_bootstrap_job
+  until:
+    - minio_bootstrap_job.resources | length > 0
+    - minio_bootstrap_job.resources[0].status.succeeded is defined
+    - minio_bootstrap_job.resources[0].status.succeeded == 1
+  retries: '{{ minio_bootstrap_wait_retries | default(30) }}'
+  delay: '{{ minio_bootstrap_wait_delay | default(10) }}'
   changed_when: false

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -19,30 +19,6 @@
     wait_timeout: "{{ minio_operator_wait_timeout | default('1m') }}"
     atomic: true
 
-- name: Create tenant namespace
-  kubernetes.core.k8s:
-    name: '{{ minio_tenant_namespace }}'
-    api_version: v1
-    kind: Namespace
-    state: present
-
-- name: Set up environment secret
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: "{{ minio_env_secret_name | default('minio-env-configuration') }}"
-        namespace: '{{ minio_tenant_namespace }}'
-      type: Opaque
-      stringData:
-        config.env: |
-          export MINIO_ROOT_USER={{ s3_username }}
-          export MINIO_ROOT_PASSWORD={{ s3_password }}
-          export MINIO_REGION_NAME={{ s3_region }}
-          export MINIO_REGION={{ s3_region }}
-
 - name: Create Traefik Middleware to add trailing slash
   kubernetes.core.k8s:
     state: present
@@ -79,6 +55,45 @@
       - name: minio
         size: '{{ minio_storage_size }}'
         path: '{{ minio_dir }}'
+
+- name: Create tenant namespace
+  kubernetes.core.k8s:
+    name: '{{ minio_tenant_namespace }}'
+    api_version: v1
+    kind: Namespace
+    state: present
+
+- name: Set up environment secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ minio_env_secret_name | default('minio-env-configuration') }}"
+        namespace: '{{ minio_tenant_namespace }}'
+      type: Opaque
+      stringData:
+        config.env: |
+          export MINIO_ROOT_USER={{ s3_username }}
+          export MINIO_ROOT_PASSWORD={{ s3_password }}
+          export MINIO_REGION_NAME={{ s3_region }}
+          export MINIO_REGION={{ s3_region }}
+
+- name: Create MinIO user credential secrets
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: '{{ item.access_key }}-creds'
+        namespace: '{{ minio_tenant_namespace }}'
+      type: Opaque
+      stringData:
+        CONSOLE_ACCESS_KEY: '{{ item.access_key }}'
+        CONSOLE_SECRET_KEY: '{{ item.secret_key }}'
+  loop: '{{ minio_users }}'
 
 - name: Install/Upgrade Minio Tenant
   kubernetes.core.helm:
@@ -139,21 +154,6 @@
   retries: '{{ minio_wait_retries | default(60) }}'
   delay: '{{ minio_wait_delay | default(5) }}'
   changed_when: false
-
-- name: Create MinIO user credential secrets
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: '{{ item.access_key }}-creds'
-        namespace: '{{ minio_tenant_namespace }}'
-      type: Opaque
-      stringData:
-        CONSOLE_ACCESS_KEY: '{{ item.access_key }}'
-        CONSOLE_SECRET_KEY: '{{ item.secret_key }}'
-  loop: '{{ minio_users }}'
 
 - name: Create MinIO policy JSON ConfigMaps
   kubernetes.core.k8s:

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -19,6 +19,30 @@
     wait_timeout: "{{ minio_operator_wait_timeout | default('1m') }}"
     atomic: true
 
+- name: Create tenant namespace
+  kubernetes.core.k8s:
+    name: '{{ minio_tenant_namespace }}'
+    api_version: v1
+    kind: Namespace
+    state: present
+
+- name: Set up environment secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ minio_env_secret_name | default('minio-env-configuration') }}"
+        namespace: '{{ minio_tenant_namespace }}'
+      type: Opaque
+      stringData:
+        config.env: |
+          export MINIO_ROOT_USER={{ s3_username }}
+          export MINIO_ROOT_PASSWORD={{ s3_password }}
+          export MINIO_REGION_NAME={{ s3_region }}
+          export MINIO_REGION={{ s3_region }}
+
 - name: Create Traefik Middleware to add trailing slash
   kubernetes.core.k8s:
     state: present
@@ -48,13 +72,6 @@
           prefixes:
             - "/{{ minio_path_prefix | default('minio') }}"
 
-- name: Create tenant namespace
-  kubernetes.core.k8s:
-    name: '{{ minio_tenant_namespace }}'
-    api_version: v1
-    kind: Namespace
-    state: present
-
 - name: Configure Storage for MinIO
   include_tasks: tasks/storage_setup.yaml
   vars:
@@ -62,23 +79,6 @@
       - name: minio
         size: '{{ minio_storage_size }}'
         path: '{{ minio_dir }}'
-
-- name: Set up environment secret
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: "{{ minio_env_secret_name | default('minio-env-configuration') }}"
-        namespace: '{{ minio_tenant_namespace }}'
-      type: Opaque
-      stringData:
-        config.env: |
-          export MINIO_ROOT_USER={{ s3_username }}
-          export MINIO_ROOT_PASSWORD={{ s3_password }}
-          export MINIO_REGION_NAME={{ s3_region }}
-          export MINIO_REGION={{ s3_region }}
 
 - name: Install/Upgrade Minio Tenant
   kubernetes.core.helm:

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -1,5 +1,5 @@
 - name: Include MinIO variables
-  include_vars: vars/minio.yml
+  include_vars: vars/minio.yaml
 
 - name: Add Minio Helm repository
   kubernetes.core.helm_repository:
@@ -56,7 +56,7 @@
     state: present
 
 - name: Configure Storage for MinIO
-  include_tasks: tasks/storage_setup.yml
+  include_tasks: tasks/storage_setup.yaml
   vars:
     storage_definitions:
       - name: minio
@@ -178,6 +178,15 @@
           }
   loop: '{{ minio_policies }}'
 
+- name: Build list of projected ConfigMaps for MinIO policies
+  set_fact:
+    policy_sources: >-
+      {{
+        policy_sources | default([]) +
+        [ { 'configMap': { 'name': 'policy-' + item.name } } ]
+      }}
+  loop: '{{ minio_policies }}'
+
 - name: Bootstrap MinIO IAM (policies + bindings)
   kubernetes.core.k8s:
     state: present
@@ -220,6 +229,7 @@
                     echo "Creating policy {{ p.name }}..."
                     mc admin policy create local {{ p.name }} /policies/{{ p.name }}.json
                     mc admin policy attach local {{ p.name }} --user {{ p.user }}
+                    mc admin policy detach local consoleAdmin --user {{ p.user }}
                     {% endfor %}
 
                     echo "MinIO IAM setup completed successfully"
@@ -234,11 +244,7 @@
               - name: policies
                 projected:
                   defaultMode: 0644
-                  sources: |
-                    {% for p in minio_policies %}
-                    - configMap:
-                        name: policy-{{ p.name }}
-                    {% endfor %}
+                  sources: '{{ policy_sources }}'
               - name: rootcreds
                 secret:
                   secretName: "{{ minio_env_secret_name | default('minio-env-configuration') }}"

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -77,18 +77,47 @@
           export MINIO_REGION_NAME={{ s3_region }}
           export MINIO_REGION={{ s3_region }}
 
-- name: Create MinIO IAM policies
+- name: Define MinIO IAM policies
+  set_fact:
+    minio_policies:
+      - name: lake-r
+        actions:
+          - s3:GetObject
+          - s3:ListBucket
+          - s3:GetBucketLocation
+          - s3:ListBucketMultipartUploads
+        resources:
+          - arn:aws:s3:::lake
+          - arn:aws:s3:::lake/*
+        user: '{{ s3_lake_reader }}'
+      - name: lake-rw
+        actions:
+          - s3:*
+        resources:
+          - arn:aws:s3:::lake
+          - arn:aws:s3:::lake/*
+          - arn:aws:s3:::scratch
+          - arn:aws:s3:::scratch/*
+        user: '{{ s3_lake_writer }}'
+      - name: loki-rw
+        actions:
+          - s3:*
+        resources:
+          - arn:aws:s3:::loki-*
+          - arn:aws:s3:::loki-*/*
+        user: '{{ s3_loki_writer }}'
+
+- name: Create MinIO policy JSON ConfigMaps
   kubernetes.core.k8s:
     state: present
-    definition:
-      apiVersion: minio.min.io/v2
-      kind: Policy
+    definition: |
+      apiVersion: v1
+      kind: ConfigMap
       metadata:
-        name: "policy-{{ item.name }}"
-        namespace: '{{ minio_tenant_namespace }}'
-      spec:
-        name: "{{ item.name }}"
-        definition: |
+        name: policy-{{ item.name }}
+        namespace: {{ minio_tenant_namespace }}
+      data:
+        {{ item.name }}.json: |
           {
             "Version": "2012-10-17",
             "Statement": [
@@ -99,81 +128,28 @@
               }
             ]
           }
-  loop:
-    - name: lake-r
-      actions:
-        - s3:GetObject
-        - s3:ListBucket
-      resources:
-        - arn:aws:s3:::lake/*
-        - arn:aws:s3:::lake
-    - name: lake-rw
-      actions:
-        - s3:GetObject
-        - s3:ListBucket
-        - s3:PutObject
-        - s3:DeleteObject
-      resources:
-        - arn:aws:s3:::lake/*
-        - arn:aws:s3:::lake
-        - arn:aws:s3:::scratch/*
-        - arn:aws:s3:::scratch
-    - name: loki-rw
-      actions:
-        - s3:GetObject
-        - s3:ListBucket
-        - s3:PutObject
-        - s3:DeleteObject
-      resources:
-        - arn:aws:s3:::loki-chunks/*
-        - arn:aws:s3:::loki-chunks
-        - arn:aws:s3:::loki-ruler/*
-        - arn:aws:s3:::loki-ruler
-        - arn:aws:s3:::loki-admin/*
-        - arn:aws:s3:::loki-admin
+  loop: '{{ minio_policies }}'
 
-- name: Bind policies to users
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: minio.min.io/v2
-      kind: PolicyBinding
-      metadata:
-        name: "binding-{{ item.name }}"
-        namespace: '{{ minio_tenant_namespace }}'
-      spec:
-        policyName: "{{ item.policy_name }}"
-        userRef:
-          name: "{{ item.name }}"
-        tenant: minio-scout
-  loop:
-    - name: '{{ s3_lake_reader }}'
-      policy_name: lake-r
-    - name: '{{ s3_lake_writer }}'
-      policy_name: lake-rw
-    - name: '{{ s3_loki_writer }}'
-      policy_name: loki-rw
-
-- name: Create service account secrets for MinIO users
+- name: Create MinIO user credential secrets
   kubernetes.core.k8s:
     state: present
     definition:
       apiVersion: v1
       kind: Secret
       metadata:
-        name: "{{ item.access_key }}-creds"
+        name: '{{ item.access_key }}-creds'
         namespace: '{{ minio_tenant_namespace }}'
       type: Opaque
       stringData:
-        CONSOLE_ACCESS_KEY: "{{ item.access_key }}"
-        CONSOLE_SECRET_KEY: "{{ item.secret_key }}"
+        CONSOLE_ACCESS_KEY: '{{ item.access_key }}'
+        CONSOLE_SECRET_KEY: '{{ item.secret_key }}'
   loop:
     - access_key: '{{ s3_lake_reader }}'
-      secret_key: "{{ lake_reader_secret }}"
+      secret_key: '{{ s3_lake_reader_secret }}'
     - access_key: '{{ s3_lake_writer }}'
-      secret_key: "{{ lake_writer_secret }}"
+      secret_key: '{{ s3_lake_writer_secret }}'
     - access_key: '{{ s3_loki_writer }}'
-      secret_key: "{{ loki_writer_secret }}"
+      secret_key: '{{ s3_loki_writer_secret }}'
 
 - name: Install/Upgrade Minio Tenant
   kubernetes.core.helm:
@@ -216,9 +192,9 @@
           - name: lake
           - name: scratch
         users:
-          - '{{ s3_lake_reader }}-creds'
-          - '{{ s3_lake_writer }}-creds'
-          - '{{ s3_loki_writer }}-creds'
+          - name: '{{ s3_lake_reader }}-creds'
+          - name: '{{ s3_lake_writer }}-creds'
+          - name: '{{ s3_loki_writer }}-creds'
       ingress:
         console:
           enabled: true
@@ -230,3 +206,66 @@
             traefik.ingress.kubernetes.io/router.middlewares: >
               kube-system-minio-add-trailing-slash@kubernetescrd,
               kube-system-minio-strip-prefix@kubernetescrd
+
+- name: Wait for MinIO to be ready
+  command: 'kubectl -n {{ minio_tenant_namespace }} wait --for=condition=Ready --timeout=300s statefulset/minio-scout-pool-0'
+  register: minio_ready
+  changed_when: false
+
+- name: Bootstrap MinIO IAM (policies + bindings)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: bootstrap-minio-iam
+        namespace: '{{ minio_tenant_namespace }}'
+      spec:
+        ttlSecondsAfterFinished: 600
+        template:
+          spec:
+            restartPolicy: Never
+            serviceAccountName: minio-scout-sa
+            containers:
+              - name: mc
+                image: quay.io/minio/mc:RELEASE.2025-04-16T18-13-26Z
+                command: ["/bin/sh","-c"]
+                args:
+                  - |
+                    set -euo pipefail
+                    . /rootcreds/config.env
+                    mc alias set local http://minio-scout-hl.{{ minio_tenant_namespace }}:9000  "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" --insecure
+                    {% for p in minio_policies %}
+                    mc admin policy create local {{ p.name }} /policies/{{ p.name }}.json
+                    mc admin policy attach local {{ p.name }} --user {{ p.user }}
+                    {% endfor %}
+                volumeMounts:
+                  - name: policies
+                    mountPath: /policies
+                    readOnly: true
+                  - name: rootcreds
+                    mountPath: /rootcreds
+                    readOnly: true
+            volumes:
+              - name: policies
+                projected:
+                  defaultMode: 0644
+                  sources:
+                    - configMap:
+                        name: policy-lake-r
+                    - configMap:
+                        name: policy-lake-rw
+                    - configMap:
+                        name: policy-loki-rw
+              - name: rootcreds
+                secret:
+                  secretName: minio-scout-env-configuration
+                  items:
+                    - key: config.env
+                      path: config.env
+
+- name: Wait for job to complete
+  command: 'kubectl -n {{ minio_tenant_namespace }} wait --for=condition=complete --timeout=300s job/bootstrap-minio-iam'
+  register: minio_bootstrap_complete
+  changed_when: false

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -147,11 +147,11 @@
           name: "{{ item.name }}"
         tenant: minio-scout
   loop:
-    - name: lake-reader
+    - name: '{{ s3_lake_reader }}'
       policy_name: lake-r
-    - name: lake-writer
+    - name: '{{ s3_lake_writer }}'
       policy_name: lake-rw
-    - name: loki-writer
+    - name: '{{ s3_loki_writer }}'
       policy_name: loki-rw
 
 - name: Create service account secrets for MinIO users
@@ -161,21 +161,18 @@
       apiVersion: v1
       kind: Secret
       metadata:
-        name: "{{ item.name }}-creds"
+        name: "{{ item.access_key }}-creds"
         namespace: '{{ minio_tenant_namespace }}'
       type: Opaque
       stringData:
         CONSOLE_ACCESS_KEY: "{{ item.access_key }}"
         CONSOLE_SECRET_KEY: "{{ item.secret_key }}"
   loop:
-    - name: lake-reader
-      access_key: "lake-reader"
+    - access_key: '{{ s3_lake_reader }}'
       secret_key: "{{ lake_reader_secret }}"
-    - name: lake-writer
-      access_key: "lake-writer"
+    - access_key: '{{ s3_lake_writer }}'
       secret_key: "{{ lake_writer_secret }}"
-    - name: loki-writer
-      access_key: "loki-writer"
+    - access_key: '{{ s3_loki_writer }}'
       secret_key: "{{ loki_writer_secret }}"
 
 - name: Install/Upgrade Minio Tenant
@@ -219,9 +216,9 @@
           - name: lake
           - name: scratch
         users:
-          - lake-reader-creds
-          - lake-writer-creds
-          - loki-writer-creds
+          - '{{ s3_lake_reader }}-creds'
+          - '{{ s3_lake_writer }}-creds'
+          - '{{ s3_loki_writer }}-creds'
       ingress:
         console:
           enabled: true

--- a/ansible/playbooks/services/superset.yaml
+++ b/ansible/playbooks/services/superset.yaml
@@ -72,8 +72,8 @@
         connections:
           db_host: 'postgresql-cluster-rw.{{ postgres_cluster_namespace }}'
           db_port: '5432'
-          db_user: '{{ postgres_user }}'
-          db_pass: '{{ postgres_password }}'
+          db_user: '{{ superset_postgres_user }}'
+          db_pass: '{{ superset_postgres_password }}'
           db_name: superset
       configOverrides:
         branding: |

--- a/ansible/playbooks/services/trino.yaml
+++ b/ansible/playbooks/services/trino.yaml
@@ -21,8 +21,8 @@
           connector.name=delta_lake
           hive.metastore.uri={{ hive_metastore_endpoint }}
           fs.native-s3.enabled=true
-          s3.aws-access-key={{ s3_username }}
-          s3.aws-secret-key={{ s3_password }}
+          s3.aws-access-key={{ s3_lake_writer }}
+          s3.aws-secret-key={{ s3_lake_writer_secret }}
           s3.region={{ s3_region }}
           s3.endpoint={{ s3_endpoint }}
           s3.path-style-access=true

--- a/ansible/playbooks/services/trino.yaml
+++ b/ansible/playbooks/services/trino.yaml
@@ -20,6 +20,8 @@
         delta: |
           connector.name=delta_lake
           hive.metastore.uri={{ hive_metastore_endpoint }}
+          delta.security=ALLOW_ALL
+          delta.enable-non-concurrent-writes=true
           fs.native-s3.enabled=true
           s3.aws-access-key={{ s3_lake_writer }}
           s3.aws-secret-key={{ s3_lake_writer_secret }}

--- a/ansible/playbooks/tasks/spark_config_setup.yaml
+++ b/ansible/playbooks/tasks/spark_config_setup.yaml
@@ -16,8 +16,8 @@
         namespace: '{{ spark_defaults_configmap_namespace }}'
       data:
         spark-defaults.conf: |
-          spark.hadoop.fs.s3a.access.key {{ s3_username }}
-          spark.hadoop.fs.s3a.secret.key {{ s3_password }}
+          spark.hadoop.fs.s3a.access.key {{ spark_s3_username | default(s3_lake_reader) }}
+          spark.hadoop.fs.s3a.secret.key {{ spark_s3_password | default(s3_lake_reader_secret) }}
           spark.hadoop.fs.s3a.endpoint {{ s3_endpoint }}
           spark.hadoop.fs.s3a.endpoint.region {{ s3_region | default("us-east-1") }}
           spark.databricks.delta.schema.autoMerge.enabled true

--- a/ansible/playbooks/vars/hive.values.yaml
+++ b/ansible/playbooks/vars/hive.values.yaml
@@ -115,9 +115,9 @@ env:
   - name: S3_ENDPOINT
     value: '{{ s3_endpoint }}'
   - name: S3_ACCESS_KEY
-    value: '{{ s3_username }}'
+    value: '{{ s3_lake_writer }}'
   - name: S3_SECRET_KEY
-    value: '{{ s3_password }}'
+    value: '{{ s3_lake_writer_secret }}'
   - name: S3_PATH_STYLE_ACCESS
     value: 'true'
   - name: REGION

--- a/ansible/playbooks/vars/hive.values.yaml
+++ b/ansible/playbooks/vars/hive.values.yaml
@@ -107,9 +107,9 @@ env:
   - name: HIVE_METASTORE_JDBC_URL
     value: 'jdbc:postgresql://postgresql-cluster-rw.{{ postgres_cluster_namespace }}:5432/hive'
   - name: HIVE_METASTORE_USER
-    value: '{{ postgres_user }}'
+    value: '{{ hive_postgres_user }}'
   - name: HIVE_METASTORE_PASSWORD
-    value: '{{ postgres_password }}'
+    value: '{{ hive_postgres_password }}'
   - name: HIVE_METASTORE_WAREHOUSE_DIR
     value: '{{ hive_warehouse }}'
   - name: S3_ENDPOINT

--- a/ansible/playbooks/vars/minio.yaml
+++ b/ansible/playbooks/vars/minio.yaml
@@ -63,9 +63,8 @@ minio_policies:
   - name: lake-r
     actions:
       - s3:GetObject
-      - s3:ListBucket
       - s3:GetBucketLocation
-      - s3:ListBucketMultipartUploads
+      - s3:ListBucket
     resources:
       - arn:aws:s3:::lake
       - arn:aws:s3:::lake/*

--- a/ansible/playbooks/vars/minio.yaml
+++ b/ansible/playbooks/vars/minio.yaml
@@ -1,0 +1,96 @@
+---
+# Namespace configuration
+minio_tenant_name: scout
+
+# Storage configuration
+minio_storage_size: 750Gi
+minio_storage_class: minio-storage
+minio_server_count: 1
+
+# MinIO versions
+minio_version: ~7.1.0
+minio_client_image: quay.io/minio/mc:RELEASE.2025-04-16T18-13-26Z
+
+# Environment variables
+minio_env_secret_name: minio-scout-env-configuration
+minio_env_variables:
+  - name: MINIO_BROWSER_REDIRECT_URL
+    value: 'https://{{ server_hostname }}/minio/'
+  - name: MINIO_PROMETHEUS_AUTH_TYPE
+    value: public
+
+# Ingress configuration
+minio_path_prefix: minio
+minio_trailing_slash_middleware: minio-add-trailing-slash
+minio_strip_prefix_middleware: minio-strip-prefix
+minio_ingress_config:
+  console:
+    enabled: true
+    ingressClassName: traefik
+    host: '{{ server_hostname }}'
+    path: '/{{ minio_path_prefix }}'
+    pathType: Prefix
+    annotations:
+      traefik.ingress.kubernetes.io/router.middlewares: >
+        kube-system-{{ minio_trailing_slash_middleware }}@kubernetescrd,
+        kube-system-{{ minio_strip_prefix_middleware }}@kubernetescrd
+
+# Bucket definitions
+minio_buckets:
+  - name: loki-chunks
+  - name: loki-ruler
+  - name: loki-admin
+  - name: scratch
+  - name: lake
+
+# S3 User credentials
+minio_users:
+  - access_key: '{{ s3_lake_reader }}'
+    secret_key: '{{ s3_lake_reader_secret }}'
+  - access_key: '{{ s3_lake_writer }}'
+    secret_key: '{{ s3_lake_writer_secret }}'
+  - access_key: '{{ s3_loki_writer }}'
+    secret_key: '{{ s3_loki_writer_secret }}'
+
+# User mapping
+minio_credentials:
+  - name: '{{ s3_lake_reader }}-creds'
+  - name: '{{ s3_lake_writer }}-creds'
+  - name: '{{ s3_loki_writer }}-creds'
+
+# IAM Policy definitions
+minio_policies:
+  - name: lake-r
+    actions:
+      - s3:GetObject
+      - s3:ListBucket
+      - s3:GetBucketLocation
+      - s3:ListBucketMultipartUploads
+    resources:
+      - arn:aws:s3:::lake
+      - arn:aws:s3:::lake/*
+    user: '{{ s3_lake_reader }}'
+  - name: lake-rw
+    actions:
+      - s3:*
+    resources:
+      - arn:aws:s3:::lake
+      - arn:aws:s3:::lake/*
+      - arn:aws:s3:::scratch
+      - arn:aws:s3:::scratch/*
+    user: '{{ s3_lake_writer }}'
+  - name: loki-rw
+    actions:
+      - s3:*
+    resources:
+      - arn:aws:s3:::loki-*
+      - arn:aws:s3:::loki-*/*
+    user: '{{ s3_loki_writer }}'
+
+# Wait times and retries
+minio_operator_wait_timeout: 1m
+minio_tenant_wait_timeout: 5m
+minio_wait_retries: 60
+minio_wait_delay: 5
+minio_bootstrap_wait_retries: 30
+minio_bootstrap_wait_delay: 10


### PR DESCRIPTION
# Set up separate users and permissions for postgres databases and minio buckets

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
I believe the only product-facing change for this PR is that the minio credentials exposed via Jupyter (via Spark config) are now restricted to RO access to `lake` bucket.

### Technical
* Postgres: create different users for the 3 different databases. Users are still database owners, read-only permissions are enforced through use of the `postgres-cluster-r` service.
* Minio: create different users and buckets, with access policies specifying the actions each can take.
  * `lake-reader`: read access for `lake` bucket, used for Jupyter (via Spark config)
  * `lake-writer`: write access for `lake` and `scratch` buckets, used for Extractors (directly and via Spark for HL7 ingest), Hive, and Trino (Trino needs write access to allow Superset to create tables, which is needed if users want to inner join the delta lake with lists of identifiers)
  * `loki-writer`: write access for `loki-*` buckets, used for Loki.

## Impact

### Security 

##### Authorization
This is an auth change, as detailed in Technical section, above

##### Appsec
This should improve appsec in that we're reduce the authorization scope of various roles. In the future, it may make sense to consider using Minio's STS support, but that's a larger change in how services communicate with Minio, so out of scope for now.

### Performance
I don't expect this to have a performance impact.

### Data
N/A

### Backward compatibility
I don't think the postgres changes are backward compatible. The Minio changes _should_ be, though I haven't tested this.

## Testing
* Uninstall and reinstall on `big-04`, run large ingest, verify UX for all impacted services
* CI via this PR

## Note for reviewers

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
