### PR TITLE
Ansible delegate_to localhost improvements

### DIFF
--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -105,6 +105,7 @@ k3s_cluster:
     # stored in different locations on your system
     helm_plugins_dir: /root/.local/share/helm/plugins
     kubeconfig_yaml: /etc/rancher/k3s/k3s.yaml
+    local_kubeconfig_yaml: '{{ kubeconfig_yaml }}'
 
     # Do not change the values below, they are hard-coded various places
     extractor_namespace: extractor

--- a/ansible/playbooks/analytics.yaml
+++ b/ansible/playbooks/analytics.yaml
@@ -3,7 +3,6 @@
   hosts: server
   gather_facts: false
   environment:
-    HELM_PLUGINS: '{{ helm_plugins_dir }}'
     KUBECONFIG: '{{ kubeconfig_yaml }}'
   tasks:
     - name: Install Trino

--- a/ansible/playbooks/explorer.yaml
+++ b/ansible/playbooks/explorer.yaml
@@ -3,7 +3,6 @@
   hosts: server
   gather_facts: false
   environment:
-    HELM_PLUGINS: '{{ helm_plugins_dir }}'
     KUBECONFIG: '{{ kubeconfig_yaml }}'
 
   tasks:
@@ -20,7 +19,6 @@
             stripPrefix:
               prefixes:
                 - /launchpad
-      delegate_to: localhost
 
     - name: Install explorer using Helm
       kubernetes.core.helm:
@@ -48,4 +46,5 @@
                 paths:
                   - path: /launchpad
                     pathType: Prefix
+        kubeconfig: '{{ local_kubeconfig_yaml }}'
       delegate_to: localhost

--- a/ansible/playbooks/extractor.yaml
+++ b/ansible/playbooks/extractor.yaml
@@ -3,7 +3,6 @@
   hosts: server
   gather_facts: false
   environment:
-    HELM_PLUGINS: '{{ helm_plugins_dir }}'
     KUBECONFIG: '{{ kubeconfig_yaml }}'
   tasks:
     - name: Create namespace
@@ -12,7 +11,6 @@
         api_version: v1
         kind: Namespace
         state: present
-      delegate_to: localhost
 
     - name: Create Postgres secret
       kubernetes.core.k8s:
@@ -30,7 +28,6 @@
             DB_NAME: '{{ ingest_postgres_table_name }}'
             DB_USER: '{{ postgres_user }}'
             DB_PASSWORD: '{{ postgres_password }}'
-      delegate_to: localhost
 
     - name: Create S3 secret
       kubernetes.core.k8s:
@@ -45,7 +42,6 @@
           stringData:
             AWS_ACCESS_KEY_ID: '{{ s3_lake_writer }}'
             AWS_SECRET_ACCESS_KEY: '{{ s3_lake_writer_secret }}'
-      delegate_to: localhost
 
     - name: Create S3 configmap
       kubernetes.core.k8s:
@@ -60,19 +56,6 @@
             AWS_ENDPOINT_URL: '{{ s3_endpoint }}'
             AWS_ALLOW_HTTP: 'true'
             AWS_REGION: '{{ s3_region }}'
-      delegate_to: localhost
-
-    - name: Deploy HL7Log Extractor
-      kubernetes.core.helm:
-        name: hl7log-extractor
-        chart_ref: '{{ scout_repo_dir }}/helm/extractor/hl7log-extractor'
-        release_namespace: '{{ extractor_namespace }}'
-        release_state: present
-        wait: true
-        wait_timeout: 5m
-        atomic: true
-        values: "{{ lookup('template', 'templates/hl7log-extractor.values.yaml.j2') | from_yaml }}"
-      delegate_to: localhost
 
     - name: Setup Spark defaults ConfigMap
       include_tasks: tasks/spark_config_setup.yaml
@@ -83,14 +66,29 @@
         spark_s3_username: '{{ s3_lake_writer }}'
         spark_s3_password: '{{ s3_lake_writer_secret }}'
 
-    - name: Deploy HL7 Transformer
-      kubernetes.core.helm:
-        name: hl7-transformer
-        chart_ref: '{{ scout_repo_dir }}/helm/extractor/hl7-transformer'
-        release_namespace: '{{ extractor_namespace }}'
-        release_state: present
-        wait: true
-        wait_timeout: 5m
-        atomic: true
-        values: "{{ lookup('template', 'templates/hl7-transformer.values.yaml.j2') | from_yaml }}"
+    - name: Deploy Extractor components
       delegate_to: localhost
