### PR TITLE
Set Grafana Default Home Dashboard

### DIFF
--- a/ansible/playbooks/templates/grafana/grafana.values.yaml.j2
+++ b/ansible/playbooks/templates/grafana/grafana.values.yaml.j2
@@ -10,6 +10,8 @@ grafana.ini:
     serve_from_sub_path: true
   metrics:
     enabled: true
+  dashboards:
+    default_home_dashboard_path: /tmp/dashboards/hl7-ingest-dashboard.json
 {% if grafana_alert_contact_point == 'email' %}
   smtp:
     enabled: true


### PR DESCRIPTION
# Set Grafana Default Home Dashboard

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product / Technical
Set the HL7 Ingest dashboard as the Grafana homepage default.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
Yes, it is backward compatible.

## Testing
Tested on big-02. The HL7 Ingest dashboard is now the home screen default.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
