### PR TITLE
Make delta ingest timeout configurable and small fixes to "no HL7" alert

### DIFF
--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -101,6 +101,7 @@ k3s_cluster:
     # Extractor performance tuning
     hl7log_extractor_timeout: 180
     hl7log_extractor_concurrency: 150
+    hl7_transformer_timeout: 60
 
     # Resources
     hl7_transformer_spark_memory: 8g

--- a/ansible/playbooks/templates/grafana/alerts/no-hl7-from-scheduled-ingest-alert.json.j2
+++ b/ansible/playbooks/templates/grafana/alerts/no-hl7-from-scheduled-ingest-alert.json.j2
@@ -98,7 +98,7 @@
             "__dashboardUid__": "hl7_ingest_dashboard_01",
             "__panelId__": "3",
             "description": "Tests whether any HL7 reports were ingested from the HL7 listener log file dated 2 days ago (because we ingest yesterday''s logs today, and we cannot control when this alert runs, so it could beat the ingest)",
-            "summary": "{% raw %}Scheduled ingest of HL7 log from {{ $labels.day }} on {{ $labels.cluster }} extracted 0 reports. This may mean ingest failed to run, no log was found, or the log didnt contain any HL7.{% endraw %}"
+            "summary": "{% raw %}Scheduled ingest of HL7 log from {{ $labels.day }} on {{ $labels.cluster }} extracted 0 reports. This may mean ingest failed to run, no log was found, or the log didn''t contain any HL7.{% endraw %}"
           },
           "labels": {},
           "isPaused": false,

--- a/ansible/playbooks/templates/grafana/notification-policy.yaml.j2
+++ b/ansible/playbooks/templates/grafana/notification-policy.yaml.j2
@@ -25,5 +25,5 @@ policies:
     routes:
       - receiver: "{{ grafana_alert_contact_point }}"
         matchers:
-          - alertname = no_hl7_from_scheduled_ingest_alert_01
-        repeat_interval: 25h # Setting to 25hrs makes the date change, so it is no longer the same alert
+          - alertname = No HL7 from scheduled ingest
+        repeat_interval: 999w # Essentially, do not repeat

--- a/ansible/playbooks/templates/hl7log-extractor.values.yaml.j2
+++ b/ansible/playbooks/templates/hl7log-extractor.values.yaml.j2
@@ -39,5 +39,6 @@ config:
           splitAndUploadTimeout: {{ hl7log_extractor_timeout | default(180) }}
           splitAndUploadConcurrency: {{ hl7log_extractor_concurrency | default(150) }}
         ingestHl7ToDeltaLake:
+          deltaIngestTimeout: {{ hl7_transformer_timeout | default(60) }}
           reportTableName: '{{ report_delta_table_name }}'
           modalityMapPath: '{{ modality_map_path }}'

--- a/ansible/playbooks/vars/minio.yaml
+++ b/ansible/playbooks/vars/minio.yaml
@@ -18,6 +18,8 @@ minio_env_variables:
     value: 'https://{{ server_hostname }}/minio/'
   - name: MINIO_PROMETHEUS_AUTH_TYPE
     value: public
+  - name: MINIO_SCANNER_SPEED
+    value: slowest
 
 # Ingress configuration
 minio_path_prefix: minio

--- a/docs/source/ingest.md
+++ b/docs/source/ingest.md
@@ -16,11 +16,13 @@ corresponding Ansible variables.
 - `scratchSpaceRootPath`: root path to use for temporary files. The directory specified will be created if it does not exist.
    Ansible equivalent: `scratch_path`.
 - `hl7OutputPath`: path to write HL7 files. Note that this is _not_ the path to the resulting delta lake. Ansible equivalent: `hl7_path`.
-- `splitAndUploadTimeout`: timeout in minutes for the activity that splits the HL7 listener log files and uploads the component HL7 messages to MinIO.
-- `splitAndUploadConcurrency`: number of HL7 listener log files to process concurrently.
+- `splitAndUploadTimeout`: timeout in minutes for the activity that splits the HL7 listener log files and uploads the component HL7 messages to MinIO. 
+Ansible equivalent: `hl7log_extractor_timeout`
+- `splitAndUploadConcurrency`: number of HL7 listener log files to process concurrently. Ansible equivalent: `hl7log_extractor_concurrency`
 - `modalityMapPath`: path to read modality map file, which is the source of the `modality` column in the Delta Lake table.
    Ansible equivalent: `modality_map_path`.
 - `reportTableName`: name of the Delta Lake table to write to. Ansible equivalent: `report_delta_table_name`.
