### PR TITLE
Improve HL7 Ingest Dashboard Readability with Base 2 Log Scaling

### DIFF
--- a/helm/grafana/dashboards/hl7-ingest-dashboard.json
+++ b/helm/grafana/dashboards/hl7-ingest-dashboard.json
@@ -182,7 +182,8 @@
             },
             "lineWidth": 1,
             "scaleDistribution": {
-              "type": "linear"
+              "log": 2,
+              "type": "symlog"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -293,7 +294,8 @@
             },
             "lineWidth": 1,
             "scaleDistribution": {
-              "type": "linear"
+              "log": 2,
+              "type": "symlog"
             },
             "thresholdsStyle": {
               "mode": "off"


### PR DESCRIPTION
# Improve HL7 Ingest Dashboard Readability with Base 2 Log Scaling

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product / Technical
- Updated the HL7 Ingest Grafana Dashboard to use base 2 logarithmic scaling for axes.
- This change improves readability, especially when there are large disparities in values.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
This change does not affect backward compatibility.

## Testing
See screenshots for testing of base 2 and base 10 scaling. Base 2 was more readable. It was not possible to adjust the tick density for base 10.

<img width="2007" alt="Screenshot 2025-05-06 at 2 40 12 PM" src="https://github.com/user-attachments/assets/c8951ba1-817f-4d72-a4f9-ab61d01d7af4" />
<img width="2007" alt="Screenshot 2025-05-06 at 2 39 32 PM" src="https://github.com/user-attachments/assets/311db131-d471-4429-b4df-8036e096b966" />

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.