+      environment:
+        K8S_AUTH_KUBECONFIG: '{{ local_kubeconfig_yaml }}'
+      block:
+        - name: Deploy HL7Log Extractor
+          kubernetes.core.helm:
+            name: hl7log-extractor
+            chart_ref: '{{ scout_repo_dir }}/helm/extractor/hl7log-extractor'
+            release_namespace: '{{ extractor_namespace }}'
+            release_state: present
+            wait: true
+            wait_timeout: 5m
+            atomic: true
+            values: "{{ lookup('template', 'templates/hl7log-extractor.values.yaml.j2') | from_yaml }}"
+
+        - name: Deploy HL7 Transformer
+          kubernetes.core.helm:
+            name: hl7-transformer
+            chart_ref: '{{ scout_repo_dir }}/helm/extractor/hl7-transformer'
+            release_namespace: '{{ extractor_namespace }}'
+            release_state: present
+            wait: true
+            wait_timeout: 5m
+            atomic: true
+            values: "{{ lookup('template', 'templates/hl7-transformer.values.yaml.j2') | from_yaml }}"

--- a/ansible/playbooks/gpu.yaml
+++ b/ansible/playbooks/gpu.yaml
@@ -3,7 +3,6 @@
   hosts: server
   gather_facts: false
   environment:
-    HELM_PLUGINS: '{{ helm_plugins_dir }}'
     KUBECONFIG: '{{ kubeconfig_yaml }}'
 
   tasks:
@@ -11,7 +10,6 @@
       kubernetes.core.helm_repository:
         name: gpu-operator
         repo_url: https://nvidia.github.io/gpu-operator
-      delegate_to: localhost
 
     - name: Install NVIDIA GPU Operator
       kubernetes.core.helm:
@@ -27,4 +25,3 @@
         atomic: true
         values_files:
           - vars/gpu-operator.values.yaml
-      delegate_to: localhost

--- a/ansible/playbooks/helm.yaml
+++ b/ansible/playbooks/helm.yaml
@@ -30,4 +30,3 @@
         plugin_path: 'https://github.com/databus23/helm-diff'
         state: present
       become: false
-      delegate_to: localhost

--- a/ansible/playbooks/jupyter.yaml
+++ b/ansible/playbooks/jupyter.yaml
@@ -12,7 +12,6 @@
   hosts: server
   gather_facts: false
   environment:
-    HELM_PLUGINS: '{{ helm_plugins_dir }}'
     KUBECONFIG: '{{ kubeconfig_yaml }}'
   vars_files:
     - vars/jupyter_storage.yaml
@@ -26,7 +25,6 @@
         api_version: v1
         kind: Namespace
         state: present
-      delegate_to: localhost
 
     - name: Create PersistentVolumeClaim for Jupyter single-user storage
       kubernetes.core.k8s:
@@ -44,13 +42,11 @@
               requests:
                 storage: 250Gi
             storageClassName: '{{ jupyter_singleuser_storage_class }}'
-      delegate_to: localhost
 
     - name: Add JupyterHub Helm repository
       kubernetes.core.helm_repository:
         name: jupyterhub
         repo_url: https://raw.githubusercontent.com/jupyterhub/helm-chart/refs/heads/gh-pages/
-      delegate_to: localhost
 
     - name: Setup Spark Defaults ConfigMaps
       include_tasks: tasks/spark_config_setup.yaml
@@ -63,13 +59,11 @@
       ansible.builtin.include_vars:
         file: vars/jupyter.values.yaml
         name: jupyter_base_values
-      delegate_to: localhost
 
     - name: Load authentication-specific JupyterHub values
       ansible.builtin.include_vars:
         file: vars/jupyter.auth.{{ jupyter_auth_class }}.values.yaml
         name: jupyter_auth_values
-      delegate_to: localhost
 
     - name: Merge base and authentication-specific JupyterHub values
       set_fact:
@@ -88,4 +82,3 @@
         wait_timeout: 10m
         atomic: true
         values: '{{ jupyter_values }}'
-      delegate_to: localhost

--- a/ansible/playbooks/k3s.yaml
+++ b/ansible/playbooks/k3s.yaml
@@ -28,6 +28,8 @@
     uninstall_script: '/usr/local/bin/k3s-uninstall.sh'
     cert_path: '/root/{{ server_hostname }}.crt'
     key_path: '/root/{{ server_hostname }}.key'
+  environment:
+    KUBECONFIG: '{{ kubeconfig_yaml }}'
   tasks:
     - name: Determine deployment context
       set_fact:
@@ -98,9 +100,6 @@
         - kubectl_get_nodes_result.stdout.find("NotReady") == -1
       retries: 30
       delay: 5
-      environment:
-        KUBECONFIG: '{{ kubeconfig_yaml }}'
-      delegate_to: localhost
 
     - name: Apply taint to control plane node
       kubernetes.core.k8s_taint:
@@ -109,8 +108,6 @@
         taints:
           - key: node-role.kubernetes.io/control-plane
             effect: PreferNoSchedule
