### PR TITLE
Add HostToContainer mount propagation to handle reading a directory mounted after application deployment

### DIFF
--- a/ansible/playbooks/templates/hl7-transformer.values.yaml.j2
+++ b/ansible/playbooks/templates/hl7-transformer.values.yaml.j2
@@ -27,6 +27,7 @@ volumeMounts:
   - name: data
     mountPath: /data
     readOnly: true
+    mountPropagation: HostToContainer
   - name: spark-defaults
     mountPath: /opt/spark/conf/spark-defaults.conf
     subPath: spark-defaults.conf

--- a/ansible/playbooks/templates/hl7log-extractor.values.yaml.j2
+++ b/ansible/playbooks/templates/hl7log-extractor.values.yaml.j2
@@ -16,6 +16,7 @@ volumeMounts:
   - name: data
     mountPath: /data
     readOnly: true
+    mountPropagation: HostToContainer
 config:
   application:
     s3:


### PR DESCRIPTION
# Add HostToContainer mount propagation to handle reading a directory mounted after application deployment

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
No change

### Technical
HL7 log directory can be mounted after Extractors are deployed

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
I don't think this should impact performance

### Data
N/A

### Backward compatibility
Yes

## Testing
Going to test via CI on this PR to make sure the Extractors still come up with the additional field, and test on `tb-01` tomorrow.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