+- `deltaIngestTimeout`: timeout in minutes for the activity and transforms the HL7 and uploads to the delta lake. Ansible equivalent: `hl7_transformer_timeout` 
 
 ## admintools container
 

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7FilesToDeltaLakeInput.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7FilesToDeltaLakeInput.java
@@ -5,5 +5,6 @@ public record IngestHl7FilesToDeltaLakeInput(
     String scratchSpaceRootPath,
     String hl7ManifestFilePath,
     String hl7RootPath,
-    String reportTableName
+    String reportTableName,
+    Integer deltaIngestTimeout
 ) {}

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7LogWorkflowInput.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7LogWorkflowInput.java
@@ -29,16 +29,16 @@ public record IngestHl7LogWorkflowInput(
         ContinueIngestWorkflow continued
 ) {
     public static IngestHl7LogWorkflowInput EMPTY = new IngestHl7LogWorkflowInput(
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
         null
     );
 }

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7LogWorkflowInput.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7LogWorkflowInput.java
@@ -25,6 +25,7 @@ public record IngestHl7LogWorkflowInput(
         Integer splitAndUploadConcurrency,
         String modalityMapPath,
         String reportTableName,
+        Integer deltaIngestTimeout,
         ContinueIngestWorkflow continued
 ) {
     public static IngestHl7LogWorkflowInput EMPTY = new IngestHl7LogWorkflowInput(
@@ -37,6 +38,7 @@ public record IngestHl7LogWorkflowInput(
             null,
             null,
             null,
-            null
+            null,
+        null
     );
 }

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/DefaultArgs.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/DefaultArgs.java
@@ -14,6 +14,7 @@ public class DefaultArgs {
     private static Integer splitAndUploadConcurrency;
     private static String modalityMapPath;
     private static String reportTableName;
+    private static Integer deltaIngestTimeout;
 
     @Value("${scout.workflowArgDefaults.ingestHl7Log.logsRootPath}")
     public void setLogsRootPath(String logsRootPath) {
@@ -69,6 +70,14 @@ public class DefaultArgs {
     }
     public static String getReportTableName(String input) {
         return getValueOrDefault(input, reportTableName);
+    }
+
+    @Value("${scout.workflowArgDefaults.ingestHl7ToDeltaLake.deltaIngestTimeout}")
+    public void setDeltaIngestTimeout(Integer deltaIngestTimeout) {
+        DefaultArgs.deltaIngestTimeout = deltaIngestTimeout;
+    }
+    public static Integer getDeltaIngestTimeout(Integer input) {
+        return getValueOrDefault(input, deltaIngestTimeout);
     }
 
     private static String getValueOrDefault(String value, String defaultValue) {

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/workflow/IngestHl7LogWorkflowImpl.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/workflow/IngestHl7LogWorkflowImpl.java
@@ -144,7 +144,8 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
                 scratchSpaceRootPath,
                 hl7ManifestFileOutput.manifestFilePath(),
                 null,
-                input.reportTableName()
+                input.reportTableName(),
+                input.deltaIngestTimeout()
             )
         );
         // Wait for child workflow to start
@@ -167,6 +168,7 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
                     input.splitAndUploadConcurrency(),
                     input.modalityMapPath(),
                     input.reportTableName(),
+                    input.deltaIngestTimeout(),
                     nextContinued
                 )
             );

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/workflow/IngestHl7ToDeltaLakeWorkflowImpl.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/workflow/IngestHl7ToDeltaLakeWorkflowImpl.java
@@ -38,20 +38,20 @@ public class IngestHl7ToDeltaLakeWorkflowImpl implements IngestHl7ToDeltaLakeWor
                 .build()
         );
 