-        kubeconfig: '{{ kubeconfig_yaml }}'
-      delegate_to: localhost
 
 ################################################################################
 - hosts: gpu_workers

--- a/ansible/playbooks/lake.yaml
+++ b/ansible/playbooks/lake.yaml
@@ -12,7 +12,6 @@
   hosts: server
   gather_facts: false
   environment:
-    HELM_PLUGINS: '{{ helm_plugins_dir }}'
     KUBECONFIG: '{{ kubeconfig_yaml }}'
   vars_files:
     - vars/lake_storage.yaml

--- a/ansible/playbooks/monitor.yaml
+++ b/ansible/playbooks/monitor.yaml
@@ -12,7 +12,6 @@
   hosts: server
   gather_facts: false
   environment:
-    HELM_PLUGINS: '{{ helm_plugins_dir }}'
     KUBECONFIG: '{{ kubeconfig_yaml }}'
   vars_files:
     - vars/monitor_storage.yaml

--- a/ansible/playbooks/orchestrator.yaml
+++ b/ansible/playbooks/orchestrator.yaml
@@ -12,7 +12,6 @@
   hosts: server
   gather_facts: false
   environment:
-    HELM_PLUGINS: '{{ helm_plugins_dir }}'
     KUBECONFIG: '{{ kubeconfig_yaml }}'
   vars_files:
     - vars/orchestrator_storage.yaml
@@ -24,7 +23,6 @@
       kubernetes.core.helm_repository:
         name: jetstack
         repo_url: https://charts.jetstack.io
-      delegate_to: localhost
 
     - name: Install cert-manager
       kubernetes.core.helm:
@@ -39,13 +37,11 @@
         atomic: true
         values:
           installCRDs: true
-      delegate_to: localhost
 
     - name: Add k8ssandra Helm repository
       kubernetes.core.helm_repository:
         name: k8ssandra
         repo_url: https://helm.k8ssandra.io/stable
-      delegate_to: localhost
 
     - name: Install the cass-operator
       kubernetes.core.helm:
@@ -59,7 +55,6 @@
         wait: true
         wait_timeout: 10m
         atomic: true
-      delegate_to: localhost
 
     - name: Install the Cassandra datacenter
       kubernetes.core.k8s:
@@ -89,19 +84,16 @@
               jvm-server-options:
                 initial_heap_size: '{{ temporal_cassandra_init_heap | default("2G") }}'
                 max_heap_size: '{{ temporal_cassandra_max_heap | default("8G") }}'
-      delegate_to: localhost
 
     - name: Wait for Cassandra to be ready
       command: 'kubectl -n {{ temporal_namespace }} wait --for=condition=Ready --timeout=600s cassandradatacenter/dc1'
       register: cassandra_ready
       changed_when: false
-      delegate_to: localhost
 
     - name: Add Temporal Helm repository
       kubernetes.core.helm_repository:
         name: temporal
         repo_url: https://raw.githubusercontent.com/temporalio/helm-charts/refs/heads/gh-pages/
-      delegate_to: localhost
 
     - name: Install/Upgrade Temporal Helm chart
       register: temporal_helm_result
@@ -162,7 +154,6 @@
               ingressClassName: traefik
               hosts:
                 - '{{ server_hostname }}/temporal'
-      delegate_to: localhost
 
     - name: Wait for Temporal schema job to complete
       shell: >-
@@ -171,7 +162,6 @@
         fi
       register: temporal_schema
       changed_when: false
-      delegate_to: localhost
 
     - name: Construct cron schedule
       when: scheduled_ingest_cron is undefined and scheduled_ingest_hour is defined
@@ -218,4 +208,3 @@
                       - IngestHl7LogWorkflow
                       - '--cron'
                       - '{{ scheduled_ingest_cron }}'
-      delegate_to: localhost

--- a/ansible/playbooks/postgres.yaml
+++ b/ansible/playbooks/postgres.yaml
@@ -12,7 +12,6 @@
   hosts: server
   gather_facts: false
   environment:
-    HELM_PLUGINS: '{{ helm_plugins_dir }}'
     KUBECONFIG: '{{ kubeconfig_yaml }}'
   vars_files:
     - vars/postgres_storage.yaml
@@ -39,7 +38,6 @@
       kubernetes.core.helm_repository:
         name: cnpg
         repo_url: https://raw.githubusercontent.com/cloudnative-pg/charts/refs/heads/gh-pages/
-      delegate_to: localhost
 
     - name: Install/Upgrade Postgres Operator
       kubernetes.core.helm:
@@ -53,7 +51,6 @@
         wait: true
         wait_timeout: 5m
         atomic: true
-      delegate_to: localhost
 
     - name: Create namespace
       kubernetes.core.k8s:
