### PR TITLE
Extraction updates for primary radiologist and observation ID suffix parsing

### DIFF
--- a/docs/source/dataschema.md
+++ b/docs/source/dataschema.md
@@ -5,42 +5,43 @@ and manage HL7 radiology reports and other data and metadata. There is one main 
 Below is a description of the report table schema and the mapping of HL7 fields to the report table columns. Note that 
 some fields are derived from others, and some fields may not be directly mapped to HL7 fields.
 
-| Column Name                        | HL7 Report Field | Data Type      | Nullable | Description/Notes                                                                                                                    |
-|------------------------------------|------------------|----------------|----------|--------------------------------------------------------------------------------------------------------------------------------------|
-| `source_file`                      |                  | string         | No       | The location of the report file.                                                                                                     |
-| `updated`                          |                  | timestamp      | No       | Timestamp of the last update to the report in the Delta Lake.                                                                        |
-| `message_control_id`               | MSH-10           | string         | Yes      | Unique identifier for the HL7 message.                                                                                               |
-| `sending_facility`                 | MSH-4            | string         | Yes      | Facility that sent the HL7 message.                                                                                                  |
-| `version_id`                       | MSH-12           | string         | Yes      | HL7 version used in the message.                                                                                                     |
-| `message_dt`                       | MSH-7            | timestamp      | Yes      | Date and time the message was created.                                                                                               |
-| `birth_date`                       | PID-7            | date           | Yes      | Patient’s date of birth.                                                                                                             |
-| `sex`                              | PID-8            | string         | Yes      | Patient’s gender.                                                                                                                    |
-| `race`                             | PID-10           | string         | Yes      | Patient’s race.                                                                                                                      |
-| `zip_or_postal_code`               | PID-11.5         | string         | Yes      | Patient’s ZIP or postal code.                                                                                                        |
-| `country`                          | PID-11.6         | string         | Yes      | Patient’s country.                                                                                                                   |
-| `ethnic_group`                     | PID-22           | string         | Yes      | Patient’s ethnicity.                                                                                                                 |
-| `patient_id_json`                  |                  | string         | Yes      | JSON representation of all patient identifiers. Patient ID columns are also created for each assigning authority (e.g., `epic_mrn`). |
-| `epic_mrn`                         |                  | string         | Yes      | Patient ID from Epic system.                                                                                                         |
-| `orc_2_placer_order_number`        | ORC-2            | string         | Yes      | Placer order number from the order control segment.                                                                                  |
-| `obr_2_placer_order_number`        | OBR-2            | string         | Yes      | Placer order number from the observation request segment.                                                                            |
-| `orc_3_filler_order_number`        | ORC-3            | string         | Yes      | Filler order number from the order control segment.                                                                                  |
-| `obr_3_filler_order_number`        | OBR-3            | string         | Yes      | Filler order number from the observation request segment.                                                                            |
-| `service_identifier`               | OBR-4.1          | string         | Yes      | Code for the service or exam.                                                                                                        |
-| `service_name`                     | OBR-4.2          | string         | Yes      | Name of the service or exam.                                                                                                         |
-| `service_coding_system`            | OBR-4.3          | string         | Yes      | Coding system used for the service identifier.                                                                                       |
-| `diagnostic_service_id`            | OBR-24           | string         | Yes      | Identifier for the diagnostic service.                                                                                               |
-| `modality`                         | Derived          | string         | Yes      | Modality of the exam (e.g., CT, MRI).                                                                                                |
-| `requested_dt`                     | OBR-6            | timestamp      | Yes      | Date and time the service was requested.                                                                                             |
-| `observation_dt`                   | OBR-7            | timestamp      | Yes      | Date and time the observation was made.                                                                                              |
-| `observation_end_dt`               | OBR-8            | timestamp      | Yes      | Date and time the observation ended.                                                                                                 |
-| `results_report_status_change_dt`  | OBR-22           | timestamp      | Yes      | Date and time the report status changed.                                                                                             |
-| `diagnosis_code`                   | DG1-3.1          | string         | Yes      | Diagnosis code.                                                                                                                      |
-| `diagnosis_code_text`              | DG1-3.2          | string         | Yes      | Description of the diagnosis.                                                                                                        |
-| `diagnosis_code_coding_system`     | DG1-3.3          | string         | Yes      | Coding system used for the diagnosis code.                                                                                           |
-| `study_instance_uid`               | ZDS-1            | string         | Yes      | Unique identifier for the study instance.                                                                                            |
-| `report_text`                      | OBX-5            | string         | Yes      | Full text of the diagnostic report.                                                                                                  |
-| `report_status`                    | OBX-11           | string         | Yes      | Status of the diagnostic report.                                                                                                     |
-| `year`                             | Derived          | integer        | Yes      | Year the message was created, derived from `message_dt`.                                                                             |
+| Column Name                       | HL7 Report Field | Data Type | Nullable | Description/Notes                                                                                                                       |
+|-----------------------------------|------------------|-----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `source_file`                     |                  | string    | No       | The location of the report file.                                                                                                        |
+| `updated`                         |                  | timestamp | No       | Timestamp of the last update to the report in the Delta Lake.                                                                           |
+| `message_control_id`              | MSH-10           | string    | Yes      | Unique identifier for the HL7 message.                                                                                                  |
+| `sending_facility`                | MSH-4            | string    | Yes      | Facility that sent the HL7 message.                                                                                                     |
+| `version_id`                      | MSH-12           | string    | Yes      | HL7 version used in the message.                                                                                                        |
+| `message_dt`                      | MSH-7            | timestamp | Yes      | Date and time the message was created.                                                                                                  |
+| `birth_date`                      | PID-7            | date      | Yes      | Patient’s date of birth.                                                                                                                |
+| `sex`                             | PID-8            | string    | Yes      | Patient’s gender.                                                                                                                       |
+| `race`                            | PID-10           | string    | Yes      | Patient’s race.                                                                                                                         |
+| `zip_or_postal_code`              | PID-11.5         | string    | Yes      | Patient’s ZIP or postal code.                                                                                                           |
+| `country`                         | PID-11.6         | string    | Yes      | Patient’s country.                                                                                                                      |
+| `ethnic_group`                    | PID-22           | string    | Yes      | Patient’s ethnicity.                                                                                                                    |
+| `patient_id_json`                 |                  | string    | Yes      | JSON representation of all patient identifiers. Patient ID columns are also created for each assigning authority (e.g., `epic_mrn`).    |
+| `epic_mrn`                        |                  | string    | Yes      | Patient ID from Epic system.                                                                                                            |
+| `orc_2_placer_order_number`       | ORC-2            | string    | Yes      | Placer order number from the order control segment.                                                                                     |
+| `obr_2_placer_order_number`       | OBR-2            | string    | Yes      | Placer order number from the observation request segment.                                                                               |
+| `orc_3_filler_order_number`       | ORC-3            | string    | Yes      | Filler order number from the order control segment.                                                                                     |
+| `obr_3_filler_order_number`       | OBR-3            | string    | Yes      | Filler order number from the observation request segment.                                                                               |
+| `service_identifier`              | OBR-4.1          | string    | Yes      | Code for the service or exam.                                                                                                           |
+| `service_name`                    | OBR-4.2          | string    | Yes      | Name of the service or exam.                                                                                                            |
+| `service_coding_system`           | OBR-4.3          | string    | Yes      | Coding system used for the service identifier.                                                                                          |
+| `diagnostic_service_id`           | OBR-24           | string    | Yes      | Identifier for the diagnostic service.                                                                                                  |
+| `modality`                        | Derived          | string    | Yes      | Modality of the exam (e.g., CT, MRI).                                                                                                   |
+| `requested_dt`                    | OBR-6            | timestamp | Yes      | Date and time the service was requested.                                                                                                |
+| `observation_dt`                  | OBR-7            | timestamp | Yes      | Date and time the observation was made.                                                                                                 |
+| `observation_end_dt`              | OBR-8            | timestamp | Yes      | Date and time the observation ended.                                                                                                    |
+| `results_report_status_change_dt` | OBR-22           | timestamp | Yes      | Date and time the report status changed.                                                                                                |
+| `primary_radiologist`             | OBR-32 or OBR-33 | string    | Yes      | Presumed primary radiologist for the content of report. Pulled from OBR-32 if non-empty, otherwise falls back to first entry in OBR-33. |
+| `diagnosis_code`                  | DG1-3.1          | string    | Yes      | Diagnosis code.                                                                                                                         |
+| `diagnosis_code_text`             | DG1-3.2          | string    | Yes      | Description of the diagnosis.                                                                                                           |
+| `diagnosis_code_coding_system`    | DG1-3.3          | string    | Yes      | Coding system used for the diagnosis code.                                                                                              |
+| `study_instance_uid`              | ZDS-1            | string    | Yes      | Unique identifier for the study instance.                                                                                               |
+| `report_text`                     | OBX-5            | string    | Yes      | Full text of the diagnostic report. See {ref}`Report Text <report_text_ref>` for more detail.                                           |
+| `report_status`                   | OBX-11           | string    | Yes      | Status of the diagnostic report.                                                                                                        |
+| `year`                            | Derived          | integer   | Yes      | Year the message was created, derived from `message_dt`.                                                                                |
 
 The `patient_id_json` column contains a JSON representation of all patient identifiers associated with the report.
 
