### PR TITLE
Test additions & CI tweak

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,9 +170,9 @@ jobs:
           cp .github/ci_resources/test_config_template.json tests/src/test/resources/config/local.json
           sed -i "s:WORK_DIR:$(pwd):" .github/ci_resources/tests-job.yaml
           sudo -E kubectl apply -f .github/ci_resources/tests-job.yaml
-          sudo -E kubectl wait --for=condition=complete --timeout=300s job/ci-tests -n extractor &
+          sudo -E kubectl wait --for=condition=complete --timeout=600s job/ci-tests -n extractor &
           completion_pid=$!
-          sudo -E kubectl wait --for=condition=failed --timeout=300s job/ci-tests -n extractor && exit 1 &
+          sudo -E kubectl wait --for=condition=failed --timeout=600s job/ci-tests -n extractor && exit 1 &
           failure_pid=$!
           wait -n $completion_pid $failure_pid
       - name: Test Logs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,9 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'ci/**'
 
 env:
   JAVA_DIST: 'zulu'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-      - 'ci/**'
+      - 'ci-**'
 
 env:
   JAVA_DIST: 'zulu'

--- a/tests/src/test/java/edu/washu/tag/BaseTest.java
+++ b/tests/src/test/java/edu/washu/tag/BaseTest.java
@@ -11,6 +11,7 @@ public class BaseTest {
     protected static IngestJobDetails ingestWorkflow;
     protected final TestConfig config;
     protected final TemporalClient temporalClient;
+    public static final String RELAUNCH_PRECURSOR = "relaunch_precursor";
 
     public BaseTest() {
         config = TestConfig.instance;

--- a/tests/src/test/java/edu/washu/tag/tests/TestScoutQueries.java
+++ b/tests/src/test/java/edu/washu/tag/tests/TestScoutQueries.java
@@ -6,7 +6,6 @@ import edu.washu.tag.BaseTest;
 import edu.washu.tag.TestQuery;
 import edu.washu.tag.TestQuerySuite;
 import edu.washu.tag.util.FileIOUtils;
-import io.delta.sql.DeltaSparkSessionExtension;
 import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,15 +40,17 @@ public class TestScoutQueries extends BaseTest {
 
     @Test(dataProvider = "known_queries")
     public void testQueryById(String queryId) {
-        final TestQuery<?> query = exportedQueries
-            .getTestQueries()
-            .stream()
-            .filter(testQuery -> testQuery.getId().equals(queryId))
-            .findFirst()
-            .orElseThrow(RuntimeException::new);
+        runTest(queryId);
+    }
 
-        logger.info("Performing query with spark: {}", query.getSql());
-        query.getExpectedQueryResult().validateResult(spark.sql(query.getSql()));
+    @Test
+    public void testRepeatIngest() {
+        temporalClient.launchIngest(
+            config.getTemporalConfig().getIngestJobInput(),
+            true
+        );
+        runTest("all"); // make sure no rows in the whole dataset have been duplicated
+        runTest("extended_metadata"); // ...and let's make sure the metadata still looks good
     }
 
     private static TestQuerySuite<?> readQueries() {
@@ -61,6 +62,21 @@ public class TestScoutQueries extends BaseTest {
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static TestQuery<?> getQueryById(String id) {
+        return exportedQueries
+            .getTestQueries()
+            .stream()
+            .filter(testQuery -> testQuery.getId().equals(id))
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+    }
+
+    private void runTest(String id) {
+        final TestQuery<?> query = getQueryById(id);
+        logger.info("Performing query with spark: {}", query.getSql());
+        query.getExpectedQueryResult().validateResult(spark.sql(query.getSql()));
     }
 
 }

--- a/tests/src/test/java/edu/washu/tag/tests/TestScoutQueries.java
+++ b/tests/src/test/java/edu/washu/tag/tests/TestScoutQueries.java
@@ -20,7 +20,7 @@ public class TestScoutQueries extends BaseTest {
     private static final Logger logger = LoggerFactory.getLogger(TestScoutQueries.class);
 
     @BeforeClass
-    public void initSparkSession() {
+    private void initSparkSession() {
         spark = SparkSession.builder()
             .appName("TestClient")
             .master("local")
@@ -30,7 +30,7 @@ public class TestScoutQueries extends BaseTest {
     }
 
     @DataProvider(name = "known_queries")
-    public Object[][] knownQueries() {
+    private Object[][] knownQueries() {
         return exportedQueries
             .getTestQueries()
             .stream()
@@ -43,7 +43,7 @@ public class TestScoutQueries extends BaseTest {
         runTest(queryId);
     }
 
-    @Test
+    @Test(dependsOnGroups = BaseTest.RELAUNCH_PRECURSOR, alwaysRun = true)
     public void testRepeatIngest() {
         temporalClient.launchIngest(
             config.getTemporalConfig().getIngestJobInput(),

--- a/tests/src/test/java/edu/washu/tag/tests/TestStatusDatabase.java
+++ b/tests/src/test/java/edu/washu/tag/tests/TestStatusDatabase.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
+@Test(groups = BaseTest.RELAUNCH_PRECURSOR)
 public class TestStatusDatabase extends BaseTest {
 
     private static final Logger logger = LoggerFactory.getLogger(TestStatusDatabase.class);

--- a/tests/src/test/resources/spark_queries.json
+++ b/tests/src/test/resources/spark_queries.json
@@ -171,7 +171,6 @@
             "sex": "M",
             "zip_or_postal_code": "61111",
             "country": "USA",
-            "ethnic_group": "",
             "orc_3_filler_order_number": "7795082770",
             "obr_3_filler_order_number": "7795082770",
             "service_name": "78452 MPI SPECT Multiple",

--- a/tests/src/test/resources/spark_queries.json
+++ b/tests/src/test/resources/spark_queries.json
@@ -202,6 +202,10 @@
           {
             "type": ".InstantType",
             "columnName": "results_report_status_change_dt"
+          },
+          {
+            "type": ".IntegerType",
+            "columnName": "year"
           }
         ]
       },

--- a/tests/src/test/resources/spark_queries.json
+++ b/tests/src/test/resources/spark_queries.json
@@ -188,7 +188,7 @@
           }
         }
       },
-      "sql": null,
+      "sql": "SELECT * FROM syntheticdata WHERE message_control_id='2.25.102803968063529570743623449055112845697'",
       "id": "extended_metadata"
     },
     {
@@ -300,7 +300,7 @@
         "expectedNumResults": 0,
         "additionalValidation": null
       },
-      "sql": "SELECT COUNT(*) FROM syntheticdata WHERE message_dt IS NULL",
+      "sql": "SELECT * FROM syntheticdata WHERE message_dt IS NULL",
       "id": "null_message_dt"
     },
     {

--- a/tests/src/test/resources/spark_queries.json
+++ b/tests/src/test/resources/spark_queries.json
@@ -177,6 +177,7 @@
             "service_coding_system": "UNKDEV",
             "diagnostic_service_id": "NM",
             "study_instance_uid": "2.25.136209846447404962078056783820660603567",
+            "birth_date": "1976-04-21",
             "message_dt": "2019-08-25T08:26:40+00:00",
             "requested_dt": "2019-08-22T13:21:10+00:00",
             "results_report_status_change_dt": "2019-08-25T08:26:40+00:00",
@@ -184,7 +185,25 @@
             "modality": "NM",
             "year": "2019"
           }
-        }
+        },
+        "columnTypes": [
+          {
+            "type": ".LocalDateType",
+            "columnName": "birth_date"
+          },
+          {
+            "type": ".InstantType",
+            "columnName": "message_dt"
+          },
+          {
+            "type": ".InstantType",
+            "columnName": "requested_dt"
+          },
+          {
+            "type": ".InstantType",
+            "columnName": "results_report_status_change_dt"
+          }
+        ]
       },
       "sql": "SELECT * FROM syntheticdata WHERE message_control_id='2.25.102803968063529570743623449055112845697'",
       "id": "extended_metadata"
@@ -278,7 +297,8 @@
             "abc_mr": "ABC450997",
             "epic_mrn": null
           }
-        }
+        },
+        "columnTypes": []
       },
       "sql": "SELECT * FROM syntheticdata WHERE abc_mr IN ('ABC450993', 'ABC450994', 'ABC450995', 'ABC450996', 'ABC450997')",
       "id": "patient_id"
