### PR TITLE
Ansible improvements

### DIFF
--- a/ansible/playbooks/orchestrator.yaml
+++ b/ansible/playbooks/orchestrator.yaml
@@ -182,7 +182,7 @@
             labels:
               app: prospective-indexing
           spec:
-            backoffLimit: 10
+            backoffLimit: 5
             template:
               metadata:
                 labels:
@@ -192,6 +192,9 @@
                 containers:
                   - name: prospective-indexing-setup
                     image: temporalio/admin-tools
+                    env:
+                      - name: TEMPORAL_CLI_ADDRESS
+                        value: 'temporal-frontend.{{ temporal_namespace }}:7233'
                     command:
                       - temporal
                       - schedule

--- a/ansible/playbooks/orchestrator.yaml
+++ b/ansible/playbooks/orchestrator.yaml
@@ -193,7 +193,7 @@
                   - name: prospective-indexing-setup
                     image: temporalio/admin-tools
                     env:
-                      - name: TEMPORAL_CLI_ADDRESS
+                      - name: TEMPORAL_ADDRESS
                         value: 'temporal-frontend.{{ temporal_namespace }}:7233'
                     command:
                       - temporal

--- a/ansible/playbooks/orchestrator.yaml
+++ b/ansible/playbooks/orchestrator.yaml
@@ -182,7 +182,7 @@
             labels:
               app: prospective-indexing
           spec:
-            backoffLimit: 3
+            backoffLimit: 10
             template:
               metadata:
                 labels:

--- a/ansible/playbooks/orchestrator.yaml
+++ b/ansible/playbooks/orchestrator.yaml
@@ -163,3 +163,46 @@
         fi
       register: temporal_schema
       changed_when: false
+
+    - name: Construct cron schedule
+      when: scheduled_ingest_cron is undefined and scheduled_ingest_hour is defined
+      set_fact:
+        scheduled_ingest_cron: '0 {{ scheduled_ingest_hour }} * * *'
+
+    - name: Add scheduled task for prospective report indexing
+      when: scheduled_ingest_cron is defined
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: 'add-prospective-indexing'
+            namespace: '{{ temporal_namespace }}'
+            labels:
+              app: prospective-indexing
+          spec:
+            backoffLimit: 3
+            template:
+              metadata:
+                labels:
+                  app: prospective-indexing
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: prospective-indexing-setup
+                    image: temporalio/admin-tools
+                    command:
+                      - temporal
+                      - schedule
+                      - create
+                      - '--schedule-id'
+                      - ScheduledReportIngest
+                      - '--workflow-id'
+                      - ScheduledReportIngest
+                      - '--task-queue'
+                      - ingest-hl7-log
+                      - '--type'
+                      - IngestHl7LogWorkflow
+                      - '--cron'
+                      - '{{ scheduled_ingest_cron }}'

--- a/ansible/playbooks/scout.yaml
+++ b/ansible/playbooks/scout.yaml
@@ -8,4 +8,4 @@
       git:
         repo: https://github.com/washu-tag/scout.git
         dest: '{{ scout_repo_dir }}'
-        version: main
+        version: '{{ scout_branch | default("main") }}'


### PR DESCRIPTION
# Ansible improvements for automatic scheduled ingest setup and scout branch specification

## Type of change
- [X] Work behind a feature flag
- [X] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
There are two changes in this PR to the installation process with ansible:
1. You can specify either of the ansible variables `scheduled_ingest_cron` or `scheduled_ingest_hour` to automatically set up scheduled report indexing when temporal is installed. `scheduled_ingest_cron` specifies the full cron string for the schedule for flexibility. Alternatively, `scheduled_ingest_hour` can be specified instead as an integer for a simple daily schedule at the specified hour.
2. In the `scout` playbook, cloning the `main` branch is no longer hardcoded. Specifying `scout_branch` in your ansible inventory will allow you to check out an arbitrary branch instead for development. If not specified, it will default back to `main`.

### Technical
Setting up the scheduled ingest is done as a Kubernetes job with no `ttlSecondsAfterFinished` specified. This is to keep the completed job around indefinitely so that it will never run again, even if the variables have been updated. I would rather err on the side of caution and not make any changes (if, for example, the schedule was changed in the temporal UI), and this is something we expect to only set up the first time.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
Leaving out all of the new variables should default to the old behavior.

## Testing
Tested out specifying the variables on my dev VM.

## Note for reviewers
See description.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
