### PR TITLE
Add jupyter ai ollama lib + egress to jupyter notebook

### DIFF
--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -60,6 +60,7 @@ k3s_cluster:
     prometheus_namespace: prometheus
     grafana_namespace: grafana
     loki_namespace: loki
+    ollama_namespace: ollama
 
     # Local paths
     base_dir: /var/lib

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -111,6 +111,7 @@ k3s_cluster:
     prometheus_namespace: prometheus
     grafana_namespace: grafana
     loki_namespace: loki
+    ollama_namespace: ollama
 
     # Local paths
     base_dir: /var/lib/rancher/k3s/storage # Path to directory for container images and sandbox data

--- a/ansible/playbooks/vars/jupyter.values.yaml
+++ b/ansible/playbooks/vars/jupyter.values.yaml
@@ -109,3 +109,9 @@ singleuser:
                 kubernetes.io/metadata.name: '{{ hive_namespace }}'
         ports:
           - port: 9083
+      - to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: '{{ ollama_namespace | default("ollama")}}'
+        ports:
+          - port: 11434

--- a/helm/jupyter/notebook/requirements.txt
+++ b/helm/jupyter/notebook/requirements.txt
@@ -2,3 +2,4 @@ delta-spark
 jupyterlab-git
 jupyter-ai
 langchain-openai
+langchain-ollama


### PR DESCRIPTION

## Type of change
- [ ] Work behind a feature flag
- [X] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
Jupyter AI users can configure a connection to models on an ollama

### Technical
- Add a dependency on `langchain-ollama` to jupyter's `requirements.txt`. This enables support for configuring connections to models on ollama servers in the jupyter AI plugin.
- Add egress from jupyter to the ollama namespace

## Impact
This doesn't have a lot of impact now, since I haven't added the ollama deploy to ansible. But this is a small first step that makes development and testing easier (i.e. I won't have to build and deploy a custom jupyter image).

## Testing
I have previously built the image this way and manually applied it to my dev cluster. I had trouble doing the same more recently with the `containerd` runtime, so I haven't tried it recently. But I'm pretty sure it will still work.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