@@ -61,7 +58,6 @@
         api_version: v1
         kind: Namespace
         state: present
-      delegate_to: localhost
 
     - name: Set up storage
       include_tasks: tasks/storage_setup.yaml
@@ -79,7 +75,6 @@
           stringData:
             username: '{{ postgres_user }}'
             password: '{{ postgres_password }}'
-      delegate_to: localhost
 
     - name: Create Postgres superuser secret
       kubernetes.core.k8s:
@@ -94,7 +89,6 @@
           stringData:
             username: 'postgres'
             password: '{{ postgres_superuser_password }}'
-      delegate_to: localhost
 
     - name: Create Postgres cluster
       kubernetes.core.k8s:
@@ -123,7 +117,6 @@
                 secret:
                   name: postgres-user
                 postInitSQL: '{{ postgres_init_sql }}'
-      delegate_to: localhost
 
     - name: Expose metrics service for Prometheus
       kubernetes.core.k8s:
@@ -141,10 +134,8 @@
               - name: metrics
                 port: 9187
                 targetPort: metrics
-      delegate_to: localhost
 
     - name: Wait for Postgres to be ready
       command: 'kubectl -n {{ postgres_cluster_namespace }} wait --for=condition=Ready --timeout=300s cluster/postgresql-cluster'
       register: postgres_ready
       changed_when: false
-      delegate_to: localhost

--- a/ansible/playbooks/services/grafana.yaml
+++ b/ansible/playbooks/services/grafana.yaml
@@ -2,7 +2,6 @@
   kubernetes.core.helm_repository:
     name: grafana
     repo_url: https://grafana.github.io/helm-charts
-  delegate_to: localhost
 
 - name: Create Loki namespace
   kubernetes.core.k8s:
@@ -10,7 +9,6 @@
     api_version: v1
     kind: Namespace
     state: present
-  delegate_to: localhost
 
 - name: Create S3 secret for Loki
   kubernetes.core.k8s:
@@ -25,7 +23,6 @@
       stringData:
         AWS_ACCESS_KEY_ID: '{{ s3_loki_writer }}'
         AWS_SECRET_ACCESS_KEY: '{{ s3_loki_writer_secret }}'
-  delegate_to: localhost
 
 - name: Install Loki using Helm
   kubernetes.core.helm:
@@ -36,6 +33,7 @@
     chart_version: ~6.29.0
     values: "{{ lookup('template', 'templates/loki.values.yaml.j2') | from_yaml }}"
     state: present
+    kubeconfig: '{{ local_kubeconfig_yaml }}'
   delegate_to: localhost
 
 - name: Install Promtail using Helm
@@ -52,7 +50,6 @@
           clients:
             - url: 'http://loki-gateway.{{ loki_namespace }}.svc.cluster.local:3100/loki/api/v1/push'
     state: present
-  delegate_to: localhost
 
 - name: Create Grafana namespace
   kubernetes.core.k8s:
@@ -60,16 +57,34 @@
     api_version: v1
     kind: Namespace
     state: present
-  delegate_to: localhost
 
-- name: Apply Grafana dashboard configmaps
+- name: Create SMTP secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: smtp-grafana
+        namespace: '{{ grafana_namespace }}'
+        labels:
+          grafana_alert: '1'
+      type: Opaque
+      stringData:
+        user: '{{ grafana_smtp_user }}'
+        password: '{{ grafana_smtp_password }}'
+  when: grafana_alert_contact_point == 'email'
+
+- name: Configure and install Grafana
+  delegate_to: localhost
+  environment:
+    KUBECONFIG: '{{ local_kubeconfig_yaml }}'
   block:
     - name: Find all Grafana dashboards
       find:
         paths: 'files/grafana/dashboards/'
         patterns: '*.json'
       register: dashboard_files
-      delegate_to: localhost
 
     - name: Create ConfigMap for each Grafana dashboard
       no_log: true
@@ -89,16 +104,12 @@
       loop: '{{ dashboard_files.files }}'
       loop_control:
         label: '{{ item.path | basename }}'
-      delegate_to: localhost
 
-- name: Apply Grafana alert rules as ConfigMaps
-  block:
     - name: Find all Grafana alerts
       find:
         paths: 'templates/grafana/alerts/'
         patterns: '*.json.j2'
       register: alert_templates
-      delegate_to: localhost
 
     - name: Create ConfigMap for each Grafana alert
       kubernetes.core.k8s:
@@ -112,36 +123,31 @@
             labels:
               grafana_alert: '1'
           data:
-            '{{ item.path | basename | regex_replace(".json.j2$", ".json") }}': 
+            '{{ item.path | basename | regex_replace(".json.j2$", ".json") }}':
               '{{ lookup("template", item.path) | to_nice_json }}'
       loop: '{{ alert_templates.files }}'
       loop_control:
         label: '{{ item.path | basename }}'