@@ -64,3 +65,26 @@ An example of the JSON representation is shown below:
 The assigning authority and identifier type code are used to create separate columns for each patient ID type to
 facilitate easier querying and analysis. For example, the `epic_mrn` column is created from the assigning authority 
 "EPIC" and identifier type code "MRN". The same applies to other patient ID columns.
+
+(report_text_ref)=
+# Report Text
+
+The full report text is reconstructed by the following process:
+1. Take all of the `OBX` segments in the HL7 message in order.
+2. For any of the `OBX` segments with an `OBX-2` value of `TX`, replace within `OBX-5` the default repetition character `~` with newlines.
+3. Join the ordered `OBX-5` values with newlines.
+
+This full text blob is what Scout stores in the column `report_text`.
+
+To create a rudimentarily "parsed" version of the report text, we can infer some structure to the reports from the value of the observation ID suffix defined in section 7.2.4 of the HL7 (v2.7) standard.
+For this process, we:
+1. Filter the `OBX` segments to retain those with a non-empty `OBX-3.1.2` value corresponding to this suffix.
+2. Maintaining the order of the filtered segments, group the segments by suffix.
+3. For each suffix group, join the segments by newlines and store them in the following columns:
+
+| Observation ID Suffix             | Data Lake Column Name       |
+|-----------------------------------|-----------------------------|
+| `ADT`                             | `inferred_addendum_note`    |
+| `GDT`                             | `inferred_findings`         |
+| `IMP`                             | `inferred_impression`       |
+| `TCM`                             | `inferred_technician_notes` |

