### PR TITLE
PostgreSQL Tuning

### DIFF
--- a/ansible/playbooks/postgres.yaml
+++ b/ansible/playbooks/postgres.yaml
@@ -84,10 +84,10 @@
             resources:
               requests:
                 cpu: 4
-                memory: 16Gi
+                memory: 32Gi
               limits:
                 cpu: 6
-                memory: 24Gi
+                memory: 64Gi
             enableSuperuserAccess: true
             superuserSecret:
               name: superuser-secret
@@ -95,15 +95,15 @@
               parameters:
                 # Strings only, no numbers allowed
                 max_connections: '100'
-                shared_buffers: '4GB'
-                effective_cache_size: '12GB'
+                shared_buffers: '8GB'
+                effective_cache_size: '24GB'
                 maintenance_work_mem: '2GB'
                 checkpoint_completion_target: '0.9'
                 wal_buffers: '16MB'
                 default_statistics_target: '500'
                 random_page_cost: '4'
                 effective_io_concurrency: '1'
-                work_mem: '20164kB'
+                work_mem: '40329kB'
                 huge_pages: 'off'
                 min_wal_size: '4GB'
                 max_wal_size: '16GB'

--- a/ansible/playbooks/postgres.yaml
+++ b/ansible/playbooks/postgres.yaml
@@ -81,9 +81,36 @@
             storage:
               storageClass: postgres-storage
               size: 100Mi
+            resources:
+              requests:
+                cpu: 4
+                memory: 16Gi
+              limits:
+                cpu: 6
+                memory: 24Gi
             enableSuperuserAccess: true
             superuserSecret:
               name: superuser-secret
+            postgresql:
+              parameters:
+                # Strings only, no numbers allowed
+                max_connections: '100'
+                shared_buffers: '4GB'
+                effective_cache_size: '12GB'
+                maintenance_work_mem: '2GB'
+                checkpoint_completion_target: '0.9'
+                wal_buffers: '16MB'
+                default_statistics_target: '500'
+                random_page_cost: '4'
+                effective_io_concurrency: '1'
+                work_mem: '20164kB'
+                huge_pages: 'off'
+                min_wal_size: '4GB'
+                max_wal_size: '16GB'
+                max_worker_processes: '4'
+                max_parallel_workers_per_gather: '2'
+                max_parallel_workers: '4'
+                max_parallel_maintenance_workers: '2'
             bootstrap:
               initdb:
                 database: '{{ ingest_postgres_table_name }}'

--- a/ansible/playbooks/templates/grafana/alerts/high-postgres-transaction-times-alert.json.j2
+++ b/ansible/playbooks/templates/grafana/alerts/high-postgres-transaction-times-alert.json.j2
@@ -42,7 +42,7 @@
                   {
                     "evaluator": {
                       "params": [
-                        90
+                        240
                       ],
                       "type": "gt"
                     },
@@ -73,7 +73,7 @@
           ],
           "noDataState": "KeepLast",
           "execErrState": "KeepLast",