-      delegate_to: localhost
 
-- name: Create Grafana notification policy as ConfigMap
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: notification-policy
-        namespace: '{{ grafana_namespace }}'
-        labels:
-          grafana_alert: '1'
-      data:
-        notification-policy.yaml: "{{ lookup('template', 'templates/grafana/notification-policy.yaml.j2') }}"
-  delegate_to: localhost
+    - name: Create Grafana notification policy as ConfigMap
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: notification-policy
+            namespace: '{{ grafana_namespace }}'
+            labels:
+              grafana_alert: '1'
+          data:
+            notification-policy.yaml: "{{ lookup('template', 'templates/grafana/notification-policy.yaml.j2') }}"
 
-- name: Create contact point secrets
-  block:
     - name: Find all Grafana contact points
       find:
         paths: 'templates/grafana/contact-points/'
         patterns: '*.json.j2'
       register: contact_point_templates
-      delegate_to: localhost
 
     - name: Create Secret for each Grafana contact point
       kubernetes.core.k8s:
@@ -162,48 +168,27 @@
       when: grafana_alert_contact_point in (item.path | basename)
       loop_control:
         label: '{{ item.path | basename }}'
-      delegate_to: localhost
 
-- name: Create SMTP secret
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: smtp-grafana
-        namespace: '{{ grafana_namespace }}'
-        labels:
-          grafana_alert: '1'
-      type: Opaque
-      stringData:
-        user: '{{ grafana_smtp_user }}'
-        password: '{{ grafana_smtp_password }}'
-  when: grafana_alert_contact_point == 'email'
-  delegate_to: localhost
+    - name: Create postgres datasource secret
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: postgres-ingest-db-secret
+            namespace: '{{ grafana_namespace }}'
+            labels:
+              grafana_datasource: 'true' # default value for: sidecar.datasources.label
+          stringData:
+            pg-db.yaml: "{{ lookup('template', 'templates/grafana/datasources/postgres-datasource.yaml.j2') }}"
 
-- name: Create postgres datasource secret
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: postgres-ingest-db-secret
-        namespace: '{{ grafana_namespace }}'
-        labels:
-          grafana_datasource: 'true' # default value for: sidecar.datasources.label
-      stringData:
-        pg-db.yaml: "{{ lookup('template', 'templates/grafana/datasources/postgres-datasource.yaml.j2') }}"
-  delegate_to: localhost
-
-- name: Install Grafana using Helm
-  kubernetes.core.helm:
-    state: present
-    name: grafana
-    chart_ref: grafana/grafana
-    release_namespace: '{{ grafana_namespace }}'
-    update_repo_cache: true
-    chart_version: ~8.12.1
-    values: '{{ lookup("template", "templates/grafana/grafana.values.yaml.j2") | from_yaml }}'
-  delegate_to: localhost
+    - name: Install Grafana using Helm
+      kubernetes.core.helm:
+        state: present
+        name: grafana
+        chart_ref: grafana/grafana
+        release_namespace: '{{ grafana_namespace }}'
+        update_repo_cache: true
+        chart_version: ~8.12.1
+        values: '{{ lookup("template", "templates/grafana/grafana.values.yaml.j2") | from_yaml }}'

--- a/ansible/playbooks/services/hive.yaml
+++ b/ansible/playbooks/services/hive.yaml
@@ -2,7 +2,6 @@
   ansible.builtin.include_vars:
     file: vars/hive.values.yaml
     name: hive_values
-  delegate_to: localhost
 
 - name: Install Hive Metastore Service (HMS) with helm
   kubernetes.core.helm:
@@ -15,10 +14,10 @@
     wait_timeout: 5m
     atomic: true
     values: '{{ hive_values }}'
+    kubeconfig: '{{ local_kubeconfig_yaml }}'
   delegate_to: localhost
 
 - name: Wait for Hive to be ready
   command: kubectl -n {{ hive_namespace }} wait --for=condition=Available --timeout=300s deployments/hive-metastore
   register: hive_ready
   changed_when: false
-  delegate_to: localhost

--- a/ansible/playbooks/services/minio.yaml
+++ b/ansible/playbooks/services/minio.yaml
@@ -5,7 +5,6 @@
   kubernetes.core.helm_repository:
     name: minio-operator
     repo_url: https://operator.min.io
-  delegate_to: localhost
 
 - name: Install/Upgrade Minio Operator
   kubernetes.core.helm:
@@ -19,7 +18,6 @@
     wait: true
     wait_timeout: "{{ minio_operator_wait_timeout | default('1m') }}"
     atomic: true
-  delegate_to: localhost
 
 - name: Create Traefik Middleware to add trailing slash
   kubernetes.core.k8s:
