### PR TITLE
Optimize db write from python worker

### DIFF
--- a/extractor/hl7-transformer/src/hl7scout/db.py
+++ b/extractor/hl7-transformer/src/hl7scout/db.py
@@ -61,11 +61,13 @@ def write_status_to_db(
     with psycopg.connect(**get_db_connection_args()) as conn, conn.cursor() as cursor:
         with cursor.copy(FILE_STATUSES_COPY_SQL) as copy:
             for hl7_file in hl7_files:
-                copy.write_row([
-                    hl7_file,
-                    "HL7",
-                    status,
-                    error_message,
-                    workflow_id,
-                    activity_id,
-                ])
+                copy.write_row(
+                    [
+                        hl7_file,
+                        "HL7",
+                        status,
+                        error_message,
+                        workflow_id,
+                        activity_id,
+                    ]
+                )

--- a/extractor/hl7-transformer/src/hl7scout/db.py
+++ b/extractor/hl7-transformer/src/hl7scout/db.py
@@ -53,7 +53,7 @@ def write_status_to_db(
     workflow_id: str,
     activity_id: str,
 ) -> None:
-    """Write status to the database using bulk COPY for maximum performance."""
+    """Write status to the database for a list of HL7 files (use COPY for improved performance)."""
     activity.logger.info(
         "Writing '%s' status to database for %d HL7 files", status, len(hl7_files)
     )

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/db/IngestDbServiceImpl.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/db/IngestDbServiceImpl.java
@@ -10,7 +10,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.IntStream;
 import org.slf4j.Logger;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
@@ -85,7 +84,6 @@ public class IngestDbServiceImpl implements IngestDbService {
         if (fileStatuses == null || fileStatuses.isEmpty()) {
             return;
         }
-
         if (logger.isDebugEnabled()) {
             logger.debug("WorkflowId {} ActivityId {} - Inserting {} file status records into database",
                 fileStatuses.getFirst().workflowId(), fileStatuses.getFirst().activityId(), fileStatuses.size());


### PR DESCRIPTION
# Optimize db write from python worker

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
No product-facing changes

### Technical
Swap from batch insert to COPY. See [this article](https://www.timescale.com/learn/testing-postgres-ingest-insert-vs-batch-insert-vs-copy) for more information and benchmarks. Also, from [psycopg3 docs](https://www.psycopg.org/psycopg3/docs/api/cursors.html#psycopg.Cursor.executemany):
>This is more efficient than performing separate queries, but in case of several INSERT (and with some SQL creativity for massive UPDATE too) you may consider using [copy()](https://www.psycopg.org/psycopg3/docs/api/cursors.html#psycopg.Cursor.copy).

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
This change takes the "success status" insert from python worker from 90min down to 10min (prior to postgres optimizations).

### Data
N/A

### Backward compatibility
Yes

## Testing
Run the 15M reports on `big-04`

## Note for reviewers
This is much less necessary than before the postgres optimizations, but still a good improvement - using the right tool for the job.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
