### PR TITLE
Fix null timestamps

### DIFF
--- a/extractor/hl7-transformer/src/hl7scout/hl7extractor/deltalake.py
+++ b/extractor/hl7-transformer/src/hl7scout/hl7extractor/deltalake.py
@@ -332,9 +332,9 @@ def import_hl7_files_to_deltalake(
                 *[
                     F.to_timestamp(
                         F.when(
-                            F.length(timestamp_col) == 12,
-                            F.concat(timestamp_col, F.lit("00")),
-                        ).otherwise(timestamp_col),
+                            F.length(F.col(timestamp_col)) == 12,
+                            F.concat(F.col(timestamp_col), F.lit("00")),
+                        ).otherwise(F.col(timestamp_col)),
                         "yyyyMMddHHmmss",
                     ).alias(alias)
                     for timestamp_col, alias in (

--- a/tests/src/test/resources/spark_queries.json
+++ b/tests/src/test/resources/spark_queries.json
@@ -278,6 +278,20 @@
       },
       "sql": "SELECT * FROM syntheticdata WHERE message_control_id IN ('2.25.155851373268730741395170003437433181776', '2.25.143467293620292044279751197905759993120')",
       "id": "report_text"
+    },
+    {
+      "expectedQueryResult": {
+        "type": ".GroupedAggregationResult",
+        "primaryColumnName": "dummy",
+        "secondaryColumns": ["null_message_dt_count"],
+        "result": {
+          "dummy": {
+            "null_message_dt_count": 0
+          }
+        }
+      },
+      "sql": "SELECT 'dummy', COUNT(*) as null_message_dt_count FROM syntheticdata WHERE message_dt IS NULL",
+      "id": "null_message_dt"
     }
   ]
 }


### PR DESCRIPTION

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
Timestamp columns (`message_dt`, `requested_dt`, `observation_dt`, `observation_end_dt`, and `results_report_status_change_dt`) are no longer null when their source HL7 data is non-null.

Added test to verify `message_dt` is not null for any ingested test data.

### Technical
When parsing timestamp columns, correctly reference column using spark `col(...)` function instead of just column name string.

## Testing
Ran the CI test suite on big-03. Manually queried table data in jupyter notebook; verified timestamps aren't all null.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [X] I have added end-to-end tests, unless this is a documentation-only PR.
