### PR TITLE
Distinguish "success" and "staged" in ingest dashboard

### DIFF
--- a/ansible/playbooks/files/grafana/dashboards/hl7-ingest-dashboard.json
+++ b/ansible/playbooks/files/grafana/dashboards/hl7-ingest-dashboard.json
@@ -567,7 +567,7 @@
     "list": []
   },
   "time": {
-    "from": "now-90d",
+    "from": "now-30d",
     "to": "now"
   },
   "timepicker": {},

--- a/ansible/playbooks/files/grafana/dashboards/hl7-ingest-dashboard.json
+++ b/ansible/playbooks/files/grafana/dashboards/hl7-ingest-dashboard.json
@@ -109,7 +109,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  date_trunc('day', date) AS time,\n  COUNT(*)                AS count\nFROM recent_hl7_files\nWHERE $__timeFilter(date)\n  AND status != 'failed'\nGROUP BY 1\nORDER BY 1;",
+          "rawSql": "WITH date_series AS (\n  SELECT generate_series(\n    $__timeFrom()::date,\n    $__timeTo()::date,\n    '1 day'::interval\n  )::date AS date\n),\ncounts AS (\n  SELECT \n    date,\n    COUNT(*) as count\n  FROM recent_hl7_files\n  WHERE status != 'failed'\n  AND date BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  GROUP BY date\n)\nSELECT \n  TO_CHAR(date_series.date, 'YYYY-MM-DD') as date,\n  COALESCE(counts.count, 0) as files\nFROM date_series\nLEFT JOIN counts ON date_series.date = counts.date\nORDER BY date_series.date;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -199,7 +199,7 @@
           "showLegend": false
         },
         "orientation": "auto",
-        "showValue": "never",
+        "showValue": "always",
         "stacking": "none",
         "tooltip": {
           "hideZeros": false,
@@ -219,7 +219,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  date_trunc('day', date) AS time,\n  COUNT(*)                AS count\nFROM recent_hl7_files\nWHERE $__timeFilter(date)\n  AND status = 'failed'\nGROUP BY 1\nORDER BY 1;",
+          "rawSql": "WITH date_series AS (\n  SELECT generate_series(\n    $__timeFrom()::date,\n    $__timeTo()::date,\n    '1 day'::interval\n  )::date AS date\n),\ncounts AS (\n  SELECT \n    date,\n    COUNT(*) as count\n  FROM recent_hl7_files\n  WHERE status = 'failed'\n  AND date BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  GROUP BY date\n)\nSELECT \n  TO_CHAR(date_series.date, 'YYYY-MM-DD') as date,\n  COALESCE(counts.count, 0) as files\nFROM date_series\nLEFT JOIN counts ON date_series.date = counts.date\nORDER BY date_series.date;",
           "refId": "A",
           "sql": {
             "columns": [

--- a/ansible/playbooks/files/grafana/dashboards/hl7-ingest-dashboard.json
+++ b/ansible/playbooks/files/grafana/dashboards/hl7-ingest-dashboard.json
@@ -30,7 +30,7 @@
         "defaults": {
           "color": {
             "fixedColor": "green",
-            "mode": "fixed"
+            "mode": "palette-classic"
           },
           "custom": {
             "axisBorderShow": false,
@@ -55,7 +55,6 @@
             }
           },
           "decimals": 0,
-          "displayName": "Files",
           "mappings": [],
           "min": 0,
           "thresholds": {
@@ -109,7 +108,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH date_series AS (\n  SELECT generate_series(\n    $__timeFrom()::date,\n    $__timeTo()::date,\n    '1 day'::interval\n  )::date AS date\n),\ncounts AS (\n  SELECT \n    date,\n    COUNT(*) as count\n  FROM recent_hl7_files\n  WHERE status != 'failed'\n  AND date BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  GROUP BY date\n)\nSELECT \n  date_series.date as date,\n  COALESCE(counts.count, 0) as files\nFROM date_series\nLEFT JOIN counts ON date_series.date = counts.date\nORDER BY date_series.date;",
+          "rawSql": "WITH date_series AS (\n  SELECT generate_series(\n    $__timeFrom()::date,\n    $__timeTo()::date,\n    '1 day'::interval\n  )::date AS date\n),\ncounts AS (\n  SELECT \n    date,\n    status,\n    COUNT(*) as count\n  FROM recent_hl7_files\n  WHERE status != 'failed'\n  AND date BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  GROUP BY date, status\n)\nSELECT \n  date_series.date as date,\n  counts.status as status,\n  COALESCE(counts.count, 0) as files\nFROM date_series\nLEFT JOIN counts ON date_series.date = counts.date\nORDER BY date_series.date;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -144,6 +143,23 @@
               }
             ],
             "fields": {}
+          }
+        },
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "status",
+            "emptyValue": "zero",
+            "rowField": "date",
+            "valueField": "files"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": ["date\\status", "success", "staged"]
+            }
           }
         }
       ],

