### PR TITLE
Use bitnamilegacy image for superset redis chart

### DIFF
--- a/ansible/playbooks/services/superset.yaml
+++ b/ansible/playbooks/services/superset.yaml
@@ -61,6 +61,9 @@
       image:
         repository: '{{ superset_image | default("ghcr.io/washu-tag/superset") }}'
         tag: 4.1.2
+      redis:
+        image:
+          repository: bitnamilegacy/redis
       extraSecretEnv:
         SUPERSET_SECRET_KEY: '{{ superset_secret }}'
       ingress:


### PR DESCRIPTION
## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

Bitnami has removed their docker images to support a paywall strategy. But they have copied the existing images to a "legacy" account. See https://github.com/bitnami/charts/issues/35164

Superset depends on bitnami charts / images. See https://github.com/apache/superset/issues/34414

We can _temporarily_ work around this by pointing the superset redis chart to the legacy bitnami image. But longer term hopefully superset will update their chart to remove the bitnami dependency; we will need to update our superset chart at that time.

## Impact
This restores existing functionality. As far as I know there are no functional differences between the old image we used to use for this and the legacy image we use now.

## Testing
Successfully deployed this change to the `03` cluster.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