@@ -312,7 +332,8 @@
           "2.25.143467293620292044279751197905759993120": {
             "report_text": "EXAMINATION: Single-view X-ray\n\nIMPRESSION: \nThe single-view X-ray findings are within normal limits, showing no\nsignificant changes or abnormalities compared to prior studies. The\nsingle-view X-ray performed on 2015-11-29 presents normal alignment\nand ossification of the bony structures assessed. There are no\nevident signs of osteopenia, fratures, or degenerative changes. The\nsoft tissues are unremarkable, with visualized joints appearing\nwell-maintained. No pathology that requires further investigation is\nnoted, indicating a stable radiographic appearance without any acute\nconcerns.\nDictated by: Joseph Barajas Interpreter, M.D."
           }
-        }
+        },
+        "columnTypes": []
       },
       "sql": "SELECT * FROM syntheticdata WHERE message_control_id IN ('2.25.155851373268730741395170003437433181776', '2.25.143467293620292044279751197905759993120')",
       "id": "report_text"

--- a/tests/src/test/resources/spark_queries.json
+++ b/tests/src/test/resources/spark_queries.json
@@ -177,7 +177,6 @@
             "service_coding_system": "UNKDEV",
             "diagnostic_service_id": "NM",
             "study_instance_uid": "2.25.136209846447404962078056783820660603567",
