### PR TITLE
Upgrade checkstyle warnings to errors, and info to warnings

### DIFF
--- a/linting_java_checkstyle.xml
+++ b/linting_java_checkstyle.xml
@@ -20,7 +20,7 @@
 
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="${org.checkstyle.google.severity}" default="warning"/>
+    <property name="severity" value="${org.checkstyle.google.severity}" default="error"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Excludes all 'module-info.java' files              -->
@@ -378,7 +378,7 @@
             <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
         </module>
         <module name="MissingJavadocMethod">
-            <property name="severity" value="info"/>
+            <property name="severity" value="warning"/>
             <property name="scope" value="protected"/>
             <property name="allowMissingPropertyJavadoc" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>
@@ -394,7 +394,7 @@
                                  [not(./MODIFIERS/LITERAL_PUBLIC)]]"/>
         </module>
         <module name="MissingJavadocType">
-            <property name="severity" value="info"/>
+            <property name="severity" value="warning"/>
             <property name="scope" value="protected"/>
             <property name="tokens"
                       value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,


### PR DESCRIPTION
# Upgrade checkstyle warnings to errors, and info to warnings

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
N/A

### Technical
Makes checkstyle actually fail for style complaints rather than just warn.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
Worked locally to fail checkstyle task when I introduced a style issue.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
