### PR TITLE
Fix string defaults in boolean condition

### DIFF
--- a/ansible/playbooks/helm.yaml
+++ b/ansible/playbooks/helm.yaml
@@ -23,7 +23,7 @@
           environment:
             DESIRED_VERSION: '{{ helm_version | default("") }}'
 
-      when: install_helm | default('true')
+      when: install_helm | default(true)
 
     - name: Install Helm Diff
       kubernetes.core.helm_plugin:

--- a/ansible/playbooks/main.yaml
+++ b/ansible/playbooks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Clone Scout repository
   import_playbook: scout.yaml
-  when: clone_scout_repo | default('true')
+  when: clone_scout_repo | default(true)
 
 - name: Install K3s
   import_playbook: k3s.yaml


### PR DESCRIPTION
## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

Once I merged #171, the [CI job](https://github.com/washu-tag/scout/actions/runs/18018994633) failed on main. I'm not sure why, because the same exact thing succeeded when [it was run on the PR](https://github.com/washu-tag/scout/actions/runs/17987831795).

It seems that some of my ansible changes have string defaults when they should have booleans. This changes that.

## Impact
This enables the proper default behavior when the `install_helm` and `clone_scout_repo` inventory variables are unset.

## Testing
I ran the CI, which passed. https://github.com/washu-tag/scout/actions/runs/17987831795

This doesn't inspire much confidence, though, since the code with the bug already ran through CI and it passed, so... 🤷🏼 .

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
