### PR TITLE
Add heartbeats to split and upload activity for fine-grained timeout and proper cancellation

### DIFF
--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -99,7 +99,8 @@ k3s_cluster:
     ingest_postgres_table_name: ingest
 
     # Extractor performance tuning
-    hl7log_extractor_timeout: 180
+    hl7log_extractor_timeout: 480
+    hl7log_extractor_heartbeat_timeout: 30
     hl7log_extractor_concurrency: 150
     hl7_transformer_timeout: 60
 

--- a/ansible/playbooks/templates/hl7log-extractor.values.yaml.j2
+++ b/ansible/playbooks/templates/hl7log-extractor.values.yaml.j2
@@ -36,7 +36,8 @@ config:
           logsRootPath: '{{ hl7logs_root_dir }}'
           scratchSpaceRootPath: '{{ scratch_path }}'
           hl7OutputPath: '{{ hl7_path }}'
-          splitAndUploadTimeout: {{ hl7log_extractor_timeout | default(180) }}
+          splitAndUploadTimeout: {{ hl7log_extractor_timeout | default(480) }}
+          splitAndUploadHeartbeatTimeout: {{ hl7log_extractor_heartbeat_timeout | default(30) }}
           splitAndUploadConcurrency: {{ hl7log_extractor_concurrency | default(150) }}
         ingestHl7ToDeltaLake:
           deltaIngestTimeout: {{ hl7_transformer_timeout | default(60) }}

--- a/docs/source/ingest.md
+++ b/docs/source/ingest.md
@@ -18,6 +18,9 @@ corresponding Ansible variables.
 - `hl7OutputPath`: path to write HL7 files. Note that this is _not_ the path to the resulting delta lake. Ansible equivalent: `hl7_path`.
 - `splitAndUploadTimeout`: timeout in minutes for the activity that splits the HL7 listener log files and uploads the component HL7 messages to MinIO. 
 Ansible equivalent: `hl7log_extractor_timeout`
+- `splitAndUploadHeartbeatTimeout`: timeout in minutes for **heartbeats** during the activity that splits the HL7 listener log files and uploads 
+the component HL7 messages to MinIO. This is roughly the time to parse and upload one HL7 message, but it also includes steps like writing the manifest 
+file and updating the database. Ansible equivalent: `hl7log_extractor_heartbeat_timeout`
 - `splitAndUploadConcurrency`: number of HL7 listener log files to process concurrently. Ansible equivalent: `hl7log_extractor_concurrency`
 - `modalityMapPath`: path to read modality map file, which is the source of the `modality` column in the Delta Lake table.
    Ansible equivalent: `modality_map_path`.

--- a/docs/source/ingest.md
+++ b/docs/source/ingest.md
@@ -19,8 +19,9 @@ corresponding Ansible variables.
 - `splitAndUploadTimeout`: timeout in minutes for the activity that splits the HL7 listener log files and uploads the component HL7 messages to MinIO. 
 Ansible equivalent: `hl7log_extractor_timeout`
 - `splitAndUploadHeartbeatTimeout`: timeout in minutes for **heartbeats** during the activity that splits the HL7 listener log files and uploads 
-the component HL7 messages to MinIO. This is roughly the time to parse and upload one HL7 message, but it also includes steps like writing the manifest 
-file and updating the database. Ansible equivalent: `hl7log_extractor_heartbeat_timeout`
+the component HL7 messages to MinIO. At a minimum, this is roughly the time to parse and upload one HL7 message, but it also includes steps like writing the manifest 
+file and updating the database. (Note also: the temporal client only sends the heartbeats to the server periodically; in between sends, it queues up
+heartbeats internally and could coalesce or drop heartbeats if they are too frequent.) Ansible equivalent: `hl7log_extractor_heartbeat_timeout`
 - `splitAndUploadConcurrency`: number of HL7 listener log files to process concurrently. Ansible equivalent: `hl7log_extractor_concurrency`
 - `modalityMapPath`: path to read modality map file, which is the source of the `modality` column in the Delta Lake table.
    Ansible equivalent: `modality_map_path`.

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/activity/SplitHl7LogActivityImpl.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/activity/SplitHl7LogActivityImpl.java
@@ -116,7 +116,7 @@ public class SplitHl7LogActivityImpl implements SplitHl7LogActivity {
             throw ApplicationFailure.newFailureWithCause("Failed to upload log file list to " + hl7ListFileUri, "type", e);
         }
 
