### PR TITLE
Add instructions for POC Open WebUI + Ollama deploy

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,122 @@
+# Models
+
+Scout's ML model deployment and serving infrastructure; To be completed.
+
+For now this contains directions to deploy a prototype infrastructure:
+- Ollama to serve public models
+- Open WebUI, a web interface to chat with LLMs on Ollama
+- An MCP service to enable an LLM to query our data
+
+## Deploy Ollama (optional)
+This step is to deploy Ollama on its own. It is not necessary if you also deploy Open WebUI, because it is configured to deploy Ollama as well.
+
+Create a namespace for ollama
+```
+kubectl create ns ollama
+```
+
+We must create a volume to store the model data on a spacious part of our disk. For me, that is `/scout/persistence/ollama`.
+Use the file `models/ollama/pv.yaml` in this repo; change the path on the last line to your desired path.
+Then create it with 
+```
+kubectl apply -f models/ollama/pv.yaml
+```
+
+We will serve Ollama at a subpath, but it wasn't designed to do that.
+We need to create a traefik `Middleware` to strip the subpath.
+```
+kubectl apply models/ollama/middleware.yaml
+```
+
+Now we can deploy Ollama with helm.
+You'll need to edit the values file to change the `ingress.hosts[0].host` to your host instead of `big-03.minmi-algol.ts.net`.
+```
+helm install ollama otwld/ollama --namespace ollama --values models/ollama/values.yaml
+```
+
+## Deploy Open WebUI + Ollama
+In this step we will deploy Open WebUI using its helm chart, which also deploys Ollama using its helm chart.
+
+Create a namespace
+```
+kubectl create ns open-webui
+```
+
+Add the open-webui helm repo
+```
+helm repo add open-webui https://helm.openwebui.com/
+```
+
+Open WebUI wants to use a PostgreSQL database. We will create a new database for it to use in our PostgreSQL.
+First run a pod that can access the database.
+```
+kubectl -n postgres run psql --rm -it --image=ghcr.io/cloudnative-pg/postgresql:17.4 -- psql -h postgresql-cluster-rw.postgres -p 5432 -U postgres ingest
+```
+Enter the password when the pod starts. Note we are using the superuser `postgres`.
+
+Create the database and give the `scout` user permissions.
+```sql
+CREATE DATABASE openwebui;
+GRANT ALL PRIVILEGES ON DATABASE openwebui TO scout;
+```
+Switch to the database.
+```sql
+\c openwebui
+```
+Now set the rest of the permissions.
+```sql
+-- Grant usage on the public schema (needed for table operations)
+GRANT USAGE ON SCHEMA public TO scout;
+
+-- Grant create privileges on the public schema (allows creating tables)
+GRANT CREATE ON SCHEMA public TO scout;
+
+-- Set default privileges for future tables and sequences created by any user
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO scout;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO scout;
+```
+
+Remove Superset. This is because the default Scout deployment is configured for the root path to route to Superset.
+But Open WebUI also only wants to be deployed to the root of the domain.
+In order to use Open WebUI we must remove Superset.
+```
+helm -n superset uninstall superset
+```
+
+Lastly, you may need to customize the `models/open-webui/values.yaml` file.
+- `ollama.ingress.hosts[0].host` is set to `big-03.minmi-algol.ts.net`
+- `ingress.host` is set to `big-03.minmi-algol.ts.net`
+- `extraResources[1].spec.hostPath.path` is the local path for Open WebUI data; I set it to `/scout/persistence/open-webui`
+- `extraResources[4].spec.hostPath.path` is the local path for Ollama data; I set it to `/scout/persistence/ollama`
+- `databaseUrl` is a connection string for Postgres, with username and password embedded. Customize it to your values.
+
+Now we can deploy Open WebUI + Ollama + a Redis instance for managing websockets using the helm chart.
+```
+helm install open-webui open-webui/open-webui --namespace open-webui --values models/open-webui/values.yaml
+```
+
+Open WebUI should be available at the root of your domain.
+
+## Deploy Trino MCP + Open WebUI MCPO
+This sets up an MCP server that can help an LLM query our report data in Delta Lake via our Trino service.
+In addition, because Open WebUI doesn't speak MCP directly, we have to deploy a proxy service to convert the MCP into OpenAPI for Open WebUI to use.
+
+I first created an `mcp` namespace.
+
+```
+kubectl create ns mcp
+```
+
+I then deployed the [`mcp-trino`](https://github.com/tuannvm/mcp-trino) service into that namespace, configuring it to point to our trino service, and to expose its own service.
+```
+kubectl run -n mcp mcp-trino --env TRINO_HOST=trino.trino --env TRINO_PORT=8080 --env TRINO_SCHEME=http --image=ghcr.io/tuannvm/mcp-trino:latest --port=9097 --expose
+```
+
+Lastly I deployed Open WebUI's MCP proxy tool [`mcpo`](https://github.com/open-webui/mcpo) and configured it to point to the `mcp-trino` service and expose its own service.
+```
+kubectl run -n mcp mcpo-trino --image=ghcr.io/open-webui/mcpo:main --port=8000 --expose -- --port 8000 --server-type sse -- http://mcp-trino.mcp:9097/sse
+```
+
+Now we can go into Open WebUI's admin settings > Tools and add the proxy service as a tool, at URL `http://mcpo-trino.mcp:8000/openapi.json`.
+
+Reload the page and there should be a new `MCP Trino` tool available in the + menu on the chat.

--- a/models/ollama/middleware.yaml
+++ b/models/ollama/middleware.yaml
@@ -1,0 +1,9 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: ollama-stripprefix
+  namespace: ollama
+spec:
+  stripPrefix:
+    prefixes:
+      - /ollama

--- a/models/ollama/pv.yaml
+++ b/models/ollama/pv.yaml
@@ -1,0 +1,21 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ollama-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ollama-pv
+spec:
+  capacity:
+    storage: 100G
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ollama-storage
+  hostPath:
+    path: /scout/persistence/ollama

--- a/models/ollama/values.yaml
+++ b/models/ollama/values.yaml
@@ -1,0 +1,19 @@
+ollama:
+  models:
+    pull:
+      - llama3.2:3b
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: ollama-ollama-stripprefix@kubernetescrd
+  hosts:
+    - host: big-03.minmi-algol.ts.net
+      paths:
+        - path: /ollama
+          pathType: Prefix
+persistentVolume:
+  enabled: true
+  size: 100G
+  storageClass: 'ollama-storage'
+  volumeName: 'ollama-pv'

--- a/models/open-webui/values.yaml
+++ b/models/open-webui/values.yaml
@@ -1,0 +1,136 @@
+nameOverride: ''
+namespaceOverride: ''
+ollama:
+  # -- Automatically install Ollama Helm chart from https://otwld.github.io/ollama-helm/. Use [Helm Values](https://github.com/otwld/ollama-helm/#helm-values) to configure
+  enabled: true
+  # -- If enabling embedded Ollama, update fullnameOverride to your desired Ollama name value, or else it will use the default ollama.name value from the Ollama chart
+  fullnameOverride: open-webui-ollama
+  ollama:
+    # gpu:
+    #   enabled: true
+    #   type: 'nvidia'
+    #   number: 1
+    models:
+      pull:
+        - llama3.2:3b
+  ingress:
+    enabled: true
+    ingressClassName: traefik
+    annotations:
+      traefik.ingress.kubernetes.io/router.middlewares: open-webui-open-webui-stripprefix@kubernetescrd
+    hosts:
+      - host: big-03.minmi-algol.ts.net
+        paths:
+          - path: /ollama
+            pathType: Prefix
+  persistentVolume:
+    enabled: true
+    size: 100G
+    storageClass: ollama-storage
+    volumeName: ollama-pv
+
+pipelines:
+  enabled: false
+
+ingress:
+  enabled: true
+  class: traefik
+  host: big-03.minmi-algol.ts.net
+
+persistence:
+  enabled: true
+  size: 100G
+  existingClaim: 'open-webui-pvc'
+
+# -- Extra resources to deploy with Open WebUI
+extraResources:
+  - apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    metadata:
+      name: open-webui-storage
+    provisioner: kubernetes.io/no-provisioner
+    volumeBindingMode: WaitForFirstConsumer
+  - apiVersion: v1
+    kind: PersistentVolume
+    metadata:
+      name: open-webui-pv
+    spec:
+      capacity:
+        storage: 100G
+      volumeMode: Filesystem
+      accessModes:
+        - ReadWriteOnce
+      persistentVolumeReclaimPolicy: Retain
+      storageClassName: open-webui-storage
+      hostPath:
+        path: /scout/persistence/open-webui
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: open-webui-pvc
+      namespace: open-webui
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100G
+      storageClassName: open-webui-storage
+      volumeMode: Filesystem
+      volumeName: open-webui-pv
+  - apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    metadata:
+      name: ollama-storage
+    provisioner: kubernetes.io/no-provisioner
+    volumeBindingMode: WaitForFirstConsumer
+  - apiVersion: v1
+    kind: PersistentVolume
+    metadata:
+      name: ollama-pv
+    spec:
+      capacity:
+        storage: 100G
+      volumeMode: Filesystem
+      accessModes:
+        - ReadWriteOnce
+      persistentVolumeReclaimPolicy: Retain
+      storageClassName: ollama-storage
+      hostPath:
+        path: /scout/persistence/ollama
+  - apiVersion: traefik.io/v1alpha1
+    kind: Middleware
+    metadata:
+      name: open-webui-stripprefix
+      namespace: open-webui
+    spec:
+      stripPrefix:
+        prefixes:
+          - /ollama
+          - /open-webui
+
+# -- Configure database URL, needed to work with Postgres (example: `postgresql://<user>:<password>@<service>:<port>/<database>`), leave empty to use the default sqlite database
+databaseUrl: 'postgresql://scout:scout123@postgresql-cluster-r.postgres:5432/openwebui'
+
+enableOpenaiApi: false
+
+websocket:
+  # -- Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT`
+  enabled: true
+  # -- Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: redis (default)
+  manager: redis
+  # -- Specifies the URL of the Redis instance for websocket communication. Template with `redis://[:<password>@]<hostname>:<port>/<db>`
+  url: redis://open-webui-redis:6379/0
+  # -- Node selector for websocket pods
+  nodeSelector: {}
+  # -- Deploys a redis
+  redis:
+    # -- Enable redis installation
+    enabled: true
+    # -- Redis name
+    name: open-webui-redis
+    # -- Redis image
+    image:
+      repository: redis
+      tag: 7.4.2-alpine3.21
+      pullPolicy: IfNotPresent


### PR DESCRIPTION
## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [X] Documentation update
- [ ] Test update

## Description
Add `models/README.md` with instructions for deploying Open WebUI, Ollama, and an MCP server that allows LLMs to query our data in Delta Lake via Trino.

Also add files to support these deploys, such as helm values files and a few k8s objects to create.

This is all experimental and POC, so it is quite manual at this time. It is not integrated into the ansible playbooks or even helm charts. Once we get further along the path of deploying these as a proper part of Scout's ansible infrastructure, I'll remove these manual instructions.

## Impact

### Security 
None

### Performance
Performance is currently extremely bad with models running on CPU.

### Data
N/A

### Backward compatibility
N/A

## Testing
None

## Note for reviewers
None

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
