### PR TITLE
Set split and upload timeout to 180min default, limit retries to 2, and allow user to specify split and upload timeout and concurrency when submitting a workflow

### DIFF
--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -98,6 +98,10 @@ k3s_cluster:
     report_delta_table_name: reports
     ingest_postgres_table_name: ingest
 
+    # Extractor performance tuning
+    hl7log_extractor_timeout: 180
+    hl7log_extractor_concurrency: 150
+
     # Resources
     hl7_transformer_spark_memory: 8g
     jupyter_spark_memory: 8g

--- a/ansible/playbooks/templates/hl7log-extractor.values.yaml.j2
+++ b/ansible/playbooks/templates/hl7log-extractor.values.yaml.j2
@@ -36,6 +36,8 @@ config:
           logsRootPath: '{{ hl7logs_root_dir }}'
           scratchSpaceRootPath: '{{ scratch_path }}'
           hl7OutputPath: '{{ hl7_path }}'
+          splitAndUploadTimeout: 180
+          splitAndUploadConcurrency: 150
         ingestHl7ToDeltaLake:
           reportTableName: '{{ report_delta_table_name }}'
           modalityMapPath: '{{ modality_map_path }}'

--- a/ansible/playbooks/templates/hl7log-extractor.values.yaml.j2
+++ b/ansible/playbooks/templates/hl7log-extractor.values.yaml.j2
@@ -36,8 +36,8 @@ config:
           logsRootPath: '{{ hl7logs_root_dir }}'
           scratchSpaceRootPath: '{{ scratch_path }}'
           hl7OutputPath: '{{ hl7_path }}'
-          splitAndUploadTimeout: 180
-          splitAndUploadConcurrency: 150
+          splitAndUploadTimeout: {{ hl7log_extractor_timeout | default(180) }}
+          splitAndUploadConcurrency: {{ hl7log_extractor_concurrency | default(150) }}
         ingestHl7ToDeltaLake:
           reportTableName: '{{ report_delta_table_name }}'
           modalityMapPath: '{{ modality_map_path }}'

--- a/docs/source/ingest.md
+++ b/docs/source/ingest.md
@@ -16,6 +16,8 @@ corresponding Ansible variables.
 - `scratchSpaceRootPath`: root path to use for temporary files. The directory specified will be created if it does not exist.
    Ansible equivalent: `scratch_path`.
 - `hl7OutputPath`: path to write HL7 files. Note that this is _not_ the path to the resulting delta lake. Ansible equivalent: `hl7_path`.
+- `splitAndUploadTimeout`: timeout in minutes for the activity that splits the HL7 listener log files and uploads the component HL7 messages to MinIO.
+- `splitAndUploadConcurrency`: number of HL7 listener log files to process concurrently.
 - `modalityMapPath`: path to read modality map file, which is the source of the `modality` column in the Delta Lake table.
    Ansible equivalent: `modality_map_path`.
 - `reportTableName`: name of the Delta Lake table to write to. Ansible equivalent: `report_delta_table_name`.

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/config/S3Config.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/config/S3Config.java
@@ -1,5 +1,6 @@
 package edu.washu.tag.extractor.hl7log.config;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,6 +22,9 @@ public class S3Config {
     @Value("${s3.region}")
     private String region;
 
+    @Value("${s3.max-connections}")
+    private Integer maxConnections;
+
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
@@ -31,7 +35,7 @@ public class S3Config {
                         .pathStyleAccessEnabled(true)
                         .build())
                 .httpClientBuilder(ApacheHttpClient.builder()
-                        .maxConnections(100)
+                        .maxConnections(ObjectUtils.defaultIfNull(maxConnections, 50))
                         .connectionTimeout(Duration.ofSeconds(5)))
                 .build();
     }

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/ContinueIngestWorkflow.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/ContinueIngestWorkflow.java
@@ -1,3 +1,3 @@
 package edu.washu.tag.extractor.hl7log.model;
 
-public record ContinueIngestWorkflow(String manifestFilePath, int numLogFiles, int nextIndex) {}
+public record ContinueIngestWorkflow(String manifestFilePath, int numLogFiles, int nextIndex, int splitAndUploadConcurrency) {}

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/FindHl7LogFileInput.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/FindHl7LogFileInput.java
@@ -2,4 +2,4 @@ package edu.washu.tag.extractor.hl7log.model;
 
 import java.util.List;
 