-    private final ActivityStub ingestActivity =
-        Workflow.newUntypedActivityStub(
-            ActivityOptions.newBuilder()
-                .setTaskQueue(INGEST_DELTA_LAKE_QUEUE)
-                .setStartToCloseTimeout(Duration.ofMinutes(30))
-                .setRetryOptions(RetryOptions.newBuilder()
-                    .setMaximumInterval(Duration.ofSeconds(1))
-                    .setMaximumAttempts(10)
-                    .build())
-                .build());
-
     @Override
     public IngestHl7FilesToDeltaLakeOutput ingestHl7FileToDeltaLake(IngestHl7FilesToDeltaLakeInput input) {
         WorkflowInfo workflowInfo = Workflow.getInfo();
+
+        final ActivityStub ingestActivity =
+            Workflow.newUntypedActivityStub(
+                ActivityOptions.newBuilder()
+                    .setTaskQueue(INGEST_DELTA_LAKE_QUEUE)
+                    .setStartToCloseTimeout(Duration.ofMinutes(DefaultArgs.getDeltaIngestTimeout(input.deltaIngestTimeout())))
+                    .setRetryOptions(RetryOptions.newBuilder()
+                        .setMaximumInterval(Duration.ofMinutes(5))
+                        .setMaximumAttempts(5)
+                        .build())
+                    .build());
 
         String hl7ManifestFilePath = input.hl7ManifestFilePath();
         if (input.hl7ManifestFilePath() == null || input.hl7ManifestFilePath().isEmpty()) {

--- a/extractor/hl7log-extractor/src/main/resources/application.yaml
+++ b/extractor/hl7log-extractor/src/main/resources/application.yaml
@@ -37,5 +37,7 @@ scout:
       # during the delta lake insert (python worker). It's been tested on 1.3-1.4MB log files, as well as 15-45MB log files.
       splitAndUploadConcurrency: 150
     ingestHl7ToDeltaLake:
+      # Timeout (in minutes) for transform and upload to delta lake activity
+      deltaIngestTimeout: 60
       modalityMapPath: ''
       reportTableName: ''

--- a/extractor/hl7log-extractor/src/test/java/edu/washu/tag/extractor/hl7log/IngestHl7LogWorkflowInputParserTest.java
+++ b/extractor/hl7log-extractor/src/test/java/edu/washu/tag/extractor/hl7log/IngestHl7LogWorkflowInputParserTest.java
@@ -94,6 +94,7 @@ class IngestHl7LogWorkflowInputParserTest {
             null,
             null,
             null,
+            null,
             null
         );
 
@@ -114,6 +115,7 @@ class IngestHl7LogWorkflowInputParserTest {
         String date = "arbitrary-date";
         IngestHl7LogWorkflowInput input = new IngestHl7LogWorkflowInput(
             date,
+            null,
             null,
             null,
             null,
@@ -174,6 +176,7 @@ class IngestHl7LogWorkflowInputParserTest {
             null,
             null,
             null,
+            null,
             null
         );
 
@@ -207,6 +210,7 @@ class IngestHl7LogWorkflowInputParserTest {
             date,
             logsRootPath,
             String.join(",", ignoredLogPaths),
+            null,
             null,
             null,
             null,
@@ -249,6 +253,7 @@ class IngestHl7LogWorkflowInputParserTest {
             null,
             timeout,
             concurrency,
+            null,
             null,
             null,
             null

--- a/extractor/hl7log-extractor/src/test/resources/application.yaml
+++ b/extractor/hl7log-extractor/src/test/resources/application.yaml
@@ -32,5 +32,6 @@ scout:
       splitAndUploadTimeout: 180
       splitAndUploadConcurrency: 150
     ingestHl7ToDeltaLake:
+      deltaIngestTimeout: 60
       modalityMapPath: '/path/to/modality_map.csv'
       reportTableName: 'reports'


### PR DESCRIPTION
# Make delta ingest timeout configurable and small fixes to "no HL7" alert

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
User can specify delta ingest timeout via Ansible or at runtime (via workflow parameters). Delta ingest retries reduced from 10 to 5, and wait period increased from 1s to 5min.

Also, a quick bugfix for "no HL7" alert - dropping repeat to 999w (essentially: do not repeat).

Also, turn down [minio scanning](https://min.io/docs/minio/linux/operations/concepts/scanner.html)

### Technical
(See #106 for similar change on the split & upload side of things.)

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
Yes, it's backward compatible.

## Testing
CI and `big-04`

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
