### PR TITLE
Use walkFileTree to handle errors during directory walk

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
   push:
-    branches: [main]
+    branches: [main, fix-scheduled]
 
 env:
   JAVA_DIST: 'zulu'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
   push:
-    branches: [main, fix-scheduled]
+    branches: [main]
 
 env:
   JAVA_DIST: 'zulu'

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/activity/FindHl7LogsActivityImpl.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/activity/FindHl7LogsActivityImpl.java
@@ -179,16 +179,13 @@ public class FindHl7LogsActivityImpl implements FindHl7LogsActivity {
                         );
                         return Collections.<String>emptyList();
                     }
-                } else if (Files.isRegularFile(logPath)) {
+                } else {
+                    // If a user has passed a file, don't filter for anything but date (if they've passed a file plus a mismatched date,
+                    // they should get an error)
                     String fileName = logPath.getFileName().toString();
-                    if (logFileFilter.test(fileName)) {
+                    if (dateFilter.test(fileName)) {
                         matchingLogs.add(logPath.toString());
                     }
-                } else {
-                    logger.warn(
-                        "WorkflowId {} ActivityId {} - Path is neither a directory nor a regular file: {}",
-                        activityInfo.getWorkflowId(), activityInfo.getActivityId(), logPathString
-                    );
                 }
                 return matchingLogs;
             })