@@ -35,7 +33,6 @@
           regex: "(.*/{{ minio_path_prefix | default('minio') }}$)"
           replacement: ${1}/
           permanent: true
-  delegate_to: localhost
 
 - name: Create Traefik Middleware to strip prefix
   kubernetes.core.k8s:
@@ -50,7 +47,6 @@
         stripPrefix:
           prefixes:
             - "/{{ minio_path_prefix | default('minio') }}"
-  delegate_to: localhost
 
 - name: Create tenant namespace
   kubernetes.core.k8s:
@@ -58,7 +54,6 @@
     api_version: v1
     kind: Namespace
     state: present
-  delegate_to: localhost
 
 - name: Set up environment secret
   kubernetes.core.k8s:
@@ -76,7 +71,6 @@
           export MINIO_ROOT_PASSWORD={{ s3_password }}
           export MINIO_REGION_NAME={{ s3_region }}
           export MINIO_REGION={{ s3_region }}
-  delegate_to: localhost
 
 - name: Create MinIO user credential secrets
   kubernetes.core.k8s:
@@ -92,7 +86,6 @@
         CONSOLE_ACCESS_KEY: '{{ item.access_key }}'
         CONSOLE_SECRET_KEY: '{{ item.secret_key }}'
   loop: '{{ minio_users }}'
-  delegate_to: localhost
 
 - name: Install/Upgrade Minio Tenant
   kubernetes.core.helm:
@@ -139,7 +132,6 @@
         buckets: '{{ minio_buckets }}'
         users: '{{ minio_credentials }}'
       ingress: '{{ minio_ingress_config }}'
-  delegate_to: localhost
 
 - name: Wait for MinIO StatefulSet to exist
   kubernetes.core.k8s_info:
@@ -152,7 +144,6 @@
   retries: '{{ minio_wait_retries | default(60) }}'
   delay: '{{ minio_wait_delay | default(5) }}'
   changed_when: false
-  delegate_to: localhost
 
 - name: Wait for MinIO StatefulSet to be ready
   kubernetes.core.k8s_info:
@@ -167,7 +158,6 @@
   retries: '{{ minio_wait_retries | default(60) }}'
   delay: '{{ minio_wait_delay | default(5) }}'
   changed_when: false
-  delegate_to: localhost
 
 - name: Create MinIO policy JSON ConfigMaps
   kubernetes.core.k8s:
@@ -191,7 +181,6 @@
             ]
           }
   loop: '{{ minio_policies }}'
-  delegate_to: localhost
 
 - name: Build list of projected ConfigMaps for MinIO policies
   set_fact:
@@ -201,7 +190,6 @@
         [ { 'configMap': { 'name': 'policy-' + item.name } } ]
       }}
   loop: '{{ minio_policies }}'
-  delegate_to: localhost
 
 - name: Bootstrap MinIO IAM (policies + bindings)
   kubernetes.core.k8s:
@@ -268,7 +256,6 @@
                   items:
                     - key: config.env
                       path: config.env
-  delegate_to: localhost
 
 - name: Wait for bootstrap job to complete
   kubernetes.core.k8s_info:
@@ -284,4 +271,3 @@
   retries: '{{ minio_bootstrap_wait_retries | default(30) }}'
   delay: '{{ minio_bootstrap_wait_delay | default(10) }}'
   changed_when: false
-  delegate_to: localhost

--- a/ansible/playbooks/services/prometheus.yaml
+++ b/ansible/playbooks/services/prometheus.yaml
@@ -2,7 +2,6 @@
   kubernetes.core.helm_repository:
     name: prometheus-community
     repo_url: https://prometheus-community.github.io/helm-charts
-  delegate_to: localhost
 
 - name: Create namespace
   kubernetes.core.k8s:
@@ -10,7 +9,6 @@
     api_version: v1
     kind: Namespace
     state: present
-  delegate_to: localhost
 
 - name: Create JupyterHub metrics API token secret
   kubernetes.core.k8s:
@@ -24,7 +22,6 @@
       type: Opaque
       stringData:
         metrics-api-token: '{{ jupyter_metrics_api_token }}'
-  delegate_to: localhost
 
 - name: Install Prometheus using Helm
   kubernetes.core.helm:
@@ -36,4 +33,5 @@
     update_repo_cache: true
     chart_version: ~27.11.0
     values: '{{ lookup("template", "templates/prometheus.values.yaml.j2") | from_yaml }}'
+    kubeconfig: '{{ local_kubeconfig_yaml }}'
   delegate_to: localhost

--- a/ansible/playbooks/services/superset.yaml
+++ b/ansible/playbooks/services/superset.yaml
@@ -2,7 +2,6 @@
   kubernetes.core.helm_repository:
     name: superset
     repo_url: https://apache.github.io/superset
