### PR TITLE
Add NVIDIA container toolkit (runtime) installation to GPU node K3s install prep work

### DIFF
--- a/ansible/playbooks/k3s.yaml
+++ b/ansible/playbooks/k3s.yaml
@@ -118,6 +118,27 @@
         content: |
           default-runtime: nvidia
 
+    - name: Add NVIDIA container toolkit repository
+      get_url:
+        url: https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo
+        dest: /etc/yum.repos.d/nvidia-container-toolkit.repo
+        mode: '0644'
+
+    - name: Install NVIDIA container toolkit packages
+      package:
+        name:
+          - nvidia-container-toolkit
+          - nvidia-container-toolkit-base
+          - libnvidia-container-tools
+          - libnvidia-container1
+        state: present
+
+    - name: Verify NVIDIA container toolkit installation
+      command: nvidia-ctk --version
+      register: nvidia_ctk_version
+      changed_when: false
+
+################################################################################
 - hosts: agents
   name: Install k3s on agent nodes
   vars:


### PR DESCRIPTION
# Add NVIDIA container toolkit (runtime) installation to GPU node K3s install prep work

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer. 

For all other change types, the developer should attempt to provide as much detail as is reasonable.

## Description

### Product
No product facing changes

### Technical
Install NVIDIA container runtime on GPU node before installing k3s with `nvidia` default runtime, which is apparently required.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
Yes

## Testing
Ran on 04 cluster

## Note for reviewers
[Any additional information or direction for reviewers.]

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