--- a/docs/source/dataschema.md
+++ b/docs/source/dataschema.md
@@ -77,14 +77,14 @@ The full report text is reconstructed by the following process:
 This full text blob is what Scout stores in the column `report_text`.
 
 To create a rudimentarily "parsed" version of the report text, we can infer some structure to the reports from the value of the observation ID suffix defined in section 7.2.4 of the HL7 (v2.7) standard.
-For this process, we:
+We also allow a nonstandard `ADN` suffix to match what our 2.3 reports seem to use instead. For this process, we:
 1. Filter the `OBX` segments to retain those with a non-empty `OBX-3.1.2` value corresponding to this suffix.
 2. Maintaining the order of the filtered segments, group the segments by suffix.
 3. For each suffix group, join the segments by newlines and store them in the following columns:
 
-| Observation ID Suffix             | Data Lake Column Name       |
-|-----------------------------------|-----------------------------|
-| `ADT`                             | `inferred_addendum_note`    |
-| `GDT`                             | `inferred_findings`         |
-| `IMP`                             | `inferred_impression`       |
-| `TCM`                             | `inferred_technician_notes` |
+| Observation ID Suffix | Data Lake Column Name       |
+|-----------------------|-----------------------------|
+| `ADT` or `ADN`        | `inferred_addendum_note`    |
+| `GDT`                 | `inferred_findings`         |
+| `IMP`                 | `inferred_impression`       |
+| `TCM`                 | `inferred_technician_notes` |

