### PR TITLE
Handle unanticipated TCP chatter in HL7 logs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
   push:
-    branches: [main]
+    branches: [main, tcp-chatter]
 
 env:
   JAVA_DIST: 'zulu'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
   push:
-    branches: [main, tcp-chatter]
+    branches: [main]
 
 env:
   JAVA_DIST: 'zulu'

--- a/tests/src/test/java/edu/washu/tag/tests/TestStatusDatabase.java
+++ b/tests/src/test/java/edu/washu/tag/tests/TestStatusDatabase.java
@@ -85,7 +85,7 @@ public class TestStatusDatabase extends BaseTest {
             logRowWithRetries
         );
 
-        final Hl7FileRow repeatedFailingHl7Message = Hl7FileRow.failure(0, null, "Split content has fewer than 3 lines");
+        final Hl7FileRow repeatedFailingHl7Message = Hl7FileRow.failure(0, null, "Log did not contain any HL7 messages");
 
         runHl7FileTest(
             SqlQuery.hl7FileTableQuery("20240102", Collections.singletonList(ingestWorkflowId)),

--- a/tests/src/test/java/edu/washu/tag/tests/TestStatusDatabase.java
+++ b/tests/src/test/java/edu/washu/tag/tests/TestStatusDatabase.java
@@ -156,6 +156,41 @@ public class TestStatusDatabase extends BaseTest {
         );
     }
 
+    /**
+     * Tests the state of the ingest database after the test data has been processed by Scout.
+     * This test is essentially the same as {@link #testStatusDbSuccess} but the log file has some extra
+     * chatter in the logs that was causing an issue in production, which is checked by this test.
+     */
+    @Test
+    public void testStatusDbTcpChatter() {
+        final LogRow logRow = LogRow.success("1999-11-30");
+
+        runLogTest(
+            SqlQuery.logTableQuery("19991130"),
+            logRow
+        );
+
+        runLogTest(
+            SqlQuery.logViewQuery("19991130"),
+            logRow
+        );
+
+        final Hl7FileRow firstHl7Message = Hl7FileRow.success(0, "1999/11/30/02/199911300242267124.hl7");
+        final Hl7FileRow secondHl7Message = Hl7FileRow.success(1, "1999/11/30/23/199911302311298376.hl7");
+
+        runHl7FileTest(
+            SqlQuery.hl7FileTableQuery("19991130", Collections.singletonList(ingestWorkflowId)),
+            firstHl7Message,
+            secondHl7Message
+        );
+
+        runHl7FileTest(
+            SqlQuery.hl7FileViewQuery("19991130", Collections.singletonList(ingestWorkflowId)),
+            firstHl7Message,
+            secondHl7Message
+        );
+    }
+
     private void runDbTest(SqlQuery query, Consumer<ResultSet> resultValidator) {
         final String sql = query.build();
         try (

--- a/tests/staging_test_data/hl7/1999/19991130.log
+++ b/tests/staging_test_data/hl7/1999/19991130.log
@@ -29,6 +29,10 @@ OBX|21|ST|&IMP|2|Dictated by: Joseph Barajas Interpreter, M.D.||||||Final|||||T6
 ZDS|2.25.100405915728099816173320934019894171432^EPIC^APPLICATION^DICOM<R>
 <EB><R>
 
+1999-11-30 23:11:29.1901|INFO|Raw.TcpLogger.TcpLogger|Receiver requested on port 9999
+1999-11-30 23:11:29.2346|INFO|Raw.Application.TcpServer.TcpServer|Port 9999. End Point is 127.0.0.1:9999
+1999-11-30 23:11:29.5508|INFO|Raw.Application.TcpServer.TcpServer|Waiting for a connection.....
+1999-11-30 23:11:29.6882|INFO|Raw.Application.TcpServer.TcpServer|Connection accepted from 127.0.0.2:12345 on port 9999
 1999-11-30 23:11:29.8376|INFO|Raw.Application.TcpServer.TcpServer|
 <SB>
 MSH|^~\&|SOMERIS|ABCHOSP|SOMEAPP|ABC_HOSP_DEPT_X|19991130231129|TBD|ORU^R01|2.25.258872894671527226589049435320087888112|P|2.7<R>


### PR DESCRIPTION
# Handle unanticipated TCP chatter in HL7 logs

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
If a logfile doesn't contain any HL7, we write an error message to the hl7 table for segment 0 saying "Log did not contain any HL7 messages". I debated if this should be an error on the log file itself, but I felt like the hl7 table gets a little more visibility and was consistent with prior behavior (which would have produced the message "Split content has fewer than 3 lines").

### Technical
The HL7 logs may contain multiple lines from the HL7 receiver about the TCP connection, interspersed between HL7 segments. 

This extractor used to assume that after a blank line or at the start of the log file, we would see precisely one timestamp line, one `<SB>` tag, and then everything up through the next blank line was treated as HL7 content.

This change assumes that an HL7 message is demarcated by an `<SB>` (start) tag and `<EB>` (end) tag. The line immediately preceding the `<SB>` tag must contain the timestamp for receipt of the HL7 message (which is assumed to be unique to that HL7 message). Any other lines in the log file (aka not between `<SB>` tag and `<EB>` and not the line immediately preceding the `<SB>` tag) are ignored.

If we see multiple `<SB>`/`<EB>` demarcated entries within a given timestamped message, we ingest the first and throw errors for the rest.

Notably, <EB> tags are now not included in the *.hl7 files we generate.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
Shouldn't be any different than previous operations

### Data
I hope this is more specific, in the right ways, than we were before. 

### Backward compatibility
This does change error messaging a bit.

## Testing
Running CI tests (which @cmoore01 contributed to this PR)

## Note for reviewers


## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [x] I have added end-to-end tests, unless this is a documentation-only PR.