--- a/ansible/playbooks/files/grafana/dashboards/hl7-ingest-dashboard.json
+++ b/ansible/playbooks/files/grafana/dashboards/hl7-ingest-dashboard.json
@@ -109,7 +109,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH date_series AS (\n  SELECT generate_series(\n    $__timeFrom()::date,\n    $__timeTo()::date,\n    '1 day'::interval\n  )::date AS date\n),\ncounts AS (\n  SELECT \n    date,\n    COUNT(*) as count\n  FROM recent_hl7_files\n  WHERE status != 'failed'\n  AND date BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  GROUP BY date\n)\nSELECT \n  TO_CHAR(date_series.date, 'YYYY-MM-DD') as date,\n  COALESCE(counts.count, 0) as files\nFROM date_series\nLEFT JOIN counts ON date_series.date = counts.date\nORDER BY date_series.date;",
+          "rawSql": "WITH date_series AS (\n  SELECT generate_series(\n    $__timeFrom()::date,\n    $__timeTo()::date,\n    '1 day'::interval\n  )::date AS date\n),\ncounts AS (\n  SELECT \n    date,\n    COUNT(*) as count\n  FROM recent_hl7_files\n  WHERE status != 'failed'\n  AND date BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  GROUP BY date\n)\nSELECT \n  date_series.date as date,\n  COALESCE(counts.count, 0) as files\nFROM date_series\nLEFT JOIN counts ON date_series.date = counts.date\nORDER BY date_series.date;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -131,6 +131,22 @@
         }
       ],
       "title": "HL7 Files Ingested",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "dateFormat": "YYYY-MM-DD",
+                "destinationType": "string",
+                "targetField": "date",
+                "timezone": "utc"
+              }
+            ],
+            "fields": {}
+          }
+        }
+      ],
       "type": "barchart"
     },
     {
@@ -219,7 +235,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH date_series AS (\n  SELECT generate_series(\n    $__timeFrom()::date,\n    $__timeTo()::date,\n    '1 day'::interval\n  )::date AS date\n),\ncounts AS (\n  SELECT \n    date,\n    COUNT(*) as count\n  FROM recent_hl7_files\n  WHERE status = 'failed'\n  AND date BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  GROUP BY date\n)\nSELECT \n  TO_CHAR(date_series.date, 'YYYY-MM-DD') as date,\n  COALESCE(counts.count, 0) as files\nFROM date_series\nLEFT JOIN counts ON date_series.date = counts.date\nORDER BY date_series.date;",
+          "rawSql": "WITH date_series AS (\n  SELECT generate_series(\n    $__timeFrom()::date,\n    $__timeTo()::date,\n    '1 day'::interval\n  )::date AS date\n),\ncounts AS (\n  SELECT \n    date,\n    COUNT(*) as count\n  FROM recent_hl7_files\n  WHERE status = 'failed'\n  AND date BETWEEN $__timeFrom()::date AND $__timeTo()::date\n  GROUP BY date\n)\nSELECT \n  date_series.date as date,\n  COALESCE(counts.count, 0) as files\nFROM date_series\nLEFT JOIN counts ON date_series.date = counts.date\nORDER BY date_series.date;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -241,6 +257,12 @@
         }
       ],
       "title": "HL7 Ingest Errors (Log Scale)",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {}
+        }
+      ],
       "type": "barchart"
     },
     {


### PR DESCRIPTION
## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
In the HL7 Ingest Grafana dashboard, show different non-failed ingest statuses—namely "success" and "staged"—as different colors in a stacked bar chart.

<img width="1181" alt="Screenshot 2025-05-14 at 11 42 26 AM" src="https://github.com/user-attachments/assets/11d532e1-7493-4d10-9fce-e04c101c7600" />

### Technical
- Added `status` column to ingest dashboard query
- Added post-query transformation to pivot the status values to columns
- Changed the color scheme to show the status column values in different colors

Also, I reverted the dashboard query back to an earlier form that first generates a date series for all days in the user-selected range then joins that to the data of interest. With the current query I was not seeing any gaps in the chart for missing days, I was only seeing bars for the days that had data that expanded to fill the whole width.

## Impact

### Security 
N/A

### Performance
The postgres queries we're running to generate the charts may have a high cost. I plan to follow up this PR by investigating the query performance and how we get the chart data to grafana.

### Data
N/A

### Backward compatibility
This is hopefully forward compatible. I didn't hard-code the status values anywhere, so if we add more statuses the chart should display them as-is.

## Testing
Deployed to big-03 with ansible, manual inspection

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