-          "for": "10m",
+          "for": "1m",
           "annotations": {
             "description": "{% raw %}High Postgres transaction times for user {{ $labels.usename }} and database {{ $labels.datname }}{% endraw %}",
             "summary": "{% raw %}High Postgres transaction times for user {{ $labels.usename }} and database {{ $labels.datname }}. Longest transaction time currently {{ printf \"%.2f\" $values.A.Value }} seconds.{% endraw %}"

--- a/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/workflow/RefreshIngestDbViewsWorkflowImpl.java
+++ b/extractor/hl7log-extractor/src/main/java/edu/washu/tag/extractor/hl7log/workflow/RefreshIngestDbViewsWorkflowImpl.java
@@ -1,15 +1,15 @@
 package edu.washu.tag.extractor.hl7log.workflow;
 
-import static edu.washu.tag.extractor.hl7log.util.Constants.REFRESH_VIEWS_QUEUE;
+import java.time.Duration;
 
 import edu.washu.tag.extractor.hl7log.activity.RefreshIngestDbViewsActivity;
 import edu.washu.tag.extractor.hl7log.model.RefreshIngestDbViewsInput;
 import edu.washu.tag.extractor.hl7log.model.RefreshIngestDbViewsOutput;
+import static edu.washu.tag.extractor.hl7log.util.Constants.REFRESH_VIEWS_QUEUE;
 import io.temporal.activity.ActivityOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.spring.boot.WorkflowImpl;
 import io.temporal.workflow.Workflow;
-import java.time.Duration;
 
 @WorkflowImpl(taskQueues = REFRESH_VIEWS_QUEUE)
 public class RefreshIngestDbViewsWorkflowImpl implements RefreshIngestDbViewsWorkflow {
@@ -17,9 +17,9 @@ public class RefreshIngestDbViewsWorkflowImpl implements RefreshIngestDbViewsWor
     private final RefreshIngestDbViewsActivity refreshIngestDbViewsActivity =
         Workflow.newActivityStub(RefreshIngestDbViewsActivity.class,
             ActivityOptions.newBuilder()
-                .setStartToCloseTimeout(Duration.ofMinutes(10))
+                .setStartToCloseTimeout(Duration.ofHours(3))
                 .setRetryOptions(RetryOptions.newBuilder()
-                    .setMaximumInterval(Duration.ofSeconds(1))
+                    .setMaximumInterval(Duration.ofSeconds(60))
                     .setMaximumAttempts(3)
                     .build())
                 .build());


### PR DESCRIPTION
# PostgreSQL Tuning

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
- PostgreSQL tuning for performance
- Added resource requests and limits for PG cluster
- Aligned the alert threshold for long PostgreSQL transaction times with the timeouts used in the hl7log-extractor.
- Increased timeouts for the RefreshIngestDbViewsWorkflow.

### Technical
- PostgreSQL configuration tuning based on recommendations from [PostgresqlCO.NF](https://postgresqlco.nf/) and [PGTune](https://pgtune.leopard.in.ua/?dbVersion=17&osType=linux&dbType=dw&cpuNum=4&totalMemory=32&totalMemoryUnit=GB&connectionNum=100&hdType=hdd). The suggestions from both tools were generally consistent.
- Testing was done on big-02 to determine CPU and memory allocations.
- We are still experiencing issues with long-running `RefreshIngestDbViewsWorkflow`s. For now, we are increasing the timeout and plan to revisit this in a future PR.

My notes on each PG setting:
- `max_connections`: Explicitly set to 100 for clarity and alignment with PG Tune recommendations.
- `shared_buffers`: Sets the amount of memory the database server uses for shared memory buffers. Conventional wisdom suggests 25% of the RAM. Do your own benchmarks varying this parameter. If you are into hundreds of GBs, consider setting up huge pages. Adjust accordingly for non-dedicated servers, considering that each Postgres instance will reserve its own memory allocations. This variable is in direct relation with OS kernel parameters `shmmax` and `shmall`. *If we request 32gb of RAM then that is 8GB and this aligns with the PGTune recommendation. Currently set to 128MB*
- `effective_cache_size`: Sets the planner's assumption about the total size of the data caches. Set it to (approximately): system RAM - (shared_buffers + work_mem * max_connections * 2) * 1.1, or a lower value if the server is not dedicated exclusively to PostgreSQL. Note that this setting does not affect the amount of physical RAM used by queries. *24GB was suggested by PGTune. So 32GB (requested) - (8 gb + ...)1.1 is about 24GB. Currently set to 4GB*
- `maintenance_work_mem`:  Sets the maximum memory to be used for maintenance operations. Increasing this value will speed up maintenance tasks such as VACUUM and index rebuilds, therefore it is recommended to raise it notably with large RAM resources and write operations. Note that this is -unless directly controlled by autovacuum_work_mem- also the amount of memory *each* autovacuum workers might use. *2GB is suggested by PGTune. Currently set to 65536kb*
- `checkpoint_completion_target`: Raise it to smooth I/O activity of checkpoints over larger periods of time. If you rely on this value for feeding non-streaming replicas, it is recommended to keep this within a low percentage. On development instances, it is usual to set it to ‘0.9’. *Sticking with the default and PGTune recommend 0.9.* 
- `wal_buffers`: Sets the number of disk-page buffers in shared memory for WAL. The amount of shared memory used for WAL data that has not yet been written to disk. The default setting of -1 selects a size equal to 1/32nd (about 3%) of [shared_buffers](https://postgresqlco.nf/doc/en/param/shared_buffers/), but not less than `64kB` nor more than the size of one WAL segment, typically `16MB`. *16MB is has high as we can go. Currently set to 512kb*
- `default_statistics_target`: Raise this value if you have large tables. Understand well the effects on raising this value. Medium-sized systems typically do well with values around 200 and large systems may need to increase it to 500 or 1000. *PGTune selected 500 because we are a 'data warehouse'. Default and current value is 100.*
`random_page_cost`: Set it to 1.x (e.g. ‘1.2’) if your disk technology has a random access profile similar to that of SSDs. 4 is the default.
- `effective_io_concurrency`: Number of simultaneous requests that can be handled efficiently by the disk subsystem. Sets the number of concurrent disk I/O operations that PostgreSQL expects can be executed simultaneously. Raising this value will increase the number of I/O operations that any individual PostgreSQL session attempts to initiate in parallel. The allowed range is 1 to 1000, or zero to disable issuance of asynchronous I/O requests. Currently, this setting only affects bitmap heap scans.
- *`random_page_cost` and `effective_io_concurrency` are both kept are there default value of 4 and 1 respectively. We have issues with disk I/O already and setting to the PGTune suggested rpc of 1.1 and eioc to 200/300 for Networked and SSD drives may cause issues so we will stick with the defaults.*
`work_mem`: Sets the base maximum amount of memory to be used by a query operation (such as a sort or hash table) before writing to temporary disk files. If this value is specified without units, it is taken as kilobytes. The default value is four megabytes (`4MB`). Note that a complex query might perform several sort and hash operations at the same time, with each operation generally being allowed to use as much memory as this value specifies before it starts to write data into temporary files. Also, several running sessions could be doing such operations concurrently. Therefore, the total memory used could be many times the value of `work_mem`; it is necessary to keep this fact in mind when choosing the value.
- `huge_pages`: Use of huge pages on Linux or Windows. Set to ‘off’. If you really know what you are doing, set to ‘on’ and configure sysctl appropriately. Avoid ‘try’. 
- `min_wal_size`: The default value is very low. Unless you have significant disk space restrictions, raise it up to 1GB. *Current and default is 80MB*
- `max_wal_size`: Unless there are disk space constraints, raise this value to make sure automatic checkpoints are typically caused by timeout and not by disk space. Increasing this value increases the recovery time after a database crash. *Current and default is 1GB *
- `max_worker_processes` An easy approach is to set it to 75% up to 90% (for high core count) of the number of cores. A more detailed approach is the sum of all worker parameters. This is currently set to 32 which is the number of cpus for the entire node but we only appear to be using at most 2.3 CPUs in Grafana.
- `max_parallel_workers_per_gather`: Beware of setting to a high value for high throughput OLTP systems. Oftentimes it is better to leave it on 1 or 2 at most. Raise it for analytical/DW systems, always to a fraction of cores. This parameter is affected by work_mem, we recommend to review that value accordingly. Default current, and PG Tune suggestions is 2.
- `max_parallel_workers`: Sets the maximum number of parallel workers that can be active at one time. *Using PGTune suggestion of 4. Default/current is 32.*
- `max_parallel_maintenance_workers`: Sets the maximum number of parallel processes per maintenance operation. *Default and current is 2.*

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
Testing with a 7-million-record dataset on big-02 showed substantial improvements. Longest transaction times dropped below 3 minutes, compared to the previous 45-90 minute durations. However, when tested with a 15-million-record dataset, RefreshIngestDbViewsWorkflows began to pile up in Temporal and failed to complete. It seems the database reaches a tipping point where view refresh performance degrades significantly. PG tuning is a known improvement for XNAT environments, we will need to address the db view refresh strategy in a separate PR.

### Data
Tested on 7 and 15 million data set.

### Backward compatibility
Should be bc

## Testing
Tested on big-02. See performance section above for details.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
