### PR TITLE
Fix grafana broken in #139

### DIFF
--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -59,6 +59,7 @@ k3s_cluster:
     postgres_cluster_namespace: cloudnative-pg
     prometheus_namespace: prometheus
     grafana_namespace: grafana
+    loki_namespace: loki
 
     # Local paths
     base_dir: /var/lib
@@ -102,7 +103,6 @@ k3s_cluster:
     # Do not change the values below, they are hard-coded various places
     extractor_namespace: extractor
     minio_tenant_namespace: minio-scout
-    loki_namespace: loki
     temporal_namespace: temporal
 
     # computed values, used across playbooks

--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -31,6 +31,8 @@ k3s_cluster:
 
     # Monitor config
     prometheus_storage_size: 1Gi
+    loki_storage_size: 1Gi
+    grafana_storage_size: 1Gi
 
     # Jupyter config
     jupyter_hub_storage_size: 1Gi

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -110,6 +110,7 @@ k3s_cluster:
     postgres_cluster_namespace: cloudnative-pg
     prometheus_namespace: prometheus
     grafana_namespace: grafana
+    loki_namespace: loki
 
     # Local paths
     base_dir: /var/lib/rancher/k3s/storage # Path to directory for container images and sandbox data
@@ -160,7 +161,6 @@ k3s_cluster:
     # Do not change the values below, they are hard-coded various places
     extractor_namespace: extractor
     minio_tenant_namespace: minio-scout
-    loki_namespace: loki
     temporal_namespace: temporal
 
     # computed values, used across playbooks

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -38,6 +38,8 @@ k3s_cluster:
 
     # Monitor config
     prometheus_storage_size: 100Gi
+    loki_storage_size: 100Gi
+    grafana_storage_size: 50Gi
     grafana_alert_contact_point: slack # email or slack
     grafana_smtp_host: '' # Include the port in the value
     grafana_smtp_user: $(echo $SMTP_USER | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)

--- a/ansible/playbooks/services/grafana.yaml
+++ b/ansible/playbooks/services/grafana.yaml
@@ -31,8 +31,7 @@
     release_namespace: '{{ loki_namespace }}'
     update_repo_cache: true
     chart_version: ~6.29.0
-    values_files:
-      - '{{ scout_repo_dir }}/helm/loki/loki-values.yaml'
+    values: "{{ lookup('template', 'templates/loki.values.yaml.j2') | from_yaml }}"
     state: present
 
 - name: Install Promtail using Helm
@@ -42,8 +41,12 @@
     release_namespace: '{{ loki_namespace }}'
     update_repo_cache: true
     chart_version: ~6.16.6
-    values_files:
-      - '{{ scout_repo_dir }}/helm/loki/promtail-values.yaml'
+    values:
+      promtail:
+        enabled: true
+        config:
+          clients:
+            - url: 'http://loki-gateway.{{ loki_namespace }}.svc.cluster.local:3100/loki/api/v1/push'
     state: present
 
 - name: Create Grafana namespace

--- a/ansible/playbooks/templates/grafana/grafana.values.yaml.j2
+++ b/ansible/playbooks/templates/grafana/grafana.values.yaml.j2
@@ -76,7 +76,7 @@ sidecar:
 
 persistence:
   enabled: true
-  storageClassName: grafana-storage
+  storageClassName: '{{ grafana_storage_class }}'
 
 livenessProbe:
   initialDelaySeconds: 180

--- a/ansible/playbooks/templates/loki.values.yaml.j2
+++ b/ansible/playbooks/templates/loki.values.yaml.j2
@@ -26,8 +26,8 @@ loki:
       ruler: loki-ruler
       admin: loki-admin
     s3:
-      endpoint: minio.minio-scout.svc.cluster.local
-      region: us-east-1
+      endpoint: 'minio.{{ minio_tenant_namespace }}.svc.cluster.local'
+      region: '{{ s3_region }}'
       insecure: true
       s3ForcePathStyle: true
 
@@ -40,7 +40,7 @@ singleBinary:
   replicas: 1
   persistence:
     enabled: true
-    storageClass: loki-storage
+    storageClass: '{{ loki_storage_class }}'
   extraEnv:
     - name: AWS_ACCESS_KEY_ID
       valueFrom:

--- a/ansible/playbooks/vars/monitor_storage.yaml
+++ b/ansible/playbooks/vars/monitor_storage.yaml
@@ -1,5 +1,9 @@
 prometheus_name: prometheus
 prometheus_storage_class: '{{ prometheus_name }}-storage'
+loki_name: loki
+loki_storage_class: '{{ loki_name }}-storage'
+grafana_name: grafana
+grafana_storage_class: '{{ grafana_name }}-storage'
 
 storage_definitions:
   - name: '{{ prometheus_name }}'
@@ -7,3 +11,13 @@ storage_definitions:
     path: '{{ prometheus_dir }}'
     pv_name: '{{ prometheus_name }}-pv'
     storage_class_name: '{{ prometheus_storage_class }}'
+  - name: '{{ loki_name }}'
+    size: "{{ loki_storage_size | default('200Gi')}}"
+    path: '{{ loki_dir }}'
+    pv_name: '{{ loki_name }}-pv'
+    storage_class_name: '{{ loki_storage_class }}'
+  - name: '{{ grafana_name }}'
+    size: "{{ grafana_storage_size | default('50Gi') }}"
+    path: '{{ grafana_dir }}'
+    pv_name: '{{ grafana_name }}-pv'
+    storage_class_name: '{{ grafana_storage_class }}'


### PR DESCRIPTION
## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

I had deployed Scout to my tagdev multinode cluster. A spot check of services revealed grafana wasn't up. Investigating that revealed that the pods had not started because the PVCs were not bound to any PVs.

I found that when migrating the lists of `storage_definitions` in the ansible playbooks I had missed the entries for grafana and loki.

This adds those back.

### Product
Restore grafana to Scout

### Technical
- Add back grafana and loki storage definitions to ansible config; they had been inadvertently removed in #139
- Move loki helm values file from `helm` into `ansible` as a template so we can use variables

## Impact
N/A

## Testing
Manually deployed Scout to tagdev cluster `{control,big}-03`. Verified grafana started.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
