### PR TITLE
Add llama3.1:70b to Ollama helm chart model pulls

### DIFF
--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -107,12 +107,6 @@ k3s_cluster:
     # Superset config
     superset_secret: $(openssl rand -base64 42 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
 
-    # Ollama config
-    ollama_pull_models:
-      - llama3.2:3b
-      - llama4:scout
-      - llama3.1:70b
-
     # Orchestrator config
     cassandra_storage_size: 300Gi
     elasticsearch_storage_size: 100Gi

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -107,6 +107,12 @@ k3s_cluster:
     # Superset config
     superset_secret: $(openssl rand -base64 42 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
 
+    # Ollama config
+    ollama_pull_models:
+      - llama3.2:3b
+      - llama4:scout
+      - llama3.1:70b
+
     # Orchestrator config
     cassandra_storage_size: 300Gi
     elasticsearch_storage_size: 100Gi

--- a/models/ollama/values.yaml
+++ b/models/ollama/values.yaml
@@ -2,6 +2,7 @@ ollama:
   models:
     pull:
       - llama3.2:3b
+      - llama3.1:70b
 ingress:
   enabled: true
   ingressClassName: traefik

--- a/models/ollama/values.yaml
+++ b/models/ollama/values.yaml
@@ -1,7 +1,6 @@
 ollama:
   models:
-    pull:
-      - llama3.2:3b
+    pull: {{ ollama_pull_models | default([]) }}
 ingress:
   enabled: true
   ingressClassName: traefik

--- a/models/ollama/values.yaml
+++ b/models/ollama/values.yaml
@@ -1,6 +1,7 @@
 ollama:
   models:
-    pull: {{ ollama_pull_models | default([]) }}
+    pull:
+      - llama3.2:3b
 ingress:
   enabled: true
   ingressClassName: traefik


### PR DESCRIPTION
# Add llama3.1:70b to Ollama helm chart model pulls

## Type of change
- [x] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product/Technical
- Pull llama3.1:70b into Ollama at helm install time

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
`llama3.1:70b` is `43GB` and takes some time to pull but is a one time cost.

### Data
N/A

### Backward compatibility
N/A

## Testing
Tested with LangExtract in Jupyter nb on big-02 cluster.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
