### PR TITLE
Enable configuration to spread minio across nodes

### DIFF
--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -1,12 +1,16 @@
 ---
+server:
+  hosts:
+    HOSTNAME:
+      ansible_connection: local
+      ansible_python_interpreter: /usr/bin/python3
+      k3s_control_node: true
+minio_hosts:
+  children:
+    server:
 k3s_cluster:
   children:
     server:
-      hosts:
-        HOSTNAME:
-          ansible_connection: local
-          ansible_python_interpreter: /usr/bin/python3
-          k3s_control_node: true
   vars:
     hl7log_extractor_image: docker.io/local/washu-tag/hl7log-extractor
     hl7_transformer_image: docker.io/local/washu-tag/hl7-transformer

--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -19,6 +19,7 @@ k3s_cluster:
 
     # Minio config, ensure passwords meet complexity requirements (must be >=8 characters)
     minio_storage_size: 5Gi
+    minio_server_count: 1
     s3_username: minio
     s3_password: minio123
     s3_region: us-east-1

--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -20,6 +20,7 @@ k3s_cluster:
     # Minio config, ensure passwords meet complexity requirements (must be >=8 characters)
     minio_storage_size: 5Gi
     minio_server_count: 1
+    minio_volumes_per_server: 1
     s3_username: minio
     s3_password: minio123
     s3_region: us-east-1

--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -115,5 +115,4 @@ k3s_cluster:
     s3_endpoint: 'http://minio.{{ minio_tenant_namespace }}'
     hive_metastore_endpoint: 'thrift://hive-metastore.{{ hive_namespace }}:9083'
     server_hostname: '{{ hostvars[groups["server"][0]].external_url | default(groups["server"][0]) }}'
-    control_plane_taint_effect: '{{ "PreferNoSchedule" if groups["k3s_cluster"] | length == 1 else "NoSchedule" }}'
     # End do not change

--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -23,7 +23,6 @@ k3s_cluster:
 
     # Minio config, ensure passwords meet complexity requirements (must be >=8 characters)
     minio_storage_size: 5Gi
-    minio_server_count: 1
     minio_volumes_per_server: 1
     s3_username: minio
     s3_password: minio123

--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -115,4 +115,5 @@ k3s_cluster:
     s3_endpoint: 'http://minio.{{ minio_tenant_namespace }}'
     hive_metastore_endpoint: 'thrift://hive-metastore.{{ hive_namespace }}:9083'
     server_hostname: '{{ hostvars[groups["server"][0]].external_url | default(groups["server"][0]) }}'
+    control_plane_taint_effect: '{{ "PreferNoSchedule" if groups["k3s_cluster"] | length == 1 else "NoSchedule" }}'
     # End do not change

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -198,4 +198,5 @@ k3s_cluster:
     s3_endpoint: 'http://minio.{{ minio_tenant_namespace }}'
     hive_metastore_endpoint: 'thrift://hive-metastore.{{ hive_namespace }}:9083'
     server_hostname: '{{ hostvars[groups["server"][0]].external_url | default(groups["server"][0]) }}'
+    control_plane_taint_effect: '{{ "PreferNoSchedule" if groups["k3s_cluster"] | length == 1 else "NoSchedule" }}'
     # END - DO NOT CHANGE

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -32,6 +32,7 @@ k3s_cluster:
 
     # Minio config, ensure passwords meet complexity requirements (must be >=8 characters)
     minio_storage_size: 750Gi
+    minio_server_count: 1
     s3_username: minio
     s3_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     s3_region: us-east-1

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -33,6 +33,7 @@ k3s_cluster:
     # Minio config, ensure passwords meet complexity requirements (must be >=8 characters)
     minio_storage_size: 750Gi
     minio_server_count: 1
+    minio_volumes_per_server: 2
     s3_username: minio
     s3_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     s3_region: us-east-1

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -1,4 +1,5 @@
 ---
+# The server group contains the control plane nodes for the k3s cluster.
 server:
   hosts:
     FQDN-leader.edu:
@@ -6,6 +7,7 @@ server:
       ansible_python_interpreter: /usr/bin/python3
       k3s_control_node: true
       external_url: alt.fqdn.edu # omit to use FQDN-leader.edu
+# The workers group contains the worker nodes for the k3s cluster.
 workers:
   hosts:
     FQDN-worker-1.edu:
@@ -16,10 +18,20 @@ gpu_workers:
     FQDN-gpu-1.edu:
       ansible_connection: local
       ansible_python_interpreter: /usr/bin/python3
+# The agents group contains nodes that run only the k3s agent.
+# In this example it only includes the workers and gpu_workers groups.
 agents:
   children:
     workers:
     gpu_workers:
+# Include in this group any nodes on which MinIO should run.
+# Note that if this group contains more than one node, the value of
+#  `minio_volumes_per_server` must be greater than 1 or minio will fail to start.
+minio_hosts:
+  children:
+    server:
+    workers:
+# This group contains all nodes in the k3s cluster.
 k3s_cluster:
   children:
     server:

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -198,5 +198,4 @@ k3s_cluster:
     s3_endpoint: 'http://minio.{{ minio_tenant_namespace }}'
     hive_metastore_endpoint: 'thrift://hive-metastore.{{ hive_namespace }}:9083'
     server_hostname: '{{ hostvars[groups["server"][0]].external_url | default(groups["server"][0]) }}'
-    control_plane_taint_effect: '{{ "PreferNoSchedule" if groups["k3s_cluster"] | length == 1 else "NoSchedule" }}'
     # END - DO NOT CHANGE

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -44,7 +44,6 @@ k3s_cluster:
 
     # Minio config, ensure passwords meet complexity requirements (must be >=8 characters)
     minio_storage_size: 750Gi
-    minio_server_count: 1
     minio_volumes_per_server: 2
     s3_username: minio
     s3_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)

--- a/ansible/playbooks/k3s.yaml
+++ b/ansible/playbooks/k3s.yaml
@@ -94,6 +94,14 @@
       retries: 30
       delay: 5
 
+    - name: Apply taint to control plane node
+      kubernetes.core.k8s_taint:
+        name: '{{ inventory_hostname }}'
+        state: present
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            effect: NoSchedule
+
 ################################################################################
 - hosts: gpu_workers
   name: Configure k3s runtime on GPU worker nodes

--- a/ansible/playbooks/k3s.yaml
+++ b/ansible/playbooks/k3s.yaml
@@ -100,7 +100,7 @@
         state: present
         taints:
           - key: node-role.kubernetes.io/control-plane
-            effect: NoSchedule
+            effect: '{{ control_plane_taint_effect | default("PreferNoSchedule") }}'
 
 ################################################################################
 - hosts: gpu_workers

--- a/ansible/playbooks/k3s.yaml
+++ b/ansible/playbooks/k3s.yaml
@@ -100,7 +100,7 @@
         state: present
         taints:
           - key: node-role.kubernetes.io/control-plane
-            effect: '{{ control_plane_taint_effect | default("PreferNoSchedule") }}'
+            effect: PreferNoSchedule
 
 ################################################################################
 - hosts: gpu_workers

--- a/ansible/playbooks/k3s.yaml
+++ b/ansible/playbooks/k3s.yaml
@@ -94,14 +94,6 @@
       retries: 30
       delay: 5
 
-    - name: Apply taint to control plane node
-      kubernetes.core.k8s_taint:
-        name: '{{ inventory_hostname }}'
-        state: present
-        taints:
-          - key: node-role.kubernetes.io/control-plane
-            effect: PreferNoSchedule
-
 ################################################################################
 - hosts: gpu_workers
   name: Configure k3s runtime on GPU worker nodes

--- a/ansible/playbooks/lake.yaml
+++ b/ansible/playbooks/lake.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Create storage directories for Lake
-  hosts: k3s_cluster
+  hosts: minio_hosts
   gather_facts: false
   vars_files:
     - vars/lake_storage.yaml

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -115,7 +115,7 @@
               # Ensure MinIO pods can run on control plane nodes
               - key: 'node-role.kubernetes.io/control-plane'
                 operator: Exists
-                effect: NoSchedule
+                effect: '{{ control_plane_taint_effect | default("PreferNoSchedule") }}'
             affinity:
               podAntiAffinity:
                 requiredDuringSchedulingIgnoredDuringExecution:

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -108,7 +108,7 @@
         pools:
           - servers: '{{ minio_server_count | default(1) }}'
             name: pool-0