--- a/extractor/hl7-transformer/src/hl7scout/hl7extractor/deltalake.py
+++ b/extractor/hl7-transformer/src/hl7scout/hl7extractor/deltalake.py
@@ -22,6 +22,9 @@ import tempfile
 import zipfile
 
 
+suffixes = ["ADT", "GDT", "IMP", "TCM"]
+
+
 def parse_s3_zip_paths(hl7_file_paths: list[str]) -> dict[str, list[str]]:
     """Parse S3 zip paths into a dictionary mapping zip files to their contents."""
     zip_map = defaultdict(list)
@@ -44,6 +47,15 @@ def download_and_extract_zips(zip_map, local_dir):
                 z.extract(hl7_file, local_dir)
                 extracted_files.append((out_path, f"{s3_zip_path}/{hl7_file}"))
     return extracted_files
+
+
+def extract_observation_id_suffix_content(suffix):
+    return F.concat_ws(
+        "\n",
+        F.collect_list(
+            F.when(F.split(F.col("obx-3"), "&").getItem(1) == suffix, F.col("obx-5"))
+        ),
+    ).alias(f"report_section_{suffix.lower()}")
 
 
 def import_hl7_files_to_deltalake(
@@ -156,6 +168,8 @@ def import_hl7_files_to_deltalake(
                         ("pid", 11, (5, 6)),
                         ("obr", 4, (1, 2, 3)),
                         ("dg1", 3, (1, 2, 3)),
+                        ("obr", 32, (2, 3)),
+                        ("obr", 33, (2, 3)),
                     )
                     for component in components
                 ],
@@ -225,6 +239,7 @@ def import_hl7_files_to_deltalake(
                 )
                 # Other data types are a single line as the value
                 .otherwise(F.col("obx").getItem(4)).alias("obx-5"),
+                F.col("obx").getItem(2).alias("obx-3"),
                 F.col("obx").getItem(10).alias("obx-11"),
             )
             .groupby("source_file")
@@ -233,6 +248,7 @@ def import_hl7_files_to_deltalake(
                 F.concat_ws("\n", F.collect_list("obx-5")).alias("report_text"),
                 # Assume report statuses are the same, pick first
                 F.first("obx-11").alias("report_status"),
+                *[extract_observation_id_suffix_content(suffix) for suffix in suffixes],
             )
         )
 
@@ -320,6 +336,17 @@ def import_hl7_files_to_deltalake(
                 F.col("obr-4-2").alias("service_name"),
                 F.col("obr-4-3").alias("service_coding_system"),
                 F.col("obr-24").alias("diagnostic_service_id"),
+                F.when(
+                    (F.length(F.col("obr-32-2")) > 0)
+                    & (F.length(F.col("obr-32-3")) > 0),
+                    F.concat(F.col("obr-32-3"), F.lit(" "), F.col("obr-32-2")),
+                )
+                .when(
+                    (F.length(F.col("obr-33-2")) > 0)
+                    & (F.length(F.col("obr-33-3")) > 0),
+                    F.concat(F.col("obr-33-3"), F.lit(" "), F.col("obr-33-2")),
+                )
+                .alias("primary_radiologist"),
                 F.col("dg1-3-1").alias("diagnosis_code"),
                 F.col("dg1-3-2").alias("diagnosis_code_text"),
                 F.col("dg1-3-3").alias("diagnosis_code_coding_scheme"),


### PR DESCRIPTION
# Extraction updates for primary radiologist and observation ID suffix parsing

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
Provides new columns in the delta lake for a primary radiologist and some parsed sections of the report text.

### Technical
Fairly standard tweaks to the existing spark extractor.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
Nothing in this seems particularly expensive.

### Data
Tested with new generated data containing both addenda and technician notes.

### Backward compatibility
Adds new columns to the delta lake, but I believe that should be backwards compatible.

## Testing
See data section.

## Note for reviewers
I'm not sure this is really accurate for the `primary_radiologist` column, but I'm not sure there's a better alternative.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
