### PR TITLE
Add Keycloak audit logging for user and admin events

### DIFF
--- a/ansible/playbooks/services/keycloak.yaml
+++ b/ansible/playbooks/services/keycloak.yaml
@@ -106,6 +106,8 @@
             value: 'true'
           - name: event-metrics-user-tags
             value: 'realm,idp,clientId'
+          - name: spi-events-listener-jboss-logging-success-level
+            value: info
 
 # The operator wants to use a subdomain and does not appear to support a path-based ingress
 - name: Create Keycloak Ingress

--- a/ansible/playbooks/templates/keycloak/scout-realm.json.j2
+++ b/ansible/playbooks/templates/keycloak/scout-realm.json.j2
@@ -8,6 +8,7 @@
     "emailTheme": "scout",
     "eventsListeners": [
       "user-approval-email",
+      "jboss-logging"
     ],
     "smtpServer": {
       "debug": "{{ keycloak_smtp_debug }}",


### PR DESCRIPTION
# Add Keycloak audit logging for user and admin events

## Type of change
- [x] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
- Keycloak user and admin events (such as user registration, group membership changes, and login events) are now available in Grafana for monitoring and auditing

### Technical
- Enables jboss-logging feature in Keycloak to log admin and user events to the syslog. Loki then makes the logs available in Grafana for easy searching.
- Bump jboss event logging level to info instead of the default debug level to reduce log noise

## Impact

### Security 

##### Authorization
N/A

##### Appsec
Improves security monitoring with complete logs of user authentication events

### Performance
N/A

### Data
Event logs container user identifiers and timestamps.

### Backward compatibility
Should be. This change only adds logging configuration.

## Testing
Tested on big-02. Confirmed Keycloak event logs were available in Loki

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
