### PR TITLE
Add Open WebUI (and Ollama) to Ansible

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -76,3 +76,7 @@ install-orthanc:
 
 install-dcm4chee:
 	$(ANSIBLE_CMD) playbooks/dcm4chee.yaml
+
+install-openwebui:
+    $(ANSIBLE_CMD) playbooks/open-webui.yaml
+

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -77,6 +77,7 @@ k3s_cluster:
     superset_postgres_user: superset
     superset_postgres_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     postgres_superuser_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    postgres_cluster_name: postgresql-cluster
     postgres_resources:
       requests:
         cpu: 4
@@ -105,7 +106,21 @@ k3s_cluster:
       max_parallel_maintenance_workers: '2'
 
     # Superset config
+    superset_enabled: false # You cannot enable both superset and openwebui
     superset_secret: $(openssl rand -base64 42 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+
+    # Open WebUI and Ollama config
+    open_webui_enabled: true # You cannot enable both superset and openwebui
+    open_webui_namespace: ollama
+    open_webui_postgres_user: openwebui
+    open_webui_postgres_password: $(openssl rand -hex 32 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
+    open_webui_database: openwebui
+    open_webui_dir: '/scout/persistence/openwebui'
+    ollama_dir: '/scout/persistence/ollama'
+    ollama_models:
+      - llama3.2:3b
+      - llama3.1:70b
+      - gpt-oss:120b
 
     # Orchestrator config
     cassandra_storage_size: 300Gi
@@ -117,7 +132,6 @@ k3s_cluster:
     prometheus_namespace: prometheus
     grafana_namespace: grafana
     loki_namespace: loki
-    ollama_namespace: ollama
     gpu_operator_namespace: gpu-operator
 
     # Local paths

--- a/ansible/playbooks/analytics.yaml
+++ b/ansible/playbooks/analytics.yaml
@@ -11,3 +11,4 @@
 
     - name: Install Superset
       include_tasks: services/superset.yaml
+      when: superset_enabled | bool

--- a/ansible/playbooks/main.yaml
+++ b/ansible/playbooks/main.yaml
@@ -20,6 +20,10 @@
 - name: Install Analytics
   import_playbook: analytics.yaml
 
+- name: Install Open WebUI
+  import_playbook: open-webui.yaml
+  when: open_webui_enabled | bool
+
 - name: Install Orchestrator
   import_playbook: orchestrator.yaml
 

--- a/ansible/playbooks/open-webui.yaml
+++ b/ansible/playbooks/open-webui.yaml
@@ -1,0 +1,94 @@
+---
+- name: Create storage directories for Open WebUI and Ollama
+  hosts: k3s_cluster
+  gather_facts: false
+  vars_files:
+    - vars/open_webui_storage.yaml
+  tasks:
+    - name: Create storage directories
+      include_tasks: tasks/storage_dir_create.yaml
+
+- name: Install Open WebUI
+  hosts: server
+  gather_facts: false
+  environment:
+    HELM_PLUGINS: '{{ helm_plugins_dir }}'
+    KUBECONFIG: '{{ kubeconfig_yaml }}'
+  vars_files:
+    - vars/open_webui_storage.yaml
+  vars:
+    helm_repo_name: open-webui
+    helm_repo_url: https://helm.openwebui.com/
+    helm_chart_name: open-webui
+    helm_release_name: open-webui
+    ollama_strip_prefix_middleware: ollama-strip-prefix
+    ollama_path: /ollama-service
+
+  tasks:
+    - name: Create Open WebUI namespace
+      kubernetes.core.k8s:
+        name: "{{ open_webui_namespace }}"
+        kind: Namespace
+        state: present
+
+    - name: Add Open WebUI Helm repository
+      kubernetes.core.helm_repository:
+        name: "{{ helm_repo_name }}"
+        repo_url: "{{ helm_repo_url }}"
+
+    - name: Setup PostgreSQL database and user
+      block:
+        - name: Add SQL statements to variable
+          ansible.builtin.set_fact:
+            postgres_init_sql: '{{ lookup("template", "templates/open-webui/init_sql.yaml.j2") | from_yaml | join("\n") }}'
+
+        - name: Execute SQL initialization
+          kubernetes.core.k8s_exec:
+            namespace: "{{ postgres_cluster_namespace }}"
+            pod: "{{ postgres_cluster_name }}-1"
+            command: |
+              psql --dbname=postgres -c "{{ postgres_init_sql }}"
+          register: sql_result
+          failed_when:
+            - sql_result.rc != 0
+
+    - name: Create Traefik Middleware to strip prefix
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: traefik.io/v1alpha1
+          kind: Middleware
+          metadata:
+            name: "{{ ollama_strip_prefix_middleware }}"
+            namespace: kube-system
+          spec:
+            stripPrefix:
+              prefixes:
+                - {{ ollama_path }}
+
+    - name: Deploy Open WebUI using Helm
+      kubernetes.core.helm:
+        name: "{{ helm_release_name }}"
+        chart_ref: "{{ helm_repo_name }}/{{ helm_chart_name }}"
+        release_namespace: "{{ open_webui_namespace }}"
+        update_repo_cache: true
+        chart_version: ~7.3.0
+        values: "{{ lookup('template', 'templates/open-webui/values.yaml.j2') | from_yaml }}"
+        state: present
+        wait: true
+        wait_timeout: 15m
+
+    - name: Verify deployment
+      kubernetes.core.k8s_info:
+        api_version: apps/v1
+        kind: Deployment
+        namespace: "{{ open_webui_namespace }}"
+        label_selectors:
+          - "app.kubernetes.io/instance={{ helm_release_name }}"
+      register: deployment_status
+
+    - name: Display deployment status
+      debug:
+        msg: "Open WebUI deployment status: {{ item.status.conditions[-1].type }} - {{ item.status.conditions[-1].status }}"
+      loop: "{{ deployment_status.resources }}"
+      when: deployment_status.resources | length > 0

--- a/ansible/playbooks/open-webui.yaml
+++ b/ansible/playbooks/open-webui.yaml
@@ -25,32 +25,53 @@
     ollama_path: /ollama-service
 
   tasks:
+    - name: Set up storage
+      include_tasks: tasks/storage_setup.yaml
+
     - name: Create Open WebUI namespace
       kubernetes.core.k8s:
-        name: "{{ open_webui_namespace }}"
+        name: '{{ open_webui_namespace }}'
         kind: Namespace
         state: present
 
     - name: Add Open WebUI Helm repository
       kubernetes.core.helm_repository:
-        name: "{{ helm_repo_name }}"
-        repo_url: "{{ helm_repo_url }}"
+        name: '{{ helm_repo_name }}'
+        repo_url: '{{ helm_repo_url }}'
 
     - name: Setup PostgreSQL database and user
       block:
-        - name: Add SQL statements to variable
-          ansible.builtin.set_fact:
-            postgres_init_sql: '{{ lookup("template", "templates/open-webui/init_sql.yaml.j2") | from_yaml | join("\n") }}'
-
-        - name: Execute SQL initialization
+        - name: Create user (ignore if exists)
           kubernetes.core.k8s_exec:
-            namespace: "{{ postgres_cluster_namespace }}"
-            pod: "{{ postgres_cluster_name }}-1"
+            namespace: '{{ postgres_cluster_namespace }}'
+            pod: '{{ postgres_cluster_name }}-1'
             command: |
-              psql --dbname=postgres -c "{{ postgres_init_sql }}"
-          register: sql_result
+              psql --dbname=postgres -c "CREATE USER {{ open_webui_postgres_user }} WITH PASSWORD '{{ open_webui_postgres_password }}';"
+          register: user_result
           failed_when:
-            - sql_result.rc != 0
+            - user_result.rc != 0
+            - '"already exists" not in user_result.stderr'
+
+        - name: Create database (ignore if exists)
+          kubernetes.core.k8s_exec:
+            namespace: '{{ postgres_cluster_namespace }}'
+            pod: '{{ postgres_cluster_name }}-1'
+            command: |
+              psql --dbname=postgres -c "CREATE DATABASE {{ open_webui_database }} OWNER {{ open_webui_postgres_user }};"
+          register: db_result
+          failed_when:
+            - db_result.rc != 0
+            - '"already exists" not in db_result.stderr'
+
+        - name: Grant schema ownership to user
+          kubernetes.core.k8s_exec:
+            namespace: '{{ postgres_cluster_namespace }}'
+            pod: '{{ postgres_cluster_name }}-1'
+            command: |
+              psql --dbname={{ open_webui_database }} -c "ALTER SCHEMA public OWNER TO {{ open_webui_postgres_user }};"
+          register: schema_privileges_result
+          failed_when:
+            - schema_privileges_result.rc != 0
 
     - name: Create Traefik Middleware to strip prefix
       kubernetes.core.k8s:
@@ -59,36 +80,22 @@
           apiVersion: traefik.io/v1alpha1
           kind: Middleware
           metadata:
-            name: "{{ ollama_strip_prefix_middleware }}"
+            name: '{{ ollama_strip_prefix_middleware }}'
             namespace: kube-system
           spec:
             stripPrefix:
               prefixes:
-                - {{ ollama_path }}
+                - '{{ ollama_path }}'
 
     - name: Deploy Open WebUI using Helm
       kubernetes.core.helm:
-        name: "{{ helm_release_name }}"
-        chart_ref: "{{ helm_repo_name }}/{{ helm_chart_name }}"
-        release_namespace: "{{ open_webui_namespace }}"
-        update_repo_cache: true
-        chart_version: ~7.3.0
-        values: "{{ lookup('template', 'templates/open-webui/values.yaml.j2') | from_yaml }}"
         state: present
+        name: '{{ helm_release_name }}'
+        chart_ref: '{{ helm_repo_name }}/{{ helm_chart_name }}'
+        release_namespace: '{{ open_webui_namespace }}'
+        update_repo_cache: true
+        chart_version: ~7.5.0
         wait: true
         wait_timeout: 15m
-
-    - name: Verify deployment
-      kubernetes.core.k8s_info:
-        api_version: apps/v1
-        kind: Deployment
-        namespace: "{{ open_webui_namespace }}"
-        label_selectors:
-          - "app.kubernetes.io/instance={{ helm_release_name }}"
-      register: deployment_status
-
-    - name: Display deployment status
-      debug:
-        msg: "Open WebUI deployment status: {{ item.status.conditions[-1].type }} - {{ item.status.conditions[-1].status }}"
-      loop: "{{ deployment_status.resources }}"
-      when: deployment_status.resources | length > 0
+        atomic: true
+        values: "{{ lookup('template', 'templates/open-webui/values.yaml.j2') | from_yaml }}"

--- a/ansible/playbooks/postgres.yaml
+++ b/ansible/playbooks/postgres.yaml
@@ -102,7 +102,7 @@
           apiVersion: postgresql.cnpg.io/v1
           kind: Cluster
           metadata:
-            name: postgresql-cluster
+            name: '{{ postgres_cluster_name }}'
             namespace: '{{ postgres_cluster_namespace }}'
           spec:
             instances: 1
@@ -130,17 +130,17 @@
           apiVersion: v1
           kind: Service
           metadata:
-            name: postgresql-cluster-metrics
+            name: '{{ postgres_cluster_name }}-metrics'
             namespace: '{{ postgres_cluster_namespace }}'
           spec:
             selector:
-              cnpg.io/cluster: postgresql-cluster
+              cnpg.io/cluster: '{{ postgres_cluster_name }}'
             ports:
               - name: metrics
                 port: 9187
                 targetPort: metrics
 
     - name: Wait for Postgres to be ready
-      command: 'kubectl -n {{ postgres_cluster_namespace }} wait --for=condition=Ready --timeout=300s cluster/postgresql-cluster'
+      command: 'kubectl -n {{ postgres_cluster_namespace }} wait --for=condition=Ready --timeout=300s cluster/{{ postgres_cluster_name }}'
       register: postgres_ready
       changed_when: false

--- a/ansible/playbooks/templates/open-webui/init_sql.yaml.j2
+++ b/ansible/playbooks/templates/open-webui/init_sql.yaml.j2
@@ -1,0 +1,3 @@
+---
+- "CREATE USER IF NOT EXISTS {{ open_webui_postgres_user }} WITH PASSWORD '{{ open_webui_postgres_password }}';"
+- 'CREATE DATABASE IF NOT EXISTS {{ open_webui_database }} OWNER {{ open_webui_postgres_user }};'

--- a/ansible/playbooks/templates/open-webui/init_sql.yaml.j2
+++ b/ansible/playbooks/templates/open-webui/init_sql.yaml.j2
@@ -1,3 +1,0 @@
----
-- "CREATE USER IF NOT EXISTS {{ open_webui_postgres_user }} WITH PASSWORD '{{ open_webui_postgres_password }}';"
-- 'CREATE DATABASE IF NOT EXISTS {{ open_webui_database }} OWNER {{ open_webui_postgres_user }};'

--- a/ansible/playbooks/templates/open-webui/values.yaml.j2
+++ b/ansible/playbooks/templates/open-webui/values.yaml.j2
@@ -39,7 +39,7 @@ persistence:
   storageClass: {{ open_webui_storage_class }}
 
 # -- Configure database URL, needed to work with Postgres (example: `postgresql://<user>:<password>@<service>:<port>/<database>`), leave empty to use the default sqlite database
-databaseUrl: 'postgresql://{{ open_webui_postgres_user }}:{{ open_webui_postgres_password }}@postgresql-cluster-r.{{ postgres_cluster_namespace }}:5432/{{ open_webui_database }}'
+databaseUrl: 'postgresql://{{ open_webui_postgres_user }}:{{ open_webui_postgres_password }}@postgresql-cluster-rw.{{ postgres_cluster_namespace }}:5432/{{ open_webui_database }}'
 
 enableOpenaiApi: false
 

--- a/ansible/playbooks/templates/open-webui/values.yaml.j2
+++ b/ansible/playbooks/templates/open-webui/values.yaml.j2
@@ -1,0 +1,48 @@
+nameOverride: ''
+namespaceOverride: ''
+ollama:
+  # -- Automatically install Ollama Helm chart from https://otwld.github.io/ollama-helm/. Use [Helm Values](https://github.com/otwld/ollama-helm/#helm-values) to configure
+  enabled: true
+  # -- If enabling embedded Ollama, update fullnameOverride to your desired Ollama name value, or else it will use the default ollama.name value from the Ollama chart
+  fullnameOverride: ollama
+  ollama:
+    gpu:
+      enabled: true
+      type: 'nvidia'
+      number: 1
+    models:
+      pull: {{ ollama_models }}
+  ingress:
+    enabled: true
+    ingressClassName: traefik
+    annotations:
+      traefik.ingress.kubernetes.io/router.middlewares: kube-system-{{ ollama_strip_prefix_middleware }}@kubernetescrd
+    hosts:
+      - host: {{ server_hostname }}
+        paths:
+          - path: {{ ollama_path }}
+            pathType: Prefix
+  persistentVolume:
+    enabled: true
+    storageClass: {{ ollama_storage_class }}
+
+pipelines:
+  enabled: false
+
+ingress:
+  enabled: true
+  class: traefik
+  host: {{ server_hostname }}
+
+persistence:
+  enabled: true
+  storageClass: {{ open_webui_storage_class }}
+
+# -- Configure database URL, needed to work with Postgres (example: `postgresql://<user>:<password>@<service>:<port>/<database>`), leave empty to use the default sqlite database
+databaseUrl: 'postgresql://{{ open_webui_postgres_user }}:{{ open_webui_postgres_password }}@postgresql-cluster-r.{{ postgres_cluster_namespace }}:5432/{{ open_webui_database }}'
+
+enableOpenaiApi: false
+
+websocket:
+  # -- Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT`
+  enabled: true

--- a/ansible/playbooks/vars/open_webui_storage.yaml
+++ b/ansible/playbooks/vars/open_webui_storage.yaml
@@ -1,7 +1,7 @@
 ollama_name: ollama
-ollama_storage_class: '{{jupyter_hub_name}}-storage'
+ollama_storage_class: '{{ ollama_name }}-storage'
 open_webui_name: open-webui
-open_webui_storage_class: '{{open_webui_name}}-storage'
+open_webui_storage_class: '{{ open_webui_name }}-storage'
 open_webui_pvc: '{{ open_webui_name }}-pvc'
 
 storage_definitions:

--- a/ansible/playbooks/vars/open_webui_storage.yaml
+++ b/ansible/playbooks/vars/open_webui_storage.yaml
@@ -1,0 +1,17 @@
+ollama_name: ollama
+ollama_storage_class: '{{jupyter_hub_name}}-storage'
+open_webui_name: open-webui
+open_webui_storage_class: '{{open_webui_name}}-storage'
+open_webui_pvc: '{{ open_webui_name }}-pvc'
+
+storage_definitions:
+  - name: '{{ ollama_name }}'
+    size: "{{ ollama_storage_size | default('200Gi') }}"
+    path: '{{ ollama_dir }}'
+    pv_name: '{{ ollama_name }}-pv'
+    storage_class_name: '{{ ollama_storage_class }}'
+  - name: '{{ open_webui_name }}'
+    size: "{{ open_webui_storage_size | default('100Gi') }}"
+    path: '{{ open_webui_dir }}'
+    pv_name: '{{ open_webui_name }}-pv'
+    storage_class_name: '{{ open_webui_storage_class }}'


### PR DESCRIPTION
# Add Open WebUI (and Ollama) to Ansible

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer. 

For all other change types, the developer should attempt to provide as much detail as is reasonable.

## Description

### Product
Adds Open Web UI service, if enabled, when running `make all` or via new `make install-openwebui` command.

### Technical
Add ansible playbook to install Open Web UI, which correspondingly installs Ollama.

## Impact

### Security 

##### Authorization
No user pre-creation for Open Web UI yet - on first sign-in, you're prompted to create an admin.

##### Appsec
No appsec review.

### Performance
N/A

### Data
N/A

### Backward compatibility
Cannot run with superset until we have subdomain support. Success depends on setting proper values in `inventory.yaml` for enabling one of the two services.

## Testing
Run the `make` on `04`.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