-            volumesPerServer: 2
+            volumesPerServer: '{{ minio_volumes_per_server | default(1) }}'
             size: "{{ minio_storage_size | default('100Gi') }}"
             storageClassName: "{{ minio_storage_class | default('minio-storage') }}"
             tolerations:

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -115,7 +115,7 @@
               # Ensure MinIO pods can run on control plane nodes
               - key: 'node-role.kubernetes.io/control-plane'
                 operator: Exists
-                effect: '{{ control_plane_taint_effect | default("PreferNoSchedule") }}'
+                effect: PreferNoSchedule
             affinity:
               podAntiAffinity:
                 requiredDuringSchedulingIgnoredDuringExecution:

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -116,6 +116,15 @@
               - key: 'node-role.kubernetes.io/control-plane'
                 operator: Exists
                 effect: PreferNoSchedule
+            topologySpreadConstraints:
+              # Ensure MinIO pods are spread across nodes
+              - maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: DoNotSchedule
+                nodeTaintsPolicy: Honor
+                labelSelector:
+                  matchLabels:
+                    v1.min.io/tenant: scout
         metrics:
           enabled: true
           port: 9000

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -116,15 +116,13 @@
               - key: 'node-role.kubernetes.io/control-plane'
                 operator: Exists
                 effect: PreferNoSchedule
-            topologySpreadConstraints:
-              # Ensure MinIO pods are spread across nodes
-              - maxSkew: 1
-                topologyKey: kubernetes.io/hostname
-                whenUnsatisfiable: DoNotSchedule
-                nodeTaintsPolicy: Honor
-                labelSelector:
-                  matchLabels:
-                    v1.min.io/tenant: scout
+            affinity:
+              podAntiAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  - labelSelector:
+                      matchLabels:
+                        v1.min.io/tenant: scout
+                    topologyKey: kubernetes.io/hostname
         metrics:
           enabled: true
           port: 9000

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -115,7 +115,7 @@
               # Ensure MinIO pods can run on control plane nodes
               - key: 'node-role.kubernetes.io/control-plane'
                 operator: Exists
-                effect: PreferNoSchedule
+                effect: NoSchedule
             affinity:
               podAntiAffinity:
                 requiredDuringSchedulingIgnoredDuringExecution:

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -108,7 +108,7 @@
         pools:
           - servers: '{{ minio_server_count | default(1) }}'
             name: pool-0
-            volumesPerServer: 1
+            volumesPerServer: 2
             size: "{{ minio_storage_size | default('100Gi') }}"
             storageClassName: "{{ minio_storage_class | default('minio-storage') }}"
             tolerations:

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -106,7 +106,7 @@
           existingSecret: true
         env: '{{ minio_env_variables }}'
         pools:
-          - servers: '{{ minio_server_count | default(1) }}'
+          - servers: '{{ groups["minio_hosts"] | length | default(1) }}'
             name: pool-0
             volumesPerServer: '{{ minio_volumes_per_server | default(1) }}'
             size: "{{ minio_storage_size | default('100Gi') }}"

--- a/ansible/playbooks/tasks/storage_dir_create.yaml
+++ b/ansible/playbooks/tasks/storage_dir_create.yaml
@@ -5,3 +5,4 @@
     state: directory
     mode: '0777'
   loop: '{{ storage_definitions }}'
+  when: item.node_url is not defined or item.node_url == inventory_hostname

--- a/ansible/playbooks/tasks/storage_setup.yaml
+++ b/ansible/playbooks/tasks/storage_setup.yaml
@@ -26,6 +26,18 @@
           - ReadWriteOnce
         persistentVolumeReclaimPolicy: Retain
         storageClassName: '{{ item.storage_class_name }}'
-        hostPath:
-          path: '{{ item.path }}'
+        local: "{{ item.node_url is defined | ternary({'path': item.path}, omit) }}"
+        nodeAffinity: >-
+          {{ item.node_url is defined | ternary({
+            'required': {
+              'nodeSelectorTerms': [
+                {'matchExpressions': [
+                  {'key': 'kubernetes.io/hostname',
+                   'operator': 'In',
+                   'values': [item.node_url]}
+                ]}
+              ]
+            }
+          }, omit) }}
+        hostPath: "{{ item.node_url is not defined | ternary({'path': item.path}, omit) }}"
   loop: '{{ storage_definitions }}'

