### PR TITLE
Add LangExtract to single-user Jupyter notebook image

### DIFF
--- a/helm/jupyter/notebook/requirements.txt
+++ b/helm/jupyter/notebook/requirements.txt
@@ -3,3 +3,4 @@ jupyterlab-git
 jupyter-ai
 langchain-openai
 langchain-ollama
+langextract


### PR DESCRIPTION
# Add LangExtract to single-user Jupyter notebook image

## Type of change
- [x] Work behind a feature flag
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
- Adds [LangExtract](https://github.com/google/langextract) to the single-user Jupyter notebook image.

### Technical
- Version of LangExtract is not pinned down. v1 is only a month old and there have been multiple 1.0.x releases in the past two weeks that have fixed issues I was experiencing. Would like to grab the latest release for now.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
Tested on big-02 cluster with ollama.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
