### PR TITLE
Increase SQLAlchemy pool size for Superset

### DIFF
--- a/ansible/playbooks/services/superset.yaml
+++ b/ansible/playbooks/services/superset.yaml
@@ -101,6 +101,12 @@
                   return redirect(url_for("Superset.dashboard", dashboard_id_or_slug="scout"))
 
           FAB_INDEX_VIEW = f"{SupersetIndexView.__module__}.{SupersetIndexView.__name__}"
+        sql_alchemy: |
+          SQLALCHEMY_ENGINE_OPTIONS = {
+              "pool_size": 20,
+              "max_overflow": 30,
+              "pool_timeout": 60,
+          }
       extraVolumes:
         - name: dashboard-config
           configMap:


### PR DESCRIPTION
# Increase SQLAlchemy pool size for Superset

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

### Product
- Fix query timeout issues in Superset that leave Scout dashboards stuck with spinners.

### Technical
- Updated SQLALCHEMY_ENGINE_OPTIONS in Superset config

References:
- [SO thread](https://stackoverflow.com/questions/67839302/superset-dashboard-failed-with-timeouterror-queuepool-limit-of-size-5-overflow)
- [Superset issue #30286](https://github.com/apache/superset/issues/30286)
- [Superset issue #8207](https://github.com/apache/superset/issues/8207)

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
Allows for more concurrent connections, query execution speed not expected to improve.

### Data
N/A

### Backward compatibility
Yes

## Testing
I looked at the Grafana stats for CPU and Mem usage during Dan's usage, it seemed safe to increase the pool size. Tested on `big02` and patched `tag-big-01` with no issues during Dan's demo.

Verified before and after values using:
```sh
$ k exec -n superset superset-pod -- bash
$ superset shell
>>> from superset import db
>>> 
>>> engine = db.engine
>>> print(f"Pool size: {engine.pool.size()}")
Pool size: 5
>>> print(f"Pool timeout: {engine.pool._timeout}")
Pool timeout: 30.0
>>> print(f"Max overflow: {engine.pool._max_overflow}")
Max overflow: 10
```
After changes applied:
```sh
$ k exec -n superset superset-pod -- bash
$ superset shell
>>> from superset import db
>>> 
>>> engine = db.engine
>>> print(f"Pool size: {engine.pool.size()}")
Pool size: 20
>>> print(f"Pool timeout: {engine.pool._timeout}")
Pool timeout: 60
>>> print(f"Max overflow: {engine.pool._max_overflow}")
Max overflow: 30
```

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
