### PR TITLE
Initalize Keycloak PG User and DB with Ansible

### DIFF
--- a/ansible/playbooks/services/keycloak.yaml
+++ b/ansible/playbooks/services/keycloak.yaml
@@ -35,6 +35,40 @@
       reason: NewReplicaSetAvailable
     wait_timeout: 300
 
+- name: Setup PostgreSQL database and user
+  block:
+    - name: Create user (ignore if exists)
+      kubernetes.core.k8s_exec:
+        namespace: '{{ postgres_cluster_namespace }}'
+        pod: '{{ postgres_cluster_name }}-1'
+        command: |
+          psql --dbname=postgres -c "CREATE USER {{ keycloak_postgres_user }} WITH PASSWORD '{{ keycloak_postgres_password }}';"
+      register: user_result
+      failed_when:
+        - user_result.rc != 0
+        - '"already exists" not in user_result.stderr'
+
+    - name: Create database (ignore if exists)
+      kubernetes.core.k8s_exec:
+        namespace: '{{ postgres_cluster_namespace }}'
+        pod: '{{ postgres_cluster_name }}-1'
+        command: |
+          psql --dbname=postgres -c "CREATE DATABASE keycloak WITH ENCODING 'UTF8' OWNER {{ keycloak_postgres_user }};"
+      register: db_result
+      failed_when:
+        - db_result.rc != 0
+        - '"already exists" not in db_result.stderr'
+
+    - name: Grant schema ownership to user
+      kubernetes.core.k8s_exec:
+        namespace: '{{ postgres_cluster_namespace }}'
+        pod: '{{ postgres_cluster_name }}-1'
+        command: |
+          psql --dbname=keycloak -c "ALTER SCHEMA public OWNER TO {{ keycloak_postgres_user }};"
+      register: schema_privileges_result
+      failed_when:
+        - schema_privileges_result.rc != 0
+
 - name: Create Keycloak DB secret
   kubernetes.core.k8s:
     state: present

--- a/ansible/playbooks/templates/postgres_init/keycloak_init_sql.yaml
+++ b/ansible/playbooks/templates/postgres_init/keycloak_init_sql.yaml
@@ -1,3 +1,0 @@
----
-- CREATE USER {{ keycloak_postgres_user }} WITH PASSWORD '{{ keycloak_postgres_password }}';
-- CREATE DATABASE keycloak WITH ENCODING 'UTF8' OWNER {{ keycloak_postgres_user }};


### PR DESCRIPTION
# Initalize Keycloak PG User and DB with Ansible

## Type of change
- [x] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product / Technical
- Initalize Keycloak PG User and DB with Ansible. The CNPG `postInitSQL` option will only run on an empty / new cluster. We will need to be able to run on upgrade.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
Test on big-02 cluster.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
