### PR TITLE
Add health checks for extractor services

### DIFF
--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -124,10 +124,10 @@ k3s_cluster:
     ingest_postgres_table_name: ingest
 
     # Extractor performance tuning
-    hl7log_extractor_timeout: 480
+    hl7log_extractor_timeout: 120
     hl7log_extractor_heartbeat_timeout: 30
     hl7log_extractor_concurrency: 150
-    hl7_transformer_timeout: 60
+    hl7_transformer_timeout: 120
 
     # Resources
     hl7_transformer_spark_memory: 8g

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -124,10 +124,10 @@ k3s_cluster:
     ingest_postgres_table_name: ingest
 
     # Extractor performance tuning
-    hl7log_extractor_timeout: 120
+    hl7log_extractor_timeout: 480
     hl7log_extractor_heartbeat_timeout: 30
     hl7log_extractor_concurrency: 150
-    hl7_transformer_timeout: 120
+    hl7_transformer_timeout: 60
 
     # Resources
     hl7_transformer_spark_memory: 8g

--- a/ansible/playbooks/templates/hl7-transformer.values.yaml.j2
+++ b/ansible/playbooks/templates/hl7-transformer.values.yaml.j2
@@ -33,6 +33,12 @@ volumeMounts:
     subPath: spark-defaults.conf
 ports:
   - containerPort: 8000
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 8000
+  initialDelaySeconds: 15
+  periodSeconds: 10
 livenessProbe:
   httpGet:
     path: /healthz

--- a/ansible/playbooks/templates/hl7log-extractor.values.yaml.j2
+++ b/ansible/playbooks/templates/hl7log-extractor.values.yaml.j2
@@ -20,6 +20,18 @@ volumeMounts:
     mountPath: /data
     readOnly: true
     mountPropagation: HostToContainer
+livenessProbe:
+  httpGet:
+    path: /actuator/health/liveness
+    port: 8080
+  initialDelaySeconds: 30
+  periodSeconds: 10
+readinessProbe:
+  httpGet:
+    path: /actuator/health/readiness
+    port: 8080
+  initialDelaySeconds: 15
+  periodSeconds: 10
 config:
   application:
     management:

--- a/extractor/hl7-transformer/src/hl7scout/healthapi.py
+++ b/extractor/hl7-transformer/src/hl7scout/healthapi.py
@@ -10,7 +10,7 @@ from fastapi.responses import JSONResponse
 log = logging.getLogger(__name__)
 
 # Temporary file for Spark health check
-SPARK_HEALTH_TEMP_FILE = Path(tempfile.mkstemp()[1])
+HEALTH_TEMP_FILE = Path(tempfile.mkstemp()[1])
 HEALTHY = "healthy"
 UNHEALTHY = "unhealthy"
 HEALTHY_JSON_RESPONSE = JSONResponse(status_code=200, content={"status": HEALTHY})
@@ -23,13 +23,13 @@ app = FastAPI()
 async def healthz():
     try:
         log.debug("Running health check")
-        if not SPARK_HEALTH_TEMP_FILE.exists():
+        if not HEALTH_TEMP_FILE.exists():
             # No health information available. Assume healthy.
             log.debug("No health information available (assume healthy)")
             return HEALTHY_JSON_RESPONSE
 
         # Read the contents of the temporary file
-        contents = SPARK_HEALTH_TEMP_FILE.read_text()
+        contents = HEALTH_TEMP_FILE.read_text()
         if not contents:
             # No health information available. Assume healthy.
             log.debug("No health information available (assume healthy)")
@@ -53,7 +53,7 @@ def unhealthy_json_response(
     )
 
 
-async def start_spark_health_check_server():
+async def start_health_check_server():
     config = uvicorn.Config(app, host="0.0.0.0", port=8000, log_level="warning")
     server = uvicorn.Server(config)
     await server.serve()

--- a/extractor/hl7log-extractor/src/main/resources/application.yaml
+++ b/extractor/hl7log-extractor/src/main/resources/application.yaml
@@ -37,6 +37,11 @@ management:
       exposure:
         include:
           - prometheus # Access by /actuator/prometheus
+          - health
+  endpoint:
+    health:
+      probes:
+        enabled: true
   metrics:
     tags:
       namespace: extractor

--- a/helm/extractor/hl7-transformer/templates/deployment.yaml
+++ b/helm/extractor/hl7-transformer/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
           livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}

--- a/helm/extractor/hl7-transformer/values.yaml
+++ b/helm/extractor/hl7-transformer/values.yaml
@@ -64,6 +64,11 @@ livenessProbe:
   # httpGet:
   #   path: /
   #   port: http
+readinessProbe:
+  {}
+  # httpGet:
+  #   path: /
+  #   port: http
 
 resources:
   {}

--- a/helm/extractor/hl7log-extractor/templates/deployment.yaml
+++ b/helm/extractor/hl7log-extractor/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
           livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/helm/extractor/hl7log-extractor/values.yaml
+++ b/helm/extractor/hl7log-extractor/values.yaml
@@ -66,6 +66,11 @@ livenessProbe:
   # httpGet:
   #   path: /
   #   port: http
+readinessProbe:
+  {}
+  # httpGet:
+  #   path: /
+  #   port: http
 
 resources:
   {}


### PR DESCRIPTION
# Add health checks for extractor services

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer. 

For all other change types, the developer should attempt to provide as much detail as is reasonable.

## Description

### Product
If extractor services do not come up successfully, kubernetes will be aware and show the pods in error state.

### Technical
* Add health check endpoints to hl7log-extractor
* Update health check endpoint for hl7-transformer to return an error when temporal worker fails to come up, in addition to Spark errors.
* Add readiness probes to both extractor charts

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
Small impact in that liveness checks are now occurring in hl7log-exporter. I don't expect this to materially impact performance.

### Data
N/A

### Backward compatibility
Yes

## Testing
* Make sure stack still comes up with these changes. 
* Manually hit hl7log-extractor health endpoints. 
* Revert to bad config for hl7-transformer, rebuild image, reinstall, validate that pod ends up in Error state and helm install errors out
* CI testing.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