-public record FindHl7LogFileInput(List<String> logPaths, String date, String logsRootPath, String manifestFilePath) {}
+public record FindHl7LogFileInput(List<String> logPaths, String date, String logsRootPath, String manifestFilePath, int splitAndUploadConcurrency) {}

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7LogWorkflowInput.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7LogWorkflowInput.java
@@ -9,6 +9,8 @@ package edu.washu.tag.extractor.hl7log.model;
  *                 If logsRootPath is provided and this is not, every .log file under logsRootPath will be used.
  * @param scratchSpaceRootPath Root path to use for temporary files. Will be created if it does not exist.
  * @param hl7OutputPath Path to write HL7 files.
+ * @param splitAndUploadTimeout The timeout for the split and upload job
+ * @param splitAndUploadConcurrency The concurrency for the split and upload job (how many logs should we process concurrently?)
  * @param modalityMapPath Path to read modality map file, which is the source of the modality column in Delta Lake table.
  * @param reportTableName Name of the Delta Lake table to write to.
  * @param continued Do not set this on initial workflow run. Parameters needed to resume when workflow is Continued As New.
@@ -19,6 +21,8 @@ public record IngestHl7LogWorkflowInput(
         String logPaths,
         String scratchSpaceRootPath,
         String hl7OutputPath,
+        int splitAndUploadTimeout,
+        int splitAndUploadConcurrency,
         String modalityMapPath,
         String reportTableName,
         ContinueIngestWorkflow continued
@@ -29,6 +33,8 @@ public record IngestHl7LogWorkflowInput(
             null,
             null,
             null,
+            -1,
+            -1,
             null,
             null,
             null

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7LogWorkflowInput.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7LogWorkflowInput.java
@@ -21,8 +21,8 @@ public record IngestHl7LogWorkflowInput(
         String logPaths,
         String scratchSpaceRootPath,
         String hl7OutputPath,
-        int splitAndUploadTimeout,
-        int splitAndUploadConcurrency,
+        Integer splitAndUploadTimeout,
+        Integer splitAndUploadConcurrency,
         String modalityMapPath,
         String reportTableName,
         ContinueIngestWorkflow continued
@@ -33,8 +33,8 @@ public record IngestHl7LogWorkflowInput(
             null,
             null,
             null,
-            -1,
-            -1,
+            null,
+            null,
             null,
             null,
             null

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7LogWorkflowParsedInput.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7LogWorkflowParsedInput.java
@@ -7,5 +7,7 @@ public record IngestHl7LogWorkflowParsedInput(
     String date,
     String scratchSpaceRootPath,
     String logsRootPath,
-    String hl7OutputPath
+    String hl7OutputPath,
+    Integer splitAndUploadTimeout,
+    Integer splitAndUploadConcurrency
 ) {}

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/DefaultArgs.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/DefaultArgs.java
@@ -10,8 +10,8 @@ public class DefaultArgs {
     private static String logsRootPath;
     private static String scratchSpaceRootPath;
     private static String hl7OutputPath;
-    private static int splitAndUploadTimeout;
-    private static int splitAndUploadConcurrency;
+    private static Integer splitAndUploadTimeout;
+    private static Integer splitAndUploadConcurrency;
     private static String modalityMapPath;
     private static String reportTableName;
 
@@ -40,18 +40,18 @@ public class DefaultArgs {
     }
 
     @Value("${scout.workflowArgDefaults.ingestHl7Log.splitAndUploadTimeout}")
-    public void setSplitAndUploadTimeout(int splitAndUploadTimeout) {
+    public void setSplitAndUploadTimeout(Integer splitAndUploadTimeout) {
         DefaultArgs.splitAndUploadTimeout = splitAndUploadTimeout;
     }
-    public static int getSplitAndUploadTimeout(int input) {
+    public static Integer getSplitAndUploadTimeout(Integer input) {
         return getValueOrDefault(input, splitAndUploadTimeout);
     }
 
     @Value("${scout.workflowArgDefaults.ingestHl7Log.splitAndUploadConcurrency}")
-    public void setSplitAndUploadConcurrency(int splitAndUploadConcurrency) {
+    public void setSplitAndUploadConcurrency(Integer splitAndUploadConcurrency) {
         DefaultArgs.splitAndUploadConcurrency = splitAndUploadConcurrency;
     }
-    public static int getSplitAndUploadConcurrency(int input) {
+    public static Integer getSplitAndUploadConcurrency(Integer input) {
         return getValueOrDefault(input, splitAndUploadConcurrency);
     }
 
@@ -74,7 +74,7 @@ public class DefaultArgs {
     private static String getValueOrDefault(String value, String defaultValue) {
         return (value == null || value.isEmpty()) ? defaultValue : value;
     }
-    private static int getValueOrDefault(int value, int defaultValue) {
-        return (value == -1) ? defaultValue : value;
+    private static Integer getValueOrDefault(Integer value, Integer defaultValue) {
+        return (value == null || value == -1) ? defaultValue : value;
     }
 }

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/DefaultArgs.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/DefaultArgs.java
@@ -40,7 +40,7 @@ public class DefaultArgs {
     }
 
     @Value("${scout.workflowArgDefaults.ingestHl7Log.splitAndUploadTimeout}")
-    public static void setSplitAndUploadTimeout(int splitAndUploadTimeout) {
+    public void setSplitAndUploadTimeout(int splitAndUploadTimeout) {
         DefaultArgs.splitAndUploadTimeout = splitAndUploadTimeout;
     }
     public static int getSplitAndUploadTimeout(int input) {
@@ -48,7 +48,7 @@ public class DefaultArgs {
     }
 
     @Value("${scout.workflowArgDefaults.ingestHl7Log.splitAndUploadConcurrency}")
-    public static void setSplitAndUploadConcurrency(int splitAndUploadConcurrency) {
+    public void setSplitAndUploadConcurrency(int splitAndUploadConcurrency) {
         DefaultArgs.splitAndUploadConcurrency = splitAndUploadConcurrency;
     }
     public static int getSplitAndUploadConcurrency(int input) {

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/DefaultArgs.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/DefaultArgs.java
@@ -10,6 +10,8 @@ public class DefaultArgs {
     private static String logsRootPath;
     private static String scratchSpaceRootPath;
     private static String hl7OutputPath;
+    private static int splitAndUploadTimeout;
+    private static int splitAndUploadConcurrency;
     private static String modalityMapPath;
     private static String reportTableName;
 
@@ -37,6 +39,22 @@ public class DefaultArgs {
         return getValueOrDefault(input, hl7OutputPath);
     }
 
+    @Value("${scout.workflowArgDefaults.ingestHl7Log.splitAndUploadTimeout}")
+    public static void setSplitAndUploadTimeout(int splitAndUploadTimeout) {
+        DefaultArgs.splitAndUploadTimeout = splitAndUploadTimeout;
+    }
+    public static int getSplitAndUploadTimeout(int input) {
+        return getValueOrDefault(input, splitAndUploadTimeout);
+    }
+
+    @Value("${scout.workflowArgDefaults.ingestHl7Log.splitAndUploadConcurrency}")
+    public static void setSplitAndUploadConcurrency(int splitAndUploadConcurrency) {
+        DefaultArgs.splitAndUploadConcurrency = splitAndUploadConcurrency;
+    }
+    public static int getSplitAndUploadConcurrency(int input) {
+        return getValueOrDefault(input, splitAndUploadConcurrency);
+    }
+
     @Value("${scout.workflowArgDefaults.ingestHl7ToDeltaLake.modalityMapPath}")
     public void setModalityMapPath(String modalityMapPath) {
         DefaultArgs.modalityMapPath = modalityMapPath;
@@ -55,5 +73,8 @@ public class DefaultArgs {
 
     private static String getValueOrDefault(String value, String defaultValue) {
         return (value == null || value.isEmpty()) ? defaultValue : value;
+    }
+    private static int getValueOrDefault(int value, int defaultValue) {
+        return (value == -1) ? defaultValue : value;
     }
 }

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/IngestHl7LogWorkflowInputParser.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/IngestHl7LogWorkflowInputParser.java
@@ -21,21 +21,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class IngestHl7LogWorkflowInputParser {
+
     private static final Logger logger = LoggerFactory.getLogger(IngestHl7LogWorkflowInputParser.class);
 
     /**
      * Parse and validate input.
      * <p>
-     * Ways this workflow can be invoked:
-     * 1. In a scheduled run, we ignore the other args and use the scheduled time to find "yesterday's" logs.
-     *    These logs must be found under the logsRootPath (either provided in the args or the default), and they
-     *    must have a date in the file name in the format YYYYMMDD.
-     * 2. In a non-scheduled run we must find logs using the other args. We first assemble a list of paths to check for logs.
-     *  2a. We have a logPaths input value. The paths can be absolute (used as-is) or relative (resolved against logsRootPath).
-     *  2b. With no logPaths input, we will use logsRootPath to find all log files under that path.
-     *  Regardless of the source of the paths, we will check each path for log files. If a path is a directory we search
-     *  it recursively for files ending in ".log". If a path is a file we use it as-is.
-     *  If a date arg is provided, we will only look for logs with that date in the file name.
+     * Ways this workflow can be invoked: 1. In a scheduled run, we ignore the other args and use the scheduled time to find "yesterday's" logs. These logs must
+     * be found under the logsRootPath (either provided in the args or the default), and they must have a date in the file name in the format YYYYMMDD. 2. In a
+     * non-scheduled run we must find logs using the other args. We first assemble a list of paths to check for logs. 2a. We have a logPaths input value. The
+     * paths can be absolute (used as-is) or relative (resolved against logsRootPath). 2b. With no logPaths input, we will use logsRootPath to find all log
+     * files under that path. Regardless of the source of the paths, we will check each path for log files. If a path is a directory we search it recursively
+     * for files ending in ".log". If a path is a file we use it as-is. If a date arg is provided, we will only look for logs with that date in the file name.
      *
      * @param input Workflow input
      * @return Resolved inputs against defaults and paths made absolute
@@ -47,6 +44,9 @@ public class IngestHl7LogWorkflowInputParser {
         String logsRootPath = DefaultArgs.getLogsRootPath(input.logsRootPath());
         String scratchSpaceRootPath = DefaultArgs.getScratchSpaceRootPath(input.scratchSpaceRootPath());
         String hl7OutputPath = DefaultArgs.getHl7OutputPath(input.hl7OutputPath());
+
+        Integer splitAndUploadTimeout = DefaultArgs.getSplitAndUploadTimeout(input.splitAndUploadTimeout());
+        Integer splitAndUploadConcurrency = DefaultArgs.getSplitAndUploadConcurrency(input.splitAndUploadConcurrency());
 
         // Do we have values?
         boolean hasLogPathsInput = input.logPaths() != null && !input.logPaths().isBlank();
@@ -72,7 +72,9 @@ public class IngestHl7LogWorkflowInputParser {
                 "WorkflowId {} - Using date {} from scheduled workflow start time {} ({} in TZ {}) minus one day",
                 workflowInfo.getWorkflowId(), date, scheduledTimeUtc, scheduledTimeLocal, localTz
             );
-            return new IngestHl7LogWorkflowParsedInput(List.of(logsRootPath), date, scratchSpaceRootPath, logsRootPath, hl7OutputPath);
+            return new IngestHl7LogWorkflowParsedInput(
+                List.of(logsRootPath), date, scratchSpaceRootPath, logsRootPath, hl7OutputPath, splitAndUploadTimeout, splitAndUploadConcurrency
+            );
         } else if (isScheduledRun) {
             // We are in a scheduled run without a root path. This is an error.
             logger.error(
@@ -109,7 +111,9 @@ public class IngestHl7LogWorkflowInputParser {
             input, scratchSpaceRootPath, hl7OutputPath, hasLogPathsInput, hasLogsRootPathInput, relativeLogPathsWithoutRoot
         );
 
-        return new IngestHl7LogWorkflowParsedInput(logPaths, input.date(), scratchSpaceRootPath, logsRootPath, hl7OutputPath);
+        return new IngestHl7LogWorkflowParsedInput(
+            logPaths, input.date(), scratchSpaceRootPath, logsRootPath, hl7OutputPath, splitAndUploadTimeout, splitAndUploadConcurrency
+        );
     }
 
     private static void throwOnInvalidInput(

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/IngestHl7LogWorkflowInputParser.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/IngestHl7LogWorkflowInputParser.java
@@ -27,12 +27,16 @@ public class IngestHl7LogWorkflowInputParser {
     /**
      * Parse and validate input.
      * <p>
-     * Ways this workflow can be invoked: 1. In a scheduled run, we ignore the other args and use the scheduled time to find "yesterday's" logs. These logs must
-     * be found under the logsRootPath (either provided in the args or the default), and they must have a date in the file name in the format YYYYMMDD. 2. In a
-     * non-scheduled run we must find logs using the other args. We first assemble a list of paths to check for logs. 2a. We have a logPaths input value. The
-     * paths can be absolute (used as-is) or relative (resolved against logsRootPath). 2b. With no logPaths input, we will use logsRootPath to find all log
-     * files under that path. Regardless of the source of the paths, we will check each path for log files. If a path is a directory we search it recursively
-     * for files ending in ".log". If a path is a file we use it as-is. If a date arg is provided, we will only look for logs with that date in the file name.
+     * Ways this workflow can be invoked:
+     * 1. In a scheduled run, we ignore the other args and use the scheduled time to find "yesterday's" logs.
+     *    These logs must be found under the logsRootPath (either provided in the args or the default), and they
+     *    must have a date in the file name in the format YYYYMMDD.
+     * 2. In a non-scheduled run we must find logs using the other args. We first assemble a list of paths to check for logs.
+     *  2a. We have a logPaths input value. The paths can be absolute (used as-is) or relative (resolved against logsRootPath).
+     *  2b. With no logPaths input, we will use logsRootPath to find all log files under that path.
+     *  Regardless of the source of the paths, we will check each path for log files. If a path is a directory we search
+     *  it recursively for files ending in ".log". If a path is a file we use it as-is.
+     *  If a date arg is provided, we will only look for logs with that date in the file name.
      *
      * @param input Workflow input
      * @return Resolved inputs against defaults and paths made absolute

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/workflow/IngestHl7LogWorkflowImpl.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/workflow/IngestHl7LogWorkflowImpl.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 
 import java.time.Duration;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 
 import static edu.washu.tag.extractor.hl7log.util.Constants.PARENT_QUEUE;
 import static edu.washu.tag.extractor.hl7log.util.Constants.CHILD_QUEUE;
@@ -38,6 +39,9 @@ import static edu.washu.tag.extractor.hl7log.util.Constants.INGEST_DELTA_LAKE_QU
 @WorkflowImpl(taskQueues = PARENT_QUEUE)
 public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
     private static final Logger logger = Workflow.getLogger(IngestHl7LogWorkflowImpl.class);
+
+    @Value("${scout.split-and-upload-timeout}")
+    private int splitAndUploadTimeout;
 
     private final FindHl7LogsActivity findHl7LogsActivity =
             Workflow.newActivityStub(FindHl7LogsActivity.class,
@@ -62,10 +66,10 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
         Workflow.newActivityStub(SplitHl7LogActivity.class,
             ActivityOptions.newBuilder()
                 .setTaskQueue(CHILD_QUEUE)
-                .setStartToCloseTimeout(Duration.ofHours(1))
+                .setStartToCloseTimeout(Duration.ofMinutes(splitAndUploadTimeout))
                 .setRetryOptions(RetryOptions.newBuilder()
                     .setMaximumInterval(Duration.ofSeconds(30))
-                    .setMaximumAttempts(5)
+                    .setMaximumAttempts(2)
                     .build())
                 .build());
 

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/workflow/IngestHl7LogWorkflowImpl.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/workflow/IngestHl7LogWorkflowImpl.java
@@ -31,11 +31,13 @@ import org.slf4j.Logger;
 import java.time.Duration;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import static edu.washu.tag.extractor.hl7log.util.Constants.PARENT_QUEUE;
 import static edu.washu.tag.extractor.hl7log.util.Constants.CHILD_QUEUE;
 import static edu.washu.tag.extractor.hl7log.util.Constants.INGEST_DELTA_LAKE_QUEUE;
 
+@Component
 @WorkflowImpl(taskQueues = PARENT_QUEUE)
 public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
     private static final Logger logger = Workflow.getLogger(IngestHl7LogWorkflowImpl.class);

--- a/extractor/hl7log-extractor/src/main/resources/application.yaml
+++ b/extractor/hl7log-extractor/src/main/resources/application.yaml
@@ -23,6 +23,7 @@ spring:
 s3:
   endpoint: 'http://minio.minio:9000'
   region: us-east-1
+  max-connections: 50
 scout:
   # Placeholders for default workflow arguments that can be configured from outside and overridden in the workflow
   workflowArgDefaults:

--- a/extractor/hl7log-extractor/src/main/resources/application.yaml
+++ b/extractor/hl7log-extractor/src/main/resources/application.yaml
@@ -24,10 +24,11 @@ s3:
   endpoint: 'http://minio.minio:9000'
   region: us-east-1
 scout:
-  max-children:
-    150 # This is to limit I/O contention during the split and upload operation (java worker) and to try to hit a sweet spot of efficiency
-  # during the delta lake insert (python worker). It's been tested on 1.3-1.4MB log files, as well as 15-45MB log files.
-  split-and-upload-timeout: 180 # Timeout (in minutes) for log split and upload activity
+  # This is to limit I/O contention during the split and upload operation (java worker) and to try to hit a sweet spot of efficiency during the delta lake
+  # insert (python worker). It's been tested on 1.3-1.4MB log files, as well as 15-45MB log files.
+  max-children: 150
+  # Timeout (in minutes) for log split and upload activity
+  split-and-upload-timeout: 180
   # Placeholders for default workflow arguments that can be configured from outside and overridden in the workflow
   workflowArgDefaults:
     ingestHl7Log:

--- a/extractor/hl7log-extractor/src/main/resources/application.yaml
+++ b/extractor/hl7log-extractor/src/main/resources/application.yaml
@@ -24,18 +24,17 @@ s3:
   endpoint: 'http://minio.minio:9000'
   region: us-east-1
 scout:
-  # This is to limit I/O contention during the split and upload operation (java worker) and to try to hit a sweet spot of efficiency during the delta lake
-  # insert (python worker). It's been tested on 1.3-1.4MB log files, as well as 15-45MB log files.
-  max-children: 150
-  # Timeout (in minutes) for log split and upload activity
-  split-and-upload-timeout: 180
   # Placeholders for default workflow arguments that can be configured from outside and overridden in the workflow
   workflowArgDefaults:
     ingestHl7Log:
       logsRootPath: ''
       scratchSpaceRootPath: ''
       hl7OutputPath: ''
+      # Timeout (in minutes) for log split and upload activity
+      splitAndUploadTimeout: 180
+      # This is to limit I/O contention during the split and upload operation (java worker) and to try to hit a sweet spot of efficiency
+      # during the delta lake insert (python worker). It's been tested on 1.3-1.4MB log files, as well as 15-45MB log files.
+      splitAndUploadConcurrency: 150
     ingestHl7ToDeltaLake:
-      deltaLakePath: ''
       modalityMapPath: ''
       reportTableName: ''

--- a/extractor/hl7log-extractor/src/main/resources/application.yaml
+++ b/extractor/hl7log-extractor/src/main/resources/application.yaml
@@ -25,8 +25,9 @@ s3:
   region: us-east-1
 scout:
   max-children:
-    150 # This is to limit I/O contention during the split & transform operation (java worker) and to try to hit a sweet spot of efficiency
-    # during the delta lake insert (python worker). It's been tested on 1.3-1.4MB log files.
+    150 # This is to limit I/O contention during the split and upload operation (java worker) and to try to hit a sweet spot of efficiency
+  # during the delta lake insert (python worker). It's been tested on 1.3-1.4MB log files, as well as 15-45MB log files.
+  split-and-upload-timeout: 180 # Timeout (in minutes) for log split and upload activity
   # Placeholders for default workflow arguments that can be configured from outside and overridden in the workflow
   workflowArgDefaults:
     ingestHl7Log:

--- a/extractor/hl7log-extractor/src/test/java/edu/washu/tag/extractor/hl7log/IngestHl7LogWorkflowInputParserTest.java
+++ b/extractor/hl7log-extractor/src/test/java/edu/washu/tag/extractor/hl7log/IngestHl7LogWorkflowInputParserTest.java
@@ -84,8 +84,8 @@ class IngestHl7LogWorkflowInputParserTest {
             String.join(",", logPathsInput),
             null,
             null,
-            -1,
-            -1,
+            null,
+            null,
             null,
             null,
             null
@@ -110,8 +110,8 @@ class IngestHl7LogWorkflowInputParserTest {
             null,
             null,
             null,
-            -1,
-            -1,
+            null,
+            null,
             null,
             null,
             null
@@ -158,8 +158,8 @@ class IngestHl7LogWorkflowInputParserTest {
             null,
             null,
             null,
-            -1,
-            -1,
+            null,
+            null,
             null,
             null,
             null
@@ -195,8 +195,8 @@ class IngestHl7LogWorkflowInputParserTest {
             String.join(",", ignoredLogPaths),
             null,
             null,
-            -1,
-            -1,
+            null,
+            null,
             null,
             null,
             null

--- a/extractor/hl7log-extractor/src/test/java/edu/washu/tag/extractor/hl7log/IngestHl7LogWorkflowInputParserTest.java
+++ b/extractor/hl7log-extractor/src/test/java/edu/washu/tag/extractor/hl7log/IngestHl7LogWorkflowInputParserTest.java
@@ -58,6 +58,10 @@ class IngestHl7LogWorkflowInputParserTest {
     private String defaultScratchSpaceRootPath;
     @Value("${scout.workflowArgDefaults.ingestHl7Log.hl7OutputPath}")
     private String defaultHl7OutputPath;
+    @Value("${scout.workflowArgDefaults.ingestHl7Log.splitAndUploadTimeout}")
+    private Integer defaultSplitAndUploadTimeout;
+    @Value("${scout.workflowArgDefaults.ingestHl7Log.splitAndUploadConcurrency}")
+    private Integer defaultSplitAndUploadConcurrency;
 
     @Test
     void testParseInput_nonScheduled_defaultsOnly(IngestHl7LogWorkflowInputParserTestWorkflow workflow) {
@@ -70,7 +74,9 @@ class IngestHl7LogWorkflowInputParserTest {
         assertNull(parsedInput.date());
         assertEquals(defaultScratchSpaceRootPath, parsedInput.scratchSpaceRootPath());
         assertEquals(defaultLogsRootPath, parsedInput.logsRootPath());
-        assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());;
+        assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());
+        assertEquals(defaultSplitAndUploadTimeout, parsedInput.splitAndUploadTimeout());
+        assertEquals(defaultSplitAndUploadConcurrency, parsedInput.splitAndUploadConcurrency());
     }
 
     @Test
@@ -99,6 +105,8 @@ class IngestHl7LogWorkflowInputParserTest {
         assertEquals(defaultScratchSpaceRootPath, parsedInput.scratchSpaceRootPath());
         assertEquals(logsRootPath, parsedInput.logsRootPath());
         assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());
+        assertEquals(defaultSplitAndUploadTimeout, parsedInput.splitAndUploadTimeout());
+        assertEquals(defaultSplitAndUploadConcurrency, parsedInput.splitAndUploadConcurrency());
     }
 
     @Test
@@ -125,6 +133,8 @@ class IngestHl7LogWorkflowInputParserTest {
         assertEquals(defaultScratchSpaceRootPath, parsedInput.scratchSpaceRootPath());
         assertEquals(defaultLogsRootPath, parsedInput.logsRootPath());
         assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());
+        assertEquals(defaultSplitAndUploadTimeout, parsedInput.splitAndUploadTimeout());
+        assertEquals(defaultSplitAndUploadConcurrency, parsedInput.splitAndUploadConcurrency());
     }
 
     @Test
@@ -147,6 +157,8 @@ class IngestHl7LogWorkflowInputParserTest {
         assertEquals(defaultScratchSpaceRootPath, parsedInput.scratchSpaceRootPath());
         assertEquals(defaultLogsRootPath, parsedInput.logsRootPath());
         assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());
+        assertEquals(defaultSplitAndUploadTimeout, parsedInput.splitAndUploadTimeout());
+        assertEquals(defaultSplitAndUploadConcurrency, parsedInput.splitAndUploadConcurrency());
     }
 
     @Test
@@ -181,6 +193,8 @@ class IngestHl7LogWorkflowInputParserTest {
         assertEquals(defaultScratchSpaceRootPath, parsedInput.scratchSpaceRootPath());
         assertEquals(logsRootPath, parsedInput.logsRootPath());
         assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());
+        assertEquals(defaultSplitAndUploadTimeout, parsedInput.splitAndUploadTimeout());
+        assertEquals(defaultSplitAndUploadConcurrency, parsedInput.splitAndUploadConcurrency());
     }
 
     @Test
@@ -218,5 +232,37 @@ class IngestHl7LogWorkflowInputParserTest {
         assertEquals(defaultScratchSpaceRootPath, parsedInput.scratchSpaceRootPath());
         assertEquals(logsRootPath, parsedInput.logsRootPath());
         assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());
+        assertEquals(defaultSplitAndUploadTimeout, parsedInput.splitAndUploadTimeout());
+        assertEquals(defaultSplitAndUploadConcurrency, parsedInput.splitAndUploadConcurrency());
+    }
+
+    @Test
+    void testParseInput_splitAndUploadActivitySettings(IngestHl7LogWorkflowInputParserTestWorkflow workflow) {
+        String date = "arbitrary-date";
+        int timeout = 60;
+        int concurrency = 100;
+        IngestHl7LogWorkflowInput input = new IngestHl7LogWorkflowInput(
+            date,
+            null,
+            null,
+            null,
+            null,
+            timeout,
+            concurrency,
+            null,
+            null,
+            null
+        );
+
+        IngestHl7LogWorkflowParsedInput parsedInput = workflow.parseInput(input, null);
+
+        assertNotNull(parsedInput);
+        assertEquals(List.of(defaultLogsRootPath), parsedInput.logPaths());
+        assertEquals(date, parsedInput.date());
+        assertEquals(defaultScratchSpaceRootPath, parsedInput.scratchSpaceRootPath());
+        assertEquals(defaultLogsRootPath, parsedInput.logsRootPath());
+        assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());
+        assertEquals(timeout, parsedInput.splitAndUploadTimeout());
+        assertEquals(concurrency, parsedInput.splitAndUploadConcurrency());
     }
 }

--- a/extractor/hl7log-extractor/src/test/java/edu/washu/tag/extractor/hl7log/IngestHl7LogWorkflowInputParserTest.java
+++ b/extractor/hl7log-extractor/src/test/java/edu/washu/tag/extractor/hl7log/IngestHl7LogWorkflowInputParserTest.java
@@ -84,6 +84,8 @@ class IngestHl7LogWorkflowInputParserTest {
             String.join(",", logPathsInput),
             null,
             null,
+            -1,
+            -1,
             null,
             null,
             null
@@ -108,6 +110,8 @@ class IngestHl7LogWorkflowInputParserTest {
             null,
             null,
             null,
+            -1,
+            -1,
             null,
             null,
             null
@@ -154,6 +158,8 @@ class IngestHl7LogWorkflowInputParserTest {
             null,
             null,
             null,
+            -1,
+            -1,
             null,
             null,
             null
@@ -189,6 +195,8 @@ class IngestHl7LogWorkflowInputParserTest {
             String.join(",", ignoredLogPaths),
             null,
             null,
+            -1,
+            -1,
             null,
             null,
             null

--- a/extractor/hl7log-extractor/src/test/resources/application.yaml
+++ b/extractor/hl7log-extractor/src/test/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
   temporal:
     connection:
       target: 127.0.0.1:7233
-      target.namespace: default
+    namespace: default
     start-workers: true
     workers-auto-discovery:
       packages:
@@ -22,8 +22,8 @@ spring:
 s3:
   endpoint: 'http://minio.minio:9000'
   region: us-east-1
+  max-connections: 50
 scout:
-  max-children: 100
   workflowArgDefaults:
     ingestHl7Log:
       logsRootPath: '/path/to/logs'

--- a/extractor/hl7log-extractor/src/test/resources/application.yaml
+++ b/extractor/hl7log-extractor/src/test/resources/application.yaml
@@ -29,6 +29,8 @@ scout:
       logsRootPath: '/path/to/logs'
       scratchSpaceRootPath: '/path/to/scratch'
       hl7OutputPath: '/path/to/hl7/output'
+      splitAndUploadTimeout: 180
+      splitAndUploadConcurrency: 150
     ingestHl7ToDeltaLake:
       modalityMapPath: '/path/to/modality_map.csv'
       reportTableName: 'reports'

--- a/tests/src/test/java/edu/washu/tag/tests/TestStatusDatabase.java
+++ b/tests/src/test/java/edu/washu/tag/tests/TestStatusDatabase.java
@@ -62,9 +62,9 @@ public class TestStatusDatabase extends BaseTest {
     /**
      * Tests the state of the ingest database after the test data has been processed by Scout.
      * In particular, for the date 2024-01-02, the entire content of the log file is unusable by Scout.
-     * The {@value #TABLE_LOG_FILES} table is expected to have five "successful" rows for that day
+     * The {@value #TABLE_LOG_FILES} table is expected to have two "successful" rows for that day
      * from retries because the error is tracked later on while the {@value #VIEW_RECENT_LOG_FILES} view
-     * limits to a single row. The {@value #TABLE_HL7_FILES} table contains the 5 failed rows for that date
+     * limits to a single row. The {@value #TABLE_HL7_FILES} table contains the 2 failed rows for that date
      * with the {@value #VIEW_RECENT_HL7_FILES} view restricting to a single row.
      */
     @Test
@@ -73,9 +73,6 @@ public class TestStatusDatabase extends BaseTest {
 
         runLogTest(
             SqlQuery.logTableQuery("20240102"),
-            logRowWithRetries,
-            logRowWithRetries,
-            logRowWithRetries,
             logRowWithRetries,
             logRowWithRetries
         );
@@ -89,9 +86,6 @@ public class TestStatusDatabase extends BaseTest {
 
         runHl7FileTest(
             SqlQuery.hl7FileTableQuery("20240102", Collections.singletonList(ingestWorkflowId)),
-            repeatedFailingHl7Message,
-            repeatedFailingHl7Message,
-            repeatedFailingHl7Message,
             repeatedFailingHl7Message,
             repeatedFailingHl7Message
         );


### PR DESCRIPTION
# Set split and upload timeout to 180min default and limit retries to 2

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
This PR loosens the timeout threshold and drops the number of retries for the split and upload activities. It also allows the user to set the time and concurrency settings for the split and upload job as workflow inputs.

Lastly, it exposes `s3.max-connections` as a configuration. This isn't modifiable anywhere, but now we can tweak it via `kubectl` and get a better feel for how it should be set.

### Technical
Split and upload activity on real data at 150-log concurrency takes ~50min. If things slow down at all (iowait degrades), this tips the activity into the timeout of 1hr. The activity is actually still running, so the retry just worsens the issue, and once we're at around retry 4, things are grinding to a crawl.

Because a failure due to timeout doesn't kill anything, just restarts the activity, we want to be good & sure the prior activity is actually done and not reporting back before marking it a timeout. In this split & upload activity, we could still get into a scenario where the prior job is just really hung up on io ops, and the only way to make it actually recover would be to kill it before we restart. I think that needs to be a manual operation, triggered either by an alert on iowait or by an entire workflow failing -- timeouts & retires won't get us there.

## Impact

### Security 

##### Authorization
N/A 

##### Appsec
N/A 

### Performance
N/A 

### Data
N/A 

### Backward compatibility
N/A 

## Testing
Run CI, test with the following on big-04 (validate we only have 10 concurrent activities)
```
kubectl exec -n temporal -i deployment/temporal-admintools -- temporal workflow start --task-queue ingest-hl7-log --type IngestHl7LogWorkflow --input '{"logsRootPath": "/data/7500k_scale_test_data/1995", "splitAndUploadConcurrency": 10}'
```

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [x] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