-        ctx.heartbeat("Completed reading " + segmentResults.size() + " messages");
+        ctx.heartbeat("Completed upload of " + segmentResults.size() + " messages");
         return new SplitAndTransformHl7LogOutput(uploadedList, hl7Paths.size());
     }
 

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/activity/SplitHl7LogActivityImpl.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/activity/SplitHl7LogActivityImpl.java
@@ -12,6 +12,7 @@ import edu.washu.tag.extractor.hl7log.model.SplitAndTransformHl7LogInput;
 import edu.washu.tag.extractor.hl7log.model.SplitAndTransformHl7LogOutput;
 import edu.washu.tag.extractor.hl7log.util.FileHandler;
 import io.temporal.activity.Activity;
+import io.temporal.activity.ActivityExecutionContext;
 import io.temporal.activity.ActivityInfo;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.spring.boot.ActivityImpl;
@@ -61,17 +62,20 @@ public class SplitHl7LogActivityImpl implements SplitHl7LogActivity {
 
     @Override
     public SplitAndTransformHl7LogOutput splitAndTransformHl7Log(SplitAndTransformHl7LogInput input) {
-        ActivityInfo activityInfo = Activity.getExecutionContext().getInfo();
+        ActivityExecutionContext ctx = Activity.getExecutionContext();
+        ActivityInfo activityInfo = ctx.getInfo();
         String workflowId = activityInfo.getWorkflowId();
         String activityId = activityInfo.getActivityId();
 
+        ctx.heartbeat("Starting");
         logger.info("WorkflowId {} ActivityId {} - Splitting HL7 log file {} into component HL7 files", workflowId, activityId, input.logPath());
 
         URI destination = URI.create(input.hl7OutputPath());
         List<Hl7File> segmentResults;
         try {
-            segmentResults = processLogFile(input.logPath(), destination, workflowId, activityId);
+            segmentResults = processLogFile(input.logPath(), destination);
 
+            ctx.heartbeat("Updating status");
             ingestDbService.insertLogFile(LogFile.success(input.logPath(), workflowId, activityId));
         } catch (IOException e) {
             logger.error("WorkflowId {} ActivityId {} - Could not read log file {}",
@@ -81,6 +85,7 @@ public class SplitHl7LogActivityImpl implements SplitHl7LogActivity {
         }
 
         // Insert the HL7 file paths into the database
+        ctx.heartbeat("Processed " + segmentResults.size() + " messages");
         ingestDbService.batchInsertHl7Files(segmentResults);
 
         // If all HL7 files failed, fail the activity
@@ -95,6 +100,7 @@ public class SplitHl7LogActivityImpl implements SplitHl7LogActivity {
         }
 
         // Write the list of HL7 file paths to a file
+        ctx.heartbeat("Writing manifest file");
         String hl7ListFilePath = String.join("/",
             input.scratchDir(),
             activityInfo.getWorkflowId(),
@@ -110,6 +116,7 @@ public class SplitHl7LogActivityImpl implements SplitHl7LogActivity {
             throw ApplicationFailure.newFailureWithCause("Failed to upload log file list to " + hl7ListFileUri, "type", e);
         }
 
+        ctx.heartbeat("Completed reading " + segmentResults.size() + " messages");
         return new SplitAndTransformHl7LogOutput(uploadedList, hl7Paths.size());
     }
 
@@ -215,12 +222,15 @@ public class SplitHl7LogActivityImpl implements SplitHl7LogActivity {
      *
      * @param logFile     The HL7 log file to process
      * @param destination The URI destination
-     * @param workflowId  The workflow identifier for logs
-     * @param activityId  The activity identifier for logs
      * @return List of Hl7File instances containing generated output file paths or error messages
      * @throws IOException If an I/O error occurs
      */
-    private List<Hl7File> processLogFile(String logFile, URI destination, String workflowId, String activityId) throws IOException {
+    private List<Hl7File> processLogFile(String logFile, URI destination) throws IOException {
+        ActivityExecutionContext ctx = Activity.getExecutionContext();
+        ActivityInfo activityInfo = ctx.getInfo();
+        String workflowId = activityInfo.getWorkflowId();
+        String activityId = activityInfo.getActivityId();
+
         Path logFilePath = Paths.get(logFile);
 
         List<Hl7File> results = new ArrayList<>();
@@ -243,6 +253,10 @@ public class SplitHl7LogActivityImpl implements SplitHl7LogActivity {
                             break;
                         }
                         hl7Content.add(processed);
+                    }
+
+                    if (hl7Count % 100 == 0) {
+                        ctx.heartbeat(hl7Count);
                     }
                     results.add(validateWriteAndUploadHl7(logFile, hl7Content, previousLine, destination, hl7Count++, workflowId, activityId));
                     hl7Content.clear();

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/activity/SplitHl7LogActivityImpl.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/activity/SplitHl7LogActivityImpl.java
@@ -255,9 +255,7 @@ public class SplitHl7LogActivityImpl implements SplitHl7LogActivity {
                         hl7Content.add(processed);
                     }
 
-                    if (hl7Count % 100 == 0) {
-                        ctx.heartbeat(hl7Count);
-                    }
+                    ctx.heartbeat(hl7Count);
                     results.add(validateWriteAndUploadHl7(logFile, hl7Content, previousLine, destination, hl7Count++, workflowId, activityId));
                     hl7Content.clear();
                     previousLine = null;

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7LogWorkflowInput.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7LogWorkflowInput.java
@@ -10,9 +10,11 @@ package edu.washu.tag.extractor.hl7log.model;
  * @param scratchSpaceRootPath Root path to use for temporary files. Will be created if it does not exist.
  * @param hl7OutputPath Path to write HL7 files.
  * @param splitAndUploadTimeout The timeout for the split and upload job
+ * @param splitAndUploadHeartbeatTimeout The timeout for the split and upload job heartbeat
  * @param splitAndUploadConcurrency The concurrency for the split and upload job (how many logs should we process concurrently?)
  * @param modalityMapPath Path to read modality map file, which is the source of the modality column in Delta Lake table.
  * @param reportTableName Name of the Delta Lake table to write to.
+ * @param deltaIngestTimeout The timeout for the delta lake ingest job
  * @param continued Do not set this on initial workflow run. Parameters needed to resume when workflow is Continued As New.
  */
 public record IngestHl7LogWorkflowInput(
@@ -22,6 +24,7 @@ public record IngestHl7LogWorkflowInput(
         String scratchSpaceRootPath,
         String hl7OutputPath,
         Integer splitAndUploadTimeout,
+        Integer splitAndUploadHeartbeatTimeout,
         Integer splitAndUploadConcurrency,
         String modalityMapPath,
         String reportTableName,
@@ -29,6 +32,7 @@ public record IngestHl7LogWorkflowInput(
         ContinueIngestWorkflow continued
 ) {
     public static IngestHl7LogWorkflowInput EMPTY = new IngestHl7LogWorkflowInput(
+        null,
         null,
         null,
         null,

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7LogWorkflowParsedInput.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/model/IngestHl7LogWorkflowParsedInput.java
@@ -9,5 +9,6 @@ public record IngestHl7LogWorkflowParsedInput(
     String logsRootPath,
     String hl7OutputPath,
     Integer splitAndUploadTimeout,
+    Integer splitAndUploadHeartbeatTimeout,
     Integer splitAndUploadConcurrency
 ) {}

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/DefaultArgs.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/DefaultArgs.java
@@ -11,6 +11,7 @@ public class DefaultArgs {
     private static String scratchSpaceRootPath;
     private static String hl7OutputPath;
     private static Integer splitAndUploadTimeout;
+    private static Integer splitAndUploadHeartbeatTimeout;
     private static Integer splitAndUploadConcurrency;
     private static String modalityMapPath;
     private static String reportTableName;
@@ -46,6 +47,14 @@ public class DefaultArgs {
     }
     public static Integer getSplitAndUploadTimeout(Integer input) {
         return getValueOrDefault(input, splitAndUploadTimeout);
+    }
+
+    @Value("${scout.workflowArgDefaults.ingestHl7Log.splitAndUploadHeartbeatTimeout}")
+    public void setSplitAndUploadHeartbeatTimeout(Integer splitAndUploadHeartbeatTimeout) {
+        DefaultArgs.splitAndUploadHeartbeatTimeout = splitAndUploadHeartbeatTimeout;
+    }
+    public static Integer getSplitAndUploadHeartbeatTimeout(Integer input) {
+        return getValueOrDefault(input, splitAndUploadHeartbeatTimeout);
     }
 
     @Value("${scout.workflowArgDefaults.ingestHl7Log.splitAndUploadConcurrency}")

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/IngestHl7LogWorkflowInputParser.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/util/IngestHl7LogWorkflowInputParser.java
@@ -50,6 +50,7 @@ public class IngestHl7LogWorkflowInputParser {
         String hl7OutputPath = DefaultArgs.getHl7OutputPath(input.hl7OutputPath());
 
         Integer splitAndUploadTimeout = DefaultArgs.getSplitAndUploadTimeout(input.splitAndUploadTimeout());
+        Integer splitAndUploadHeartbeatTimeout = DefaultArgs.getSplitAndUploadHeartbeatTimeout(input.splitAndUploadHeartbeatTimeout());
         Integer splitAndUploadConcurrency = DefaultArgs.getSplitAndUploadConcurrency(input.splitAndUploadConcurrency());
 
         // Do we have values?
@@ -77,7 +78,7 @@ public class IngestHl7LogWorkflowInputParser {
                 workflowInfo.getWorkflowId(), date, scheduledTimeUtc, scheduledTimeLocal, localTz
             );
             return new IngestHl7LogWorkflowParsedInput(
-                List.of(logsRootPath), date, scratchSpaceRootPath, logsRootPath, hl7OutputPath, splitAndUploadTimeout, splitAndUploadConcurrency
+                List.of(logsRootPath), date, scratchSpaceRootPath, logsRootPath, hl7OutputPath, splitAndUploadTimeout, splitAndUploadHeartbeatTimeout, splitAndUploadConcurrency
             );
         } else if (isScheduledRun) {
             // We are in a scheduled run without a root path. This is an error.
@@ -116,7 +117,7 @@ public class IngestHl7LogWorkflowInputParser {
         );
 
         return new IngestHl7LogWorkflowParsedInput(
-            logPaths, input.date(), scratchSpaceRootPath, logsRootPath, hl7OutputPath, splitAndUploadTimeout, splitAndUploadConcurrency
+            logPaths, input.date(), scratchSpaceRootPath, logsRootPath, hl7OutputPath, splitAndUploadTimeout, splitAndUploadHeartbeatTimeout, splitAndUploadConcurrency
         );
     }
 

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/workflow/IngestHl7LogWorkflowImpl.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/workflow/IngestHl7LogWorkflowImpl.java
@@ -19,6 +19,7 @@ import edu.washu.tag.extractor.hl7log.model.SplitAndTransformHl7LogInput;
 import edu.washu.tag.extractor.hl7log.model.SplitAndTransformHl7LogOutput;
 import edu.washu.tag.extractor.hl7log.util.AllOfPromiseOnlySuccesses;
 import edu.washu.tag.extractor.hl7log.util.IngestHl7LogWorkflowInputParser;
+import io.temporal.activity.ActivityCancellationType;
 import io.temporal.activity.ActivityOptions;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.ParentClosePolicy;
@@ -97,6 +98,9 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
                 ActivityOptions.newBuilder()
                     .setTaskQueue(CHILD_QUEUE)
                     .setStartToCloseTimeout(Duration.ofMinutes(parsedInput.splitAndUploadTimeout()))
+                    .setHeartbeatTimeout(Duration.ofMinutes(parsedInput.splitAndUploadHeartbeatTimeout()))
+                    .setCancellationType(ActivityCancellationType
+                        .WAIT_CANCELLATION_COMPLETED)
                     .setRetryOptions(RetryOptions.newBuilder()
                         .setMaximumInterval(Duration.ofSeconds(30))
                         .setMaximumAttempts(2)
@@ -165,6 +169,7 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
                     scratchSpaceRootPath,
                     input.hl7OutputPath(),
                     input.splitAndUploadTimeout(),
+                    input.splitAndUploadHeartbeatTimeout(),
                     input.splitAndUploadConcurrency(),
                     input.modalityMapPath(),
                     input.reportTableName(),

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/workflow/IngestHl7LogWorkflowImpl.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/workflow/IngestHl7LogWorkflowImpl.java
@@ -99,8 +99,7 @@ public class IngestHl7LogWorkflowImpl implements IngestHl7LogWorkflow {
                     .setTaskQueue(CHILD_QUEUE)
                     .setStartToCloseTimeout(Duration.ofMinutes(parsedInput.splitAndUploadTimeout()))
                     .setHeartbeatTimeout(Duration.ofMinutes(parsedInput.splitAndUploadHeartbeatTimeout()))
-                    .setCancellationType(ActivityCancellationType
-                        .WAIT_CANCELLATION_COMPLETED)
+                    .setCancellationType(ActivityCancellationType.WAIT_CANCELLATION_COMPLETED)
                     .setRetryOptions(RetryOptions.newBuilder()
                         .setMaximumInterval(Duration.ofSeconds(30))
                         .setMaximumAttempts(2)

--- a/extractor/hl7log-extractor/src/main/resources/application.yaml
+++ b/extractor/hl7log-extractor/src/main/resources/application.yaml
@@ -32,7 +32,7 @@ scout:
       scratchSpaceRootPath: ''
       hl7OutputPath: ''
       # Timeout (in minutes) for the entire log split and upload activity
-      splitAndUploadTimeout: 180
+      splitAndUploadTimeout: 480
       # Heartbeat timeout (in minutes) within the split and upload activity
       splitAndUploadHeartbeatTimeout: 30
       # This is to limit I/O contention during the split and upload operation (java worker) and to try to hit a sweet spot of efficiency

--- a/extractor/hl7log-extractor/src/main/resources/application.yaml
+++ b/extractor/hl7log-extractor/src/main/resources/application.yaml
@@ -31,8 +31,10 @@ scout:
       logsRootPath: ''
       scratchSpaceRootPath: ''
       hl7OutputPath: ''
-      # Timeout (in minutes) for log split and upload activity
+      # Timeout (in minutes) for the entire log split and upload activity
       splitAndUploadTimeout: 180
+      # Heartbeat timeout (in minutes) within the split and upload activity
+      splitAndUploadHeartbeatTimeout: 30
       # This is to limit I/O contention during the split and upload operation (java worker) and to try to hit a sweet spot of efficiency
       # during the delta lake insert (python worker). It's been tested on 1.3-1.4MB log files, as well as 15-45MB log files.
       splitAndUploadConcurrency: 150

--- a/extractor/hl7log-extractor/src/test/java/edu/washu/tag/extractor/hl7log/IngestHl7LogWorkflowInputParserTest.java
+++ b/extractor/hl7log-extractor/src/test/java/edu/washu/tag/extractor/hl7log/IngestHl7LogWorkflowInputParserTest.java
@@ -60,6 +60,8 @@ class IngestHl7LogWorkflowInputParserTest {
     private String defaultHl7OutputPath;
     @Value("${scout.workflowArgDefaults.ingestHl7Log.splitAndUploadTimeout}")
     private Integer defaultSplitAndUploadTimeout;
+    @Value("${scout.workflowArgDefaults.ingestHl7Log.splitAndUploadHeartbeatTimeout}")
+    private Integer defaultSplitAndUploadHeartbeatTimeout;
     @Value("${scout.workflowArgDefaults.ingestHl7Log.splitAndUploadConcurrency}")
     private Integer defaultSplitAndUploadConcurrency;
 
@@ -76,6 +78,7 @@ class IngestHl7LogWorkflowInputParserTest {
         assertEquals(defaultLogsRootPath, parsedInput.logsRootPath());
         assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());
         assertEquals(defaultSplitAndUploadTimeout, parsedInput.splitAndUploadTimeout());
+        assertEquals(defaultSplitAndUploadHeartbeatTimeout, parsedInput.splitAndUploadHeartbeatTimeout());
         assertEquals(defaultSplitAndUploadConcurrency, parsedInput.splitAndUploadConcurrency());
     }
 
@@ -95,6 +98,7 @@ class IngestHl7LogWorkflowInputParserTest {
             null,
             null,
             null,
+            null,
             null
         );
 
@@ -107,6 +111,7 @@ class IngestHl7LogWorkflowInputParserTest {
         assertEquals(logsRootPath, parsedInput.logsRootPath());
         assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());
         assertEquals(defaultSplitAndUploadTimeout, parsedInput.splitAndUploadTimeout());
+        assertEquals(defaultSplitAndUploadHeartbeatTimeout, parsedInput.splitAndUploadHeartbeatTimeout());
         assertEquals(defaultSplitAndUploadConcurrency, parsedInput.splitAndUploadConcurrency());
     }
 
@@ -115,6 +120,7 @@ class IngestHl7LogWorkflowInputParserTest {
         String date = "arbitrary-date";
         IngestHl7LogWorkflowInput input = new IngestHl7LogWorkflowInput(
             date,
+            null,
             null,
             null,
             null,
@@ -136,6 +142,7 @@ class IngestHl7LogWorkflowInputParserTest {
         assertEquals(defaultLogsRootPath, parsedInput.logsRootPath());
         assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());
         assertEquals(defaultSplitAndUploadTimeout, parsedInput.splitAndUploadTimeout());
+        assertEquals(defaultSplitAndUploadHeartbeatTimeout, parsedInput.splitAndUploadHeartbeatTimeout());
         assertEquals(defaultSplitAndUploadConcurrency, parsedInput.splitAndUploadConcurrency());
     }
 
@@ -160,6 +167,7 @@ class IngestHl7LogWorkflowInputParserTest {
         assertEquals(defaultLogsRootPath, parsedInput.logsRootPath());
         assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());
         assertEquals(defaultSplitAndUploadTimeout, parsedInput.splitAndUploadTimeout());
+        assertEquals(defaultSplitAndUploadHeartbeatTimeout, parsedInput.splitAndUploadHeartbeatTimeout());
         assertEquals(defaultSplitAndUploadConcurrency, parsedInput.splitAndUploadConcurrency());
     }
 
@@ -169,6 +177,7 @@ class IngestHl7LogWorkflowInputParserTest {
         IngestHl7LogWorkflowInput input = new IngestHl7LogWorkflowInput(
             null,
             logsRootPath,
+            null,
             null,
             null,
             null,
@@ -197,6 +206,7 @@ class IngestHl7LogWorkflowInputParserTest {
         assertEquals(logsRootPath, parsedInput.logsRootPath());
         assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());
         assertEquals(defaultSplitAndUploadTimeout, parsedInput.splitAndUploadTimeout());
+        assertEquals(defaultSplitAndUploadHeartbeatTimeout, parsedInput.splitAndUploadHeartbeatTimeout());
         assertEquals(defaultSplitAndUploadConcurrency, parsedInput.splitAndUploadConcurrency());
     }
 
@@ -217,6 +227,7 @@ class IngestHl7LogWorkflowInputParserTest {
             null,
             null,
             null,
+            null,
             null
         );
 
@@ -237,6 +248,7 @@ class IngestHl7LogWorkflowInputParserTest {
         assertEquals(logsRootPath, parsedInput.logsRootPath());
         assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());
         assertEquals(defaultSplitAndUploadTimeout, parsedInput.splitAndUploadTimeout());
+        assertEquals(defaultSplitAndUploadHeartbeatTimeout, parsedInput.splitAndUploadHeartbeatTimeout());
         assertEquals(defaultSplitAndUploadConcurrency, parsedInput.splitAndUploadConcurrency());
     }
 
@@ -244,6 +256,7 @@ class IngestHl7LogWorkflowInputParserTest {
     void testParseInput_splitAndUploadActivitySettings(IngestHl7LogWorkflowInputParserTestWorkflow workflow) {
         String date = "arbitrary-date";
         int timeout = 60;
+        int heartbeatTimeout = 15;
         int concurrency = 100;
         IngestHl7LogWorkflowInput input = new IngestHl7LogWorkflowInput(
             date,
@@ -252,6 +265,7 @@ class IngestHl7LogWorkflowInputParserTest {
             null,
             null,
             timeout,
+            heartbeatTimeout,
             concurrency,
             null,
             null,
@@ -268,6 +282,7 @@ class IngestHl7LogWorkflowInputParserTest {
         assertEquals(defaultLogsRootPath, parsedInput.logsRootPath());
         assertEquals(defaultHl7OutputPath, parsedInput.hl7OutputPath());
         assertEquals(timeout, parsedInput.splitAndUploadTimeout());
+        assertEquals(heartbeatTimeout, parsedInput.splitAndUploadHeartbeatTimeout());
         assertEquals(concurrency, parsedInput.splitAndUploadConcurrency());
     }
 }

--- a/extractor/hl7log-extractor/src/test/resources/application.yaml
+++ b/extractor/hl7log-extractor/src/test/resources/application.yaml
@@ -29,7 +29,7 @@ scout:
       logsRootPath: '/path/to/logs'
       scratchSpaceRootPath: '/path/to/scratch'
       hl7OutputPath: '/path/to/hl7/output'
-      splitAndUploadTimeout: 180
+      splitAndUploadTimeout: 480
       splitAndUploadHeartbeatTimeout: 30
       splitAndUploadConcurrency: 150
     ingestHl7ToDeltaLake:

--- a/extractor/hl7log-extractor/src/test/resources/application.yaml
+++ b/extractor/hl7log-extractor/src/test/resources/application.yaml
@@ -30,6 +30,7 @@ scout:
       scratchSpaceRootPath: '/path/to/scratch'
       hl7OutputPath: '/path/to/hl7/output'
       splitAndUploadTimeout: 180
+      splitAndUploadHeartbeatTimeout: 30
       splitAndUploadConcurrency: 150
     ingestHl7ToDeltaLake:
       deltaIngestTimeout: 60


### PR DESCRIPTION
# Add heartbeats to split and upload activity for fine-grained timeout and proper cancellation

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
When a temporal user cancels the `IngestHl7LogWorkflow`, the running split & upload activities now get cancelled, and this is reflected in the UI (first cancelation is requested, once the activities stop, it's marked as cancelled).

This also adds a heartbeat timeout, which I've defaulted to 30m but made adjustable via Ansible and as part of the input. The idea here is to have a more fine-grained read on whether an activity is still working (versus having to wait the whole `startToClose` timeout). As such, I've bumped up the default `startToClose` timeout for the split & upload activity to 8hrs, though this can still be adjusted via Ansible and as an input parameter.

### Technical
Added heartbeat calls. Cancellation causes the heartbeat method to throw an exception, which culminates in the activities all cancelling.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
This may have some impact on temporal performance, as now we're hitting the heartbeat API with a lot of information. I could heartbeat less often (right now, once per parsed message, plus around the aggregate activities like writing the manifest file), but then cancelation takes longer to "take effect". I will do some experimenting to see if I can find a good balance. Temporal does throttle heartbeat traffic to ameliorate this issue.

### Data
N/A

### Backward compatibility
No change

## Testing
Running CI, running 2023 from 8k test data on `big-04` and cancelling while tailing the logs. Then restarting 2023 and looking at Temporal metrics to see if we're seeing increased latencies due to the additional network traffic.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [x] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
