### PR TITLE
Write "success" status at the end of ingest

### DIFF
--- a/extractor/hl7-transformer/src/hl7scout/db.py
+++ b/extractor/hl7-transformer/src/hl7scout/db.py
@@ -39,13 +39,31 @@ def write_errors(
     hl7_files: list[str], error_message: str, workflow_id: str, activity_id: str
 ) -> None:
     """Write an error message to the database for a list of HL7 files."""
-    activity.logger.info("Writing errors to database for %d HL7 files", len(hl7_files))
-    # Prepare the rows to insert
+    write_status_to_db(hl7_files, "failed", error_message, workflow_id, activity_id)
+
+
+def write_successes(hl7_files: list[str], workflow_id: str, activity_id: str) -> None:
+    """Write a success status to the database for a list of HL7 files."""
+    write_status_to_db(hl7_files, "success", None, workflow_id, activity_id)
+
+
+def write_status_to_db(
+    hl7_files: list[str],
+    status: str,
+    error_message: str | None,
+    workflow_id: str,
+    activity_id: str,
+) -> None:
+    """Write an error message to the database for a list of HL7 files."""
+    activity.logger.info(
+        "Writing '%s' status to database for %d HL7 files", status, len(hl7_files)
+    )
+
     insert_rows = [
         (
             hl7_file,
             "HL7",
-            "failed",
+            status,
             error_message,
             workflow_id,
             activity_id,

--- a/tests/src/test/java/edu/washu/tag/tests/TestStatusDatabase.java
+++ b/tests/src/test/java/edu/washu/tag/tests/TestStatusDatabase.java
@@ -60,7 +60,7 @@ public class TestStatusDatabase extends BaseTest {
         final RecentHl7FileRow h1 = RecentHl7FileRow.staged("1995/04/02/09/199504020930172230.hl7", 1, date);
 
         runHl7FilesTest(
-            new Hl7FileTableQuery(date, workflows),
+            new Hl7FileTableQuery(date),
             h0.hl7FilesRow,
             h1.hl7FilesRow
         );
@@ -111,7 +111,7 @@ public class TestStatusDatabase extends BaseTest {
             logRow1
         );
 
-        runHl7FilesTest(new Hl7FileTableQuery(date, workflows));
+        runHl7FilesTest(new Hl7FileTableQuery(date));
         runHl7FileStatusTest(FileStatusHl7Query.tableQuery(date, workflows));
         runHl7FileStatusTest(FileStatusHl7Query.viewQuery(date, workflows));
 
@@ -174,7 +174,7 @@ public class TestStatusDatabase extends BaseTest {
         );
         // Three files
         runHl7FilesTest(
-            new Hl7FileTableQuery(date, ingestWorkflowIds),
+            new Hl7FileTableQuery(date),
             hl70,
             hl7Message1.hl7FilesRow,
             hl7Message2.hl7FilesRow
@@ -230,7 +230,7 @@ public class TestStatusDatabase extends BaseTest {
         );
 
         runHl7FilesTest(
-            new Hl7FileTableQuery(date, workflows),
+            new Hl7FileTableQuery(date),
             hl70,
             hl71
         );
@@ -325,7 +325,7 @@ public class TestStatusDatabase extends BaseTest {
             hl7Error
         );
         runHl7FilesTest(
-            new Hl7FileTableQuery(date, ingestWorkflowIds),
+            new Hl7FileTableQuery(date),
             hl7File
         );
         runRecentHl7FilesTest(new RecentHl7FilesViewQuery(date, ingestWorkflowIds),
@@ -351,7 +351,7 @@ public class TestStatusDatabase extends BaseTest {
         final RecentHl7FileRow h1 = RecentHl7FileRow.staged("1999/11/30/23/199911302311298376.hl7", 1, date);
 
         runHl7FilesTest(
-            new Hl7FileTableQuery(date, workflows),
+            new Hl7FileTableQuery(date),
             h0.hl7FilesRow,
             h1.hl7FilesRow
         );
@@ -656,8 +656,8 @@ public class TestStatusDatabase extends BaseTest {
     }
 
     private static class Hl7FileTableQuery extends SqlQuery {
-        private Hl7FileTableQuery(String logDate, List<String> filteredWorkflowIds) {
-            super(TABLE_HL7_FILES, LOG_FILE_PATH, logDate, filteredWorkflowIds);
+        private Hl7FileTableQuery(String logDate) {
+            super(TABLE_HL7_FILES, LOG_FILE_PATH, logDate, Collections.emptyList());
         }
 
         @Override


### PR DESCRIPTION
## Type of change
- [ ] Work behind a feature flag
- [X] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

Write a `"success"` message to the ingest database for HL7 files which get fully ingested into delta lake.

## Impact

### Security 
N/A

### Performance
This will make the python spark ingest activity take a bit longer. I don't know exactly how much longer. But there is some increased risk of the activity hitting the timeout and getting canceled.

### Data
N/A

### Backward compatibility
N/A

## Testing
Updated the integration tests to check the new `"success"` status.

## Note for reviewers
I haven't updated the grafana ingest dashboard to account for this new information.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [X] I have added end-to-end tests, unless this is a documentation-only PR.