-            "birth_date": "1976-04-21",
             "message_dt": "2019-08-25T08:26:40+00:00",
             "requested_dt": "2019-08-22T13:21:10+00:00",
             "results_report_status_change_dt": "2019-08-25T08:26:40+00:00",

--- a/tests/src/test/resources/spark_queries.json
+++ b/tests/src/test/resources/spark_queries.json
@@ -166,6 +166,37 @@
         "uniqueIdColumnName": "message_control_id",
         "rowAssertions": {
           "2.25.102803968063529570743623449055112845697": {
+            "service_identifier": "H8452",
+            "sending_facility": "ABCHOSP",
+            "sex": "M",
+            "zip_or_postal_code": "61111",
+            "country": "USA",
+            "ethnic_group": "",
+            "orc_3_filler_order_number": "7795082770",
+            "obr_3_filler_order_number": "7795082770",
+            "service_name": "78452 MPI SPECT Multiple",
+            "service_coding_system": "UNKDEV",
+            "diagnostic_service_id": "NM",
+            "study_instance_uid": "2.25.136209846447404962078056783820660603567",
+            "birth_date": "1976-04-21",
+            "message_dt": "2019-08-25T08:26:40+00:00",
+            "requested_dt": "2019-08-22T13:21:10+00:00",
+            "results_report_status_change_dt": "2019-08-25T08:26:40+00:00",
+            "report_status": "Wet Read",
+            "modality": "NM",
+            "year": "2019"
+          }
+        }
+      },
+      "sql": null,
+      "id": "extended_metadata"
+    },
+    {
+      "expectedQueryResult": {
+        "type": ".ExactRowsResult",
+        "uniqueIdColumnName": "message_control_id",
+        "rowAssertions": {
+          "2.25.102803968063529570743623449055112845697": {
             "abc_mr": "ABC450993",
             "epic_mrn": null
           },
@@ -265,6 +296,15 @@
     },
     {
       "expectedQueryResult": {
+        "type": ".ExactNumberObjectsResult",
+        "expectedNumResults": 0,
+        "additionalValidation": null
+      },
+      "sql": "SELECT COUNT(*) FROM syntheticdata WHERE message_dt IS NULL",
+      "id": "null_message_dt"
+    },
+    {
+      "expectedQueryResult": {
         "type": ".ExactRowsResult",
         "uniqueIdColumnName": "message_control_id",
         "rowAssertions": {
@@ -278,20 +318,6 @@
       },
       "sql": "SELECT * FROM syntheticdata WHERE message_control_id IN ('2.25.155851373268730741395170003437433181776', '2.25.143467293620292044279751197905759993120')",
       "id": "report_text"
-    },
-    {
-      "expectedQueryResult": {
-        "type": ".GroupedAggregationResult",
-        "primaryColumnName": "dummy",
-        "secondaryColumns": ["null_message_dt_count"],
-        "result": {
-          "dummy": {
-            "null_message_dt_count": 0
-          }
-        }
-      },
-      "sql": "SELECT 'dummy', COUNT(*) as null_message_dt_count FROM syntheticdata WHERE message_dt IS NULL",
-      "id": "null_message_dt"
     }
   ]
 }


### PR DESCRIPTION
# Test additions & CI tweak

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [X] Test update

## Description

### Product
N/A

### Technical
1. Modifies the ci configuration so that branches starting with `ci-` will have CI launched on them automatically on pushes.
2. Adds Flavin's test for no null message dt elements in a simpler form.
3. Adds a new test to check many more of the columns in the delta lake.
4. Adds a new test to repeat a full ingest request to make sure the delta lake does not get duplicate rows.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
Tests fully passing on CI.

## Note for reviewers

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [X] I have added end-to-end tests, unless this is a documentation-only PR.