--- a/extractor/hl7log-extractor/src/test/java/edu/washu/tag/extractor/hl7log/FindLogFileTest.java
+++ b/extractor/hl7log-extractor/src/test/java/edu/washu/tag/extractor/hl7log/FindLogFileTest.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Set;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,17 +37,16 @@ class FindLogFileTest {
             .setActivityImplementations(new FindHl7LogsActivityImpl(fileHandler))
             .build();
 
-    private Path match;
-    private Path mismatch;
-    private Path hidden;
-    private Path notLog;
+    private final String date = "20250105";
+    private Path matchingDateLog;
+    private Path alernativeDateLog;
 
     @BeforeEach
     void setUp() throws IOException {
-        match = Files.createFile(tempDir.resolve("20250105.log"));
-        mismatch = Files.createFile(tempDir.resolve("20250106.log"));
-        hidden = Files.createFile(tempDir.resolve(".20250105.log.asef"));
-        notLog = Files.createFile(tempDir.resolve("20250105.txt"));
+        matchingDateLog = Files.createFile(tempDir.resolve(date + ".log"));
+        alernativeDateLog = Files.createFile(tempDir.resolve("20250106.log"));
+        Files.createFile(tempDir.resolve("." + date + ".log.asef"));
+        Files.createFile(tempDir.resolve("20250105.txt"));
     }
 
     @Test
@@ -63,8 +61,7 @@ class FindLogFileTest {
 
         FindHl7LogFileOutput out = activityStub.findHl7LogFiles(input);
 
-        assertThat(out.logFiles(), Matchers.containsInAnyOrder(List.of(match.toString(), mismatch.toString()),
-            "Only log files should be returned"));
+        assertThat(out.logFiles(), Matchers.containsInAnyOrder(matchingDateLog.toString(), alernativeDateLog.toString()));
         assertNull(out.continued(), "No Continue-As-New because file count < concurrency");
     }
 
@@ -72,7 +69,7 @@ class FindLogFileTest {
     void testFindLogFiles_excludesFilesCorrectlyWithDate(FindHl7LogsActivity activityStub) {
         FindHl7LogFileInput input = new FindHl7LogFileInput(
             List.of(tempDir.toString()),
-            "20250105",
+            date,
             null,
             null,
             Integer.MAX_VALUE
@@ -80,31 +77,7 @@ class FindLogFileTest {
 
         FindHl7LogFileOutput out = activityStub.findHl7LogFiles(input);
 
-        assertEquals(List.of(match.toString()), out.logFiles(), "Only the matching date file should be returned");
-        assertNull(out.continued(), "No Continue-As-New because file count < concurrency");
-    }
-
-    @Test
-    void testFindLogFiles_visitFileFailed(FindHl7LogsActivity activityStub) throws Exception {
-        // File that will raise AccessDeniedException
-        Path noPerms = Files.createFile(tempDir.resolve("privateFile"));
-        Files.setPosixFilePermissions(noPerms, Set.of());   // chmod 000
-
-        // Dir that will raise AccessDeniedException
-        Path noPermsDir = Files.createFile(tempDir.resolve("privateDir"));
-        Files.setPosixFilePermissions(noPermsDir, Set.of());   // chmod 000
-
-        FindHl7LogFileInput input = new FindHl7LogFileInput(
-            List.of(tempDir.toString()),
-            "20250105",
-            null,
-            null,
-            Integer.MAX_VALUE
-        );
-
-        FindHl7LogFileOutput out = activityStub.findHl7LogFiles(input);
-
-        assertEquals(List.of(match.toString()), out.logFiles(), "Only the matching date file should be returned");
+        assertEquals(List.of(matchingDateLog.toString()), out.logFiles(), "Only the matching date file should be returned");
         assertNull(out.continued(), "No Continue-As-New because file count < concurrency");
     }
 }

--- a/extractor/hl7log-extractor/src/test/java/edu/washu/tag/extractor/hl7log/FindLogFileTest.java
+++ b/extractor/hl7log-extractor/src/test/java/edu/washu/tag/extractor/hl7log/FindLogFileTest.java
@@ -1,0 +1,110 @@
+package edu.washu.tag.extractor.hl7log;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import edu.washu.tag.extractor.hl7log.activity.FindHl7LogsActivity;
+import edu.washu.tag.extractor.hl7log.activity.FindHl7LogsActivityImpl;
+import edu.washu.tag.extractor.hl7log.model.FindHl7LogFileInput;
+import edu.washu.tag.extractor.hl7log.model.FindHl7LogFileOutput;
+import edu.washu.tag.extractor.hl7log.util.FileHandler;
+import io.temporal.testing.TestActivityExtension;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class FindLogFileTest {
+
+    @TempDir Path tempDir;
+
+    // FileHandler is required by the activity but not used in this scenario
+    private static final FileHandler fileHandler = Mockito.mock(FileHandler.class);
+
+    @RegisterExtension
+    static final TestActivityExtension activityExt =
+        TestActivityExtension.newBuilder()
+            .setActivityImplementations(new FindHl7LogsActivityImpl(fileHandler))
+            .build();
+
+    private Path match;
+    private Path mismatch;
+    private Path hidden;
+    private Path notLog;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        match = Files.createFile(tempDir.resolve("20250105.log"));
+        mismatch = Files.createFile(tempDir.resolve("20250106.log"));
+        hidden = Files.createFile(tempDir.resolve(".20250105.log.asef"));
+        notLog = Files.createFile(tempDir.resolve("20250105.txt"));
+    }
+
+    @Test
+    void testFindLogFiles_excludesFilesCorrectly(FindHl7LogsActivity activityStub) {
+        FindHl7LogFileInput input = new FindHl7LogFileInput(
+            List.of(tempDir.toString()),
+            null,
+            null,
+            null,
+            Integer.MAX_VALUE
+        );
+
+        FindHl7LogFileOutput out = activityStub.findHl7LogFiles(input);
+
+        assertThat(out.logFiles(), Matchers.containsInAnyOrder(List.of(match.toString(), mismatch.toString()),
+            "Only log files should be returned"));
+        assertNull(out.continued(), "No Continue-As-New because file count < concurrency");
+    }
+
+    @Test
+    void testFindLogFiles_excludesFilesCorrectlyWithDate(FindHl7LogsActivity activityStub) {
+        FindHl7LogFileInput input = new FindHl7LogFileInput(
+            List.of(tempDir.toString()),
+            "20250105",
+            null,
+            null,
+            Integer.MAX_VALUE
+        );
+
+        FindHl7LogFileOutput out = activityStub.findHl7LogFiles(input);
+
+        assertEquals(List.of(match.toString()), out.logFiles(), "Only the matching date file should be returned");
+        assertNull(out.continued(), "No Continue-As-New because file count < concurrency");
+    }
+
+    @Test
+    void testFindLogFiles_visitFileFailed(FindHl7LogsActivity activityStub) throws Exception {
+        // File that will raise AccessDeniedException
+        Path noPerms = Files.createFile(tempDir.resolve("privateFile"));
+        Files.setPosixFilePermissions(noPerms, Set.of());   // chmod 000
+
+        // Dir that will raise AccessDeniedException
+        Path noPermsDir = Files.createFile(tempDir.resolve("privateDir"));
+        Files.setPosixFilePermissions(noPermsDir, Set.of());   // chmod 000
+
+        FindHl7LogFileInput input = new FindHl7LogFileInput(
+            List.of(tempDir.toString()),
+            "20250105",
+            null,
+            null,
+            Integer.MAX_VALUE
+        );
+
+        FindHl7LogFileOutput out = activityStub.findHl7LogFiles(input);
+
+        assertEquals(List.of(match.toString()), out.logFiles(), "Only the matching date file should be returned");
+        assertNull(out.continued(), "No Continue-As-New because file count < concurrency");
+    }
+}


### PR DESCRIPTION
# Use walkFileTree to handle errors during directory walk

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer. 

For all other change types, the developer should attempt to provide as much detail as is reasonable.

## Description

### Product
N/A

### Technical
Catch exceptions that can happen during directory walk due to an ongoing sync operation making temporary lockfiles (or other such issues).

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
I don't think this will have a significant performance impact, but I didn't dig in to the internals of walk vs walkFileTree.

### Data
N/A

### Backward compatibility
No issues

## Testing
Running CI

## Note for reviewers
I added a couple unit tests for this part of the code. I wanted to try some TDD, but I couldn't easily recreate the exception we were seeing (was starting to get into needing to mock private methods within FileTreeIterator, which wouldn't necessarily even be relevant for different code), so I decided to forgo that effort.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [x] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