--- a/ansible/playbooks/vars/lake_storage.yaml
+++ b/ansible/playbooks/vars/lake_storage.yaml
@@ -2,12 +2,17 @@ minio_name: minio
 minio_storage_class: minio-storage
 
 storage_definitions: >-
-  [{% for i in range(0, minio_volumes_per_server * minio_server_count) -%}
-    {
-      "name": "{{ minio_name }}{{ i }}",
-      "size": "{{ minio_storage_size | default('100Gi') }}",
-      "path": "{{ minio_dir }}{{ i }}",
-      "pv_name": "{{ minio_name }}-pv{{ i }}",
-      "storage_class_name": "{{ minio_storage_class }}"
-    }{% if not loop.last %},{% endif %}
+  [{% set ns = namespace(last_node=false) -%}
+  {% for node_url in groups["minio_hosts"] -%}
+    {% if loop.last %}{% set ns.last_node = true %}{% endif %}
+    {% for i in range(0, minio_volumes_per_server) -%}
+      {
+        "name": "{{ minio_name }}-{{ node_url }}-{{ i }}",
+        "size": "{{ minio_storage_size | default('100Gi') }}",
+        "path": "{{ minio_dir }}{{ i }}",
+        "pv_name": "{{ minio_name }}-pv-{{ node_url }}-{{ i }}",
+        "storage_class_name": "{{ minio_storage_class }}",
+        "node_url": "{{ node_url }}"
+      }{% if not (loop.last and ns.last_node) %},{% endif %}
+    {%- endfor %}
   {%- endfor %}]

--- a/ansible/playbooks/vars/lake_storage.yaml
+++ b/ansible/playbooks/vars/lake_storage.yaml
@@ -1,14 +1,13 @@
 minio_name: minio
 minio_storage_class: minio-storage
 
-storage_definitions:
-  - name: '{{ minio_name }}0'
-    size: "{{ minio_storage_size | default('100Gi') }}"
-    path: '{{ minio_dir }}0'
-    pv_name: '{{ minio_name }}-pv0'
-    storage_class_name: '{{ minio_storage_class }}'
-  - name: '{{ minio_name }}1'
-    size: "{{ minio_storage_size | default('100Gi') }}"
-    path: '{{ minio_dir }}1'
-    pv_name: '{{ minio_name }}-pv1'
-    storage_class_name: '{{ minio_storage_class }}'
+storage_definitions: >-
+  [{% for i in range(0, minio_volumes_per_server * minio_server_count) -%}
+    {
+      "name": "{{ minio_name }}{{ i }}",
+      "size": "{{ minio_storage_size | default('100Gi') }}",
+      "path": "{{ minio_dir }}{{ i }}",
+      "pv_name": "{{ minio_name }}-pv{{ i }}",
+      "storage_class_name": "{{ minio_storage_class }}"
+    }{% if not loop.last %},{% endif %}
+  {%- endfor %}]

--- a/ansible/playbooks/vars/lake_storage.yaml
+++ b/ansible/playbooks/vars/lake_storage.yaml
@@ -2,8 +2,13 @@ minio_name: minio
 minio_storage_class: minio-storage
 
 storage_definitions:
-  - name: '{{ minio_name }}'
+  - name: '{{ minio_name }}0'
     size: "{{ minio_storage_size | default('100Gi') }}"
-    path: '{{ minio_dir }}'
-    pv_name: '{{ minio_name }}-pv'
+    path: '{{ minio_dir }}0'
+    pv_name: '{{ minio_name }}-pv0'
+    storage_class_name: '{{ minio_storage_class }}'
+  - name: '{{ minio_name }}1'
+    size: "{{ minio_storage_size | default('100Gi') }}"
+    path: '{{ minio_dir }}1'
+    pv_name: '{{ minio_name }}-pv1'
     storage_class_name: '{{ minio_storage_class }}'

--- a/ansible/playbooks/vars/minio.yaml
+++ b/ansible/playbooks/vars/minio.yaml
@@ -2,9 +2,6 @@
 # Namespace configuration
 minio_tenant_name: scout
 
-# Storage configuration
-minio_server_count: 1
-
 # MinIO versions
 minio_version: ~7.1.0
 minio_client_image: quay.io/minio/mc:RELEASE.2025-04-16T18-13-26Z

--- a/models/README.md
+++ b/models/README.md
@@ -109,7 +109,7 @@ kubectl create ns mcp
 
 I then deployed the [`mcp-trino`](https://github.com/tuannvm/mcp-trino) service into that namespace, configuring it to point to our trino service, and to expose its own service.
 ```
-kubectl run -n mcp mcp-trino --env TRINO_HOST=trino.trino --env TRINO_PORT=8080 --env TRINO_SCHEME=http --image=ghcr.io/tuannvm/mcp-trino:latest --port=9097 --expose
+kubectl run -n mcp mcp-trino --env TRINO_HOST=trino.trino --env TRINO_PORT=8080 --env TRINO_SCHEME=http --env MCP_HOST=mcp-trino.mcp --image=ghcr.io/tuannvm/mcp-trino:latest --port=9097 --expose
 ```
 
 Lastly I deployed Open WebUI's MCP proxy tool [`mcpo`](https://github.com/open-webui/mcpo) and configured it to point to the `mcp-trino` service and expose its own service.

--- a/models/open-webui/values.yaml
+++ b/models/open-webui/values.yaml
@@ -19,7 +19,7 @@ ollama:
     annotations:
       traefik.ingress.kubernetes.io/router.middlewares: open-webui-open-webui-stripprefix@kubernetescrd
     hosts:
-      - host: big-03.minmi-algol.ts.net
+      - host: tagdev-control-03.minmi-algol.ts.net
         paths:
           - path: /ollama
             pathType: Prefix
@@ -35,7 +35,7 @@ pipelines:
 ingress:
   enabled: true
   class: traefik
-  host: big-03.minmi-algol.ts.net
+  host: tagdev-control-03.minmi-algol.ts.net
 
 persistence:
   enabled: true
@@ -110,7 +110,7 @@ extraResources:
           - /open-webui
 
 # -- Configure database URL, needed to work with Postgres (example: `postgresql://<user>:<password>@<service>:<port>/<database>`), leave empty to use the default sqlite database
-databaseUrl: 'postgresql://scout:scout123@postgresql-cluster-r.postgres:5432/openwebui'
+databaseUrl: 'postgresql://scout:scout123@postgresql-cluster-r.cloudnative-pg:5432/openwebui'
 
 enableOpenaiApi: false
 


### PR DESCRIPTION
## Type of change
- [ ] Work behind a feature flag
- [X] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
Minio will be more resilient when run in a multinode cluster.

### Technical
Minio can now be configured with multiple replica pods spread across the nodes in a multinode cluster, and to use multiple volume mounts per node (single- or multinode).
Two main points of configuration:
- Added a new group in ansible called `minio_hosts`. Any hosts added here (say through groups like `server` or `workers`) will have minio deployed on them.
- Added a configuration variable `minio_volumes_per_server`. If multiple minio pods are to be deployed this must be set > 1. Even if a single minio is deployed this can optionally be set > 1.

The directories that get created on each node are named `{{ minio_dir }}{{ i }}` for all `i` in the range `0` to `minio_volumes_per_server-1`, so if you want the minio volumes to use different drive mounts that's what you'd need to name them.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
I expect this will improve performance by having multiple replicas. However, in our current dev vm configuration, we are also reducing the performance by using different directories on the same drive mounts to serve as the volumes; this means we may experience a performance degradation because minio is putting extra load on each drive mount.

### Data
N/A

### Backward compatibility
~~This will not work if upgrading an existing cluster.~~ You will not be able to change an existing cluster with a single minio server into one with multiple minio replicas. This changes the number of servers in pool 0, which minio does not like. It considers the number of servers in a pool immutable; if you need to add new servers they must be added to a new pool. Which maybe calls into question the idea of deploying these changes in an ansible playbook designed to deploy a fresh scout. But I'm not sure how I would structure a playbook which could deploy a new minio with a certain configuration but also deploy an upgrade with a different configuration. So I just did it this way.

This will install fine on an existing cluster if you keep the number of minio replicas unchanged.

## Testing
- I've manually deployed this a few times on the 03 multinode cluster during development.
- CI testing installs this on a single-node cluster

## Note for reviewers
See Backward Compatibility section. I'm not particularly comfortable with the way we integrate changes into the ansible deploy that can't be installed as an upgrade. But I don't know a different way to put these changes out.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
