### PR TITLE
Cleanup space to publish Docker images

### DIFF
--- a/.github/actions/docker-push/action.yaml
+++ b/.github/actions/docker-push/action.yaml
@@ -16,3 +16,6 @@ runs:
       shell: bash
       run: |
         docker push $(docker load --input ${{ runner.temp }}/${{ inputs.image-name }}.tar | sed -e 's/.*: //g')
+    - name: Cleanup temp image tar
+      shell: bash
+      run: rm -f ${{ runner.temp }}/${{ inputs.image-name }}.tar

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -218,6 +218,11 @@ jobs:
           registry: ${{ ENV.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove unnecessary files to save space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: 'Push Image - hl7log-extractor'
         uses: ./.github/actions/docker-push
         with:
@@ -256,6 +261,11 @@ jobs:
           registry: ${{ ENV.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove unnecessary files to save space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: 'Push Image - pyspark-notebook'
         uses: ./.github/actions/docker-push
         with:


### PR DESCRIPTION
# Cleanup space to publish Docker images

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

The notebook packages added in #175 has increased our pyspark image size causing [out of space errors during the publish workflow on the Github action runners](https://github.com/washu-tag/scout/actions/runs/18173549373/attempts/2).

This will remove unused files in the runner similar to #175. This also deletes the image .tar saved to the temp directory after pushing to GHCR.

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
Not tested. The publish step occurs when merging to main and the demo branch publish workflow is only setup to push the pyspark notebook.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
