### PR TITLE
Fix CNPG dashboard maintenance_work_mem query

### DIFF
--- a/ansible/playbooks/files/grafana/dashboards/cnpg-dashboard.json
+++ b/ansible/playbooks/files/grafana/dashboards/cnpg-dashboard.json
@@ -4146,7 +4146,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": true,
-              "expr": "cnpg_pg_settings_setting{name=\"maintenance_work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "expr": "cnpg_pg_settings_setting{name=\"maintenance_work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"} * 1024",
               "instant": true,
               "interval": "",
               "legendFormat": "{{pod}}",


### PR DESCRIPTION
# Fix CNPG dashboard maintenance_work_mem query

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product / Technical
- `maintenance_work_mem` was showing 2MB when set to 2GB. Fixed the dashboard PromQL query to multiply by 1024, like the query for `work_mem` is doing.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
Yes

## Testing
Tested on `big-02`. Confirmed `maintenance_work_mem` was being correctly set in PG by logging into psql on the cluster and verified the setting.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