-  delegate_to: localhost
 
 - name: Create namespace
   kubernetes.core.k8s:
@@ -10,40 +9,40 @@
     api_version: v1
     kind: Namespace
     state: present
-  delegate_to: localhost
 
-- name: Find all analytics YAML files
+- name: Build dashboard ConfigMap data
   delegate_to: localhost
-  ansible.builtin.find:
-    paths: '{{ scout_repo_dir }}/analytics'
-    recurse: true
-    file_type: file
-    patterns: '*.yaml'
-  register: analytics_files
+  block:
+    - name: Find all analytics YAML files
+      ansible.builtin.find:
+        paths: '{{ scout_repo_dir }}/analytics'
+        recurse: true
+        file_type: file
+        patterns: '*.yaml'
+      register: analytics_files
 
-- name: Build ConfigMap data and items list
-  no_log: true
-  vars:
-    analytics_root: '{{ (scout_repo_dir | realpath) ~ "/analytics" }}'
-  ansible.builtin.set_fact:
-    superset_dashboard_data: >-
-      {{
-        superset_dashboard_data | default({}) |
-        combine({ (item.path | basename): lookup('file', item.path) })
-      }}
-    superset_dashboard_items: >-
-      {{
-        superset_dashboard_items | default([]) + [
-          {
-            'key': (item.path | basename),
-            'path': ((item.path | realpath) | regex_replace('^' ~ analytics_root ~ '/', 'analytics/'))
-          }
-        ]
-      }}
-  loop: '{{ analytics_files.files }}'
-  loop_control:
-    label: '{{ (item.path | realpath) | regex_replace("^" ~ analytics_root ~ "/", "") }}'
-  delegate_to: localhost
+    - name: Build ConfigMap data and items list
+      no_log: true
+      vars:
+        analytics_root: '{{ (scout_repo_dir | realpath) ~ "/analytics" }}'
+      ansible.builtin.set_fact:
+        superset_dashboard_data: >-
+          {{
+            superset_dashboard_data | default({}) |
+            combine({ (item.path | basename): lookup('file', item.path) })
+          }}
+        superset_dashboard_items: >-
+          {{
+            superset_dashboard_items | default([]) + [
+              {
+                'key': (item.path | basename),
+                'path': ((item.path | realpath) | regex_replace('^' ~ analytics_root ~ '/', 'analytics/'))
+              }
+            ]
+          }}
+      loop: '{{ analytics_files.files }}'
+      loop_control:
+        label: '{{ (item.path | realpath) | regex_replace("^" ~ analytics_root ~ "/", "") }}'
 
 - name: Create ConfigMap for datasource and dashboard yaml
   no_log: true
@@ -56,7 +55,6 @@
         name: dashboard-config
         namespace: superset
       data: '{{ superset_dashboard_data | default({}) }}'
-  delegate_to: localhost
 
 - name: Install/Upgrade Superset Helm chart
   kubernetes.core.helm:
@@ -173,4 +171,3 @@
             echo "Dashboard imported successfully"
           fi
           {% endraw %}
-  delegate_to: localhost

--- a/ansible/playbooks/services/trino.yaml
+++ b/ansible/playbooks/services/trino.yaml
@@ -2,7 +2,6 @@
   kubernetes.core.helm_repository:
     name: trino
     repo_url: https://trinodb.github.io/charts
-  delegate_to: localhost
 
 - name: Install/Upgrade Trino Helm chart
   kubernetes.core.helm:
@@ -35,4 +34,3 @@
       worker:
         annotations:
           prometheus.io/trino_scrape: 'true'
-  delegate_to: localhost

--- a/ansible/playbooks/tasks/set_up_kubeconfig.yaml
+++ b/ansible/playbooks/tasks/set_up_kubeconfig.yaml
@@ -3,11 +3,11 @@
   block:
     - name: Set kubeconfig dir path
       set_fact:
-        kubeconfig_yaml_dir: '{{ scout_repo_dir }}/.kube/{{ ansible_host | default(inventory_hostname) }}'
+        local_kubeconfig_yaml_dir: '{{ scout_repo_dir }}/.kube/scout/{{ ansible_host | default(inventory_hostname) }}'
 
     - name: Set kubeconfig path
       set_fact:
-        kubeconfig_yaml: '{{ kubeconfig_yaml_dir }}/config'
+        local_kubeconfig_yaml: '{{ local_kubeconfig_yaml_dir }}/config'
 
     - name: Fetch k3s kubeconfig
       slurp:
@@ -33,7 +33,7 @@
 
     - name: Create kubeconfig dir
       ansible.builtin.file:
-        path: '{{ kubeconfig_yaml_dir }}'
+        path: '{{ local_kubeconfig_yaml_dir }}'
         state: directory
         mode: '0700'
       delegate_to: localhost
