### PR TITLE
Add Jupyter GPU request

### DIFF
--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -68,6 +68,11 @@ k3s_cluster:
     jupyter_prepuller_continuous: false
     jupyter_hub_storage_size: 15Gi
     jupyter_singleuser_storage_size: 250Gi
+    jupyter_singleuser_extraResource:
+      guarantees:
+        nvidia.com/gpu: '1'
+      limits:
+        nvidia.com/gpu: '1'
 
     # Postgres config
     postgres_user: scout

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -68,7 +68,7 @@ k3s_cluster:
     jupyter_prepuller_continuous: false
     jupyter_hub_storage_size: 15Gi
     jupyter_singleuser_storage_size: 250Gi
-    jupyter_singleuser_extraResource:
+    jupyter_singleuser_extra_resource:
       guarantees:
         nvidia.com/gpu: '1'
       limits:

--- a/ansible/playbooks/vars/jupyter.values.yaml
+++ b/ansible/playbooks/vars/jupyter.values.yaml
@@ -81,7 +81,7 @@ singleuser:
   memory:
     limit: 16G
     guarantee: 2G
-  extraResource: '{{ jupyter_singleuser_extraResource | default({}) }}'
+  extraResource: '{{ jupyter_singleuser_extra_resource | default({}) }}'
   storage:
     type: static
     static:

--- a/ansible/playbooks/vars/jupyter.values.yaml
+++ b/ansible/playbooks/vars/jupyter.values.yaml
@@ -81,11 +81,7 @@ singleuser:
   memory:
     limit: 16G
     guarantee: 2G
-  extraResource:
-    guarantees:
-      nvidia.com/gpu: '1'
-    limits:
-      nvidia.com/gpu: '1'
+  extraResource: '{{ jupyter_singleuser_extraResource | default({}) }}'
   storage:
     type: static
     static:

--- a/ansible/playbooks/vars/jupyter.values.yaml
+++ b/ansible/playbooks/vars/jupyter.values.yaml
@@ -81,6 +81,11 @@ singleuser:
   memory:
     limit: 16G
     guarantee: 2G
+  extraResource:
+    guarantees:
+      nvidia.com/gpu: '1'
+    limits:
+      nvidia.com/gpu: '1'
   storage:
     type: static
     static:


### PR DESCRIPTION

## Type of change
- [ ] Work behind a feature flag
- [X] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description
Request a GPU for Jupyter notebook pods.

This isn't parameterized, and there is no user control. All Jupyter pod launches will request a single GPU.

## Testing
I've deployed this on the `03` cluster and was able to use a GPU from a notebook. I believe Charlie did the same on `01`.

## Note for reviewers
This will need to be reconsidered for production, but is fine for our limited demo use case.
The biggest downside is that we'll run out of GPUs very quickly, so only a single user will be able to launch a notebook.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
