### PR TITLE
oauth2-proxy cookie expiration / max-age

### DIFF
--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -32,6 +32,7 @@ k3s_cluster:
 
     # Oauth2 Proxy config
     oauth2_proxy_cookie_secret: $(openssl rand -hex 16 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    oauth2_proxy_cookie_expire: '24h' # Optional, default is 24h
 
     # Keycloak Config
     keycloak_namespace: auth

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -32,7 +32,7 @@ k3s_cluster:
 
     # Oauth2 Proxy config
     oauth2_proxy_cookie_secret: $(openssl rand -hex 16 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
-    oauth2_proxy_cookie_expire: '24h' # Optional, default is 24h
+    oauth2_proxy_cookie_expire: '8h' # Optional, default is 8h
 
     # Keycloak Config
     keycloak_namespace: auth

--- a/ansible/playbooks/services/oauth2-proxy.yaml
+++ b/ansible/playbooks/services/oauth2-proxy.yaml
@@ -60,6 +60,7 @@
           redirect_url = "https://{{ server_hostname }}/oauth2/callback"
           oidc_issuer_url = "https://{{ server_hostname }}/kc/realms/scout"
           allowed_roles = "scout-user"
+          cookie_expire = "{{ oauth2_proxy_cookie_expire | default('24h') }}"
           skip_provider_button = false
           email_domains=  ['*']
           reverse_proxy = true

--- a/ansible/playbooks/services/oauth2-proxy.yaml
+++ b/ansible/playbooks/services/oauth2-proxy.yaml
@@ -60,7 +60,7 @@
           redirect_url = "https://{{ server_hostname }}/oauth2/callback"
           oidc_issuer_url = "https://{{ server_hostname }}/kc/realms/scout"
           allowed_roles = "scout-user"
-          cookie_expire = "{{ oauth2_proxy_cookie_expire | default('24h') }}"
+          cookie_expire = "{{ oauth2_proxy_cookie_expire | default('8h') }}"
           skip_provider_button = false
           email_domains=  ['*']
           reverse_proxy = true


### PR DESCRIPTION
# Add optional ansible variable to set oauth2-proxy cookie expiration time

## Type of change
- [x] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
- Add optional Ansible variable to configure oauth2-proxy cookie expiration time
- Provides flexibility to adjust session duration based on security requirements
- Default set to 8h

### Technical
- Adds configurable `oauth2_proxy_cookie_expire` variable to Ansible inventory

## Impact

### Security 

##### Authorization
N/A

##### Appsec
[OWASP list](https://github.com/0xRadi/OWASP-Web-Checklist) recommends checking the cookie duration (expires / max-age). This will apply a consistent session timeout across all services behind oauth2-proxy. This is a hard expiration timeout, not an inactivity timeout. Users will need to re-authenticate when the cookie expires regardless of activity

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
Verified oa2p cookie duration was set.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
