### PR TITLE
Increase JupyterHub Spawner http_timeout

### DIFF
--- a/ansible/playbooks/vars/jupyter.values.yaml
+++ b/ansible/playbooks/vars/jupyter.values.yaml
@@ -30,6 +30,8 @@ hub:
       allowed_users: '{{ (jupyter_allowed_users | default([])) }}'
     JupyterHub:
       authenticator_class: '{{ jupyter_auth_class | default("dummy") }}'
+    Spawner:
+      http_timeout: 120
 
 ingress:
   enabled: true


### PR DESCRIPTION
# Increase JupyterHub Spawner http_timeout

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product / Technical
- Increase JupyterHub Spawner http_timeout to 120s. Pod's are occasionally not starting within the 30s default timeout.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
Should be bc.

## Testing
Tested on big-02. To confirm the http_timeout setting, I set to 1s and notebooks failed to start and the timeout was displayed in the error message.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
