### PR TITLE
Simplify postgres init script creation

### DIFF
--- a/ansible/playbooks/postgres.yaml
+++ b/ansible/playbooks/postgres.yaml
@@ -23,52 +23,20 @@
         patterns: '*_init_sql.yaml'
       register: sql_init_files
 
-    - name: Create secure temporary directory
-      ansible.builtin.tempfile:
-        state: directory
-        suffix: postgres_sql_init
-      register: temp_dir
-
     - name: Initialize empty SQL statements list
       ansible.builtin.set_fact:
         postgres_init_sql: []
 
-    - name: Process SQL init files dynamically
-      block:
-        - name: Template SQL file to temporary location
-          ansible.builtin.template:
-            src: '{{ item.path }}'
-            dest: '{{ temp_dir.path }}/{{ item.path | basename }}'
-          loop: '{{ sql_init_files.files }}'
-          loop_control:
-            label: '{{ item.path | basename }}'
-          no_log: true
-
-        - name: Include templated SQL files
-          ansible.builtin.include_vars:
-            file: '{{ temp_dir.path }}/{{ item.path | basename }}'
-          loop: '{{ sql_init_files.files }}'
-          loop_control:
-            label: '{{ item.path | basename }}'
-          no_log: true
-
-        - name: Add SQL statements to combined list
-          ansible.builtin.set_fact:
-            postgres_init_sql: '{{ postgres_init_sql + vars[module_init_sql] }}'
-          when: module_enabled not in vars or vars[module_enabled] | bool
-          vars:
-            module_name: "{{ item.path | basename | regex_replace('_init_sql\\.yaml$', '') }}"
-            module_enabled: "{{ module_name + '_enabled' }}"
-            module_init_sql: "{{ module_name + '_init_sql' }}"
-          loop: '{{ sql_init_files.files }}'
-          loop_control:
-            label: '{{ item.path | basename }}'
-          no_log: true
-      always:
-        - name: Remove temporary directory
-          ansible.builtin.file:
-            path: '{{ temp_dir.path }}'
-            state: absent
+    - name: Add SQL statements to combined list
+      ansible.builtin.set_fact:
+        postgres_init_sql: '{{ postgres_init_sql + lookup("template", item.path) | from_yaml }}'
+      when: module_enabled not in vars or vars[module_enabled] | bool
+      vars:
+        module_name: "{{ item.path | basename | regex_replace('_init_sql\\.yaml$', '') }}"
+        module_enabled: "{{ module_name + '_enabled' }}"
+      loop: '{{ sql_init_files.files }}'
+      loop_control:
+        label: '{{ item.path | basename }}'
 
   tasks:
     - name: Add Postgres Helm repository

--- a/ansible/playbooks/templates/postgres_init/README.md
+++ b/ansible/playbooks/templates/postgres_init/README.md
@@ -2,8 +2,8 @@
 Place a Postgres init SQL script here to be run when the Postgres database is created.
 
 For service `example`, create a file named `example_init_sql.yaml` in this directory.
-The file should contain a single key `example_init_sql` which should contain a list
-of SQL commands to run. These lines can contain template variables like `{{ variable }}`.
+The file should contain a list, each element of which is a line of an SQL script to run.
+These lines can contain template variables like `{{ variable }}`.
 
-Additionally, you can conditionally disable running the init SQL by defining a variable
+Additionally, you can conditionally disable running the init SQL for service `example` by defining a variable
 `example_enabled` and setting it to `false`. If this variable is not defined, it defaults to `true`.

--- a/ansible/playbooks/templates/postgres_init/hive_init_sql.yaml
+++ b/ansible/playbooks/templates/postgres_init/hive_init_sql.yaml
@@ -1,4 +1,3 @@
 ---
-hive_init_sql:
-  - "CREATE USER {{ hive_postgres_user }} WITH PASSWORD '{{ hive_postgres_password }}';"
-  - 'CREATE DATABASE hive OWNER {{ hive_postgres_user }};'
+- "CREATE USER {{ hive_postgres_user }} WITH PASSWORD '{{ hive_postgres_password }}';"
+- 'CREATE DATABASE hive OWNER {{ hive_postgres_user }};'

--- a/ansible/playbooks/templates/postgres_init/superset_init_sql.yaml
+++ b/ansible/playbooks/templates/postgres_init/superset_init_sql.yaml
@@ -1,4 +1,3 @@
 ---
-superset_init_sql:
-  - "CREATE USER {{ superset_postgres_user }} WITH PASSWORD '{{ superset_postgres_password }}';"
-  - 'CREATE DATABASE superset OWNER {{ superset_postgres_user }};'
+- "CREATE USER {{ superset_postgres_user }} WITH PASSWORD '{{ superset_postgres_password }}';"
+- 'CREATE DATABASE superset OWNER {{ superset_postgres_user }};'


### PR DESCRIPTION
## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [X] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description
Followup from #143.

I was bothered by the need to create a temp dir with resolved template files. I knew there was a simpler way but couldn't quite make it happen yesterday. Today I realized how to do it.

The part I was stuck on is that I was passing the pieces of the init scripts as vars, and `include_vars` only reads a file. We can't point it to the source files (which was my first attempt) because then it wouldn't resolve the templates, so it seemed we needed to resolve the source files to temp files and pass those to `include_vars`. But I realized we were only including the contents of the file as a var so we could pass that var to another task; but if that later task itself loaded the source file as a template then there was no need to use `include_vars` at all.

## Impact
Very little, but it makes this part of the playbook easier to understand and more maintainable IMO.

### Backward compatibility
✅ 

## Testing
Manually deployed to 03 cluster.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [X] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
