### PR TITLE
Fix required for Temporal Python SDK v1.12.0, pin version for future

### DIFF
--- a/extractor/hl7-transformer/pyproject.toml
+++ b/extractor/hl7-transformer/pyproject.toml
@@ -24,6 +24,6 @@ dependencies = [
     "psycopg[binary]",
     "pyspark==3.5.4",
     "s3fs",
-    "temporalio",
+    "temporalio ~= 1.12.0",
     "uvicorn",
 ]

--- a/extractor/hl7-transformer/src/hl7scout/ingesthl7worker.py
+++ b/extractor/hl7-transformer/src/hl7scout/ingesthl7worker.py
@@ -39,8 +39,8 @@ async def run_worker(
             activities=[ingest_hl7_files_activity.ingest_hl7_files_to_delta_lake],
             activity_executor=pool,
             max_cached_workflows=1,
-            max_concurrent_workflow_tasks=1,
-            max_concurrent_workflow_task_polls=1,
+            max_concurrent_workflow_tasks=2,
+            max_concurrent_workflow_task_polls=2,
             max_concurrent_activities=1,
             max_concurrent_activity_task_polls=1,
         )


### PR DESCRIPTION
# Fix required for Temporal Python SDK v1.12.0, pin version for future

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
No change

### Technical
* Update temporal worker settings for HL7 transformer per SDK release 1.12. 
>ValueError: Invalid worker config: `max_cached_workflows` > 0 requires `workflow_task_poller_behavior` to be at least 2
* Pin python SDK version, allowing only patch changes for future.

<img width="1251" alt="Screenshot 2025-05-30 at 1 19 10 PM" src="https://github.com/user-attachments/assets/9aa96dbd-288e-47cf-b332-0998bcee2f2a" />

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
I am assuming this will not negatively impact performance, as we're now abiding Temporal's recommendation.

### Data
N/A

### Backward compatibility
All good.

## Testing
None yet, will test via CI and then over the weekend with bolus of other changes.

## Note for reviewers


## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