@@ -41,7 +41,7 @@
     - name: Write modified kubeconfig locally
       copy:
         content: '{{ modified_kubeconfig | to_nice_yaml }}'
-        dest: '{{ kubeconfig_yaml }}'
+        dest: '{{ local_kubeconfig_yaml }}'
         mode: '0600'
       delegate_to: localhost
 
@@ -49,5 +49,5 @@
 
 - name: Setup kubeconfig for local deployment
   set_fact:
-    kubeconfig_yaml: /etc/rancher/k3s/k3s.yaml
+    local_kubeconfig_yaml: /etc/rancher/k3s/k3s.yaml
   when: is_local_deployment

--- a/ansible/playbooks/tasks/spark_config_setup.yaml
+++ b/ansible/playbooks/tasks/spark_config_setup.yaml
@@ -4,7 +4,6 @@
     api_version: v1
     kind: Namespace
     state: present
-  delegate_to: localhost
 
 - name: Create Spark ConfigMap
   kubernetes.core.k8s:
@@ -32,4 +31,3 @@
           spark.driver.extraJavaOptions -Divy.cache.dir=/tmp -Divy.home=/tmp
           spark.executor.memory {{ spark_memory | default("1g") }}
           spark.driver.memory {{ spark_memory | default("1g") }}
-  delegate_to: localhost

--- a/ansible/playbooks/tasks/storage_setup.yaml
+++ b/ansible/playbooks/tasks/storage_setup.yaml
@@ -9,7 +9,6 @@
       provisioner: kubernetes.io/no-provisioner
       volumeBindingMode: WaitForFirstConsumer
   loop: '{{ storage_definitions }}'
-  delegate_to: localhost
 
 - name: Add persistent volumes
   kubernetes.core.k8s:
@@ -42,4 +41,3 @@
           }, omit) }}
         hostPath: "{{ item.node_url is not defined | ternary({'path': item.path}, omit) }}"
   loop: '{{ storage_definitions }}'
-  delegate_to: localhost

--- a/ansible/playbooks/traefik.yaml
+++ b/ansible/playbooks/traefik.yaml
@@ -18,14 +18,12 @@
 
     - name: Read TLS cert from remote
       no_log: true
-      become: true
       slurp:
         src: '{{ cert_path }}'
       register: cert_file
 
     - name: Read TLS key from remote
       no_log: true
-      become: true
       slurp:
         src: '{{ key_path }}'
       register: key_file
@@ -44,19 +42,16 @@
           data:
             tls.crt: '{{ cert_file.content }}'
             tls.key: '{{ key_file.content }}'
-      delegate_to: localhost
 
     - name: Wait for helm-install-traefik job to complete
       command: kubectl -n kube-system wait --for=condition=complete --timeout=300s job/helm-install-traefik
       register: traefik_install
       changed_when: false
-      delegate_to: localhost
 
     - name: Wait for helm-install-traefik-crd job to complete
       command: kubectl -n kube-system wait --for=condition=complete --timeout=300s job/helm-install-traefik-crd
       register: traefik_crd_install
       changed_when: false
-      delegate_to: localhost
 
     - name: Apply Traefik TLSStore configuration
       kubernetes.core.k8s:
@@ -70,7 +65,6 @@
           spec:
             defaultCertificate:
               secretName: tls-secret
-      delegate_to: localhost
 
     - name: Apply Traefik configuration to enforce TLS
       kubernetes.core.k8s:
@@ -93,4 +87,3 @@
                       to: websecure
                       scheme: https
                       permanent: true
-      delegate_to: localhost


### PR DESCRIPTION
## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Description

Walk back some of the changes from #171 around delegating all the helm and kubernetes tasks to localhost.

We do need to do _some_ of the tasks on localhost, but only those that use local files. Most of the helm and kubernetes tasks can be accomplished on the remote control node.

When we do need to delegate, this does it more efficiently by using `block`s to only delegate once for several tasks.

## Impact

This shouldn't affect how the deployment works. But my intent with this change is to make it easier to make future changes, namely refactoring the playbooks into roles and enabling a staging server for air-gapped updates.

### Backward compatibility
I believe this is backwards compatible without any changes to inventory if you are running the `main` playbook. For CI, which does not use `main`, I added one parameter to the inventory that otherwise gets defined in a playbook that CI doesn't run.

Notably, this preserves the behavior added in #171 that ansible deploys can be run remotely.

## Testing
Ran the playbooks remotely from my laptop to deploy onto the `03` cluster.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated user documentation, if appropriate.
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate.
- [ ] I have added unit tests, unless this is a test code PR.
- [ ] I have added end-to-end tests, unless this is a documentation-only PR.
