### PR TITLE
Fix not writing kubeconfig on non-airgapped remote installs

### DIFF
--- a/ansible/roles/scout_common/defaults/main.yaml
+++ b/ansible/roles/scout_common/defaults/main.yaml
@@ -32,7 +32,7 @@ air_gapped: false
 # Ansible control node location relative to cluster
 # TRUE when control node is external to cluster - needs fetched kubeconfig
 # FALSE when control node is on the cluster - can use cluster kubeconfig directly
-ansible_control_node_external_to_cluster: "{{ ansible_connection | default('ssh') != 'local' or (air_gapped | bool) }}"
+ansible_control_node_external_to_cluster: "{{ hostvars[inventory_hostname].ansible_connection | default('ssh') != 'local' or (air_gapped | bool) }}"
 
 # Kubeconfig path for Ansible control node execution
 # When control node is on cluster, uses the cluster's kubeconfig directly


### PR DESCRIPTION
## Description

### Product
<!-- Provide a summary explanation of your changes from a product/user perspective. More details should be found in your updates to the user docs. -->
N/A

### Technical
<!-- Provide a summary explanation of your changes from a technical perspective. More details should be found in your updates to the technical docs. -->
Fixes bug on remote non-air-gapped installation. The kubeconfig file should have been copied to the ansible node but wasn't.
```
TASK [k3s : Create local kubeconfig directory on jump node] ***************************************************************************************************
skipping: [tagdev-control-01.nrg.wustl.edu] => {"changed": false, "false_condition": "ansible_control_node_external_to_cluster", "skip_reason": "Conditional result was False"}

TASK [k3s : Write modified kubeconfig locally on jump node] ***************************************************************************************************
skipping: [tagdev-control-01.nrg.wustl.edu] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
```
The `when: ansible_control_node_external_to_cluster` condition was being applied to a `block`, but that doesn't mean it gets calculated once and reused, in fact it gets calculated separately for each task in the block. Some of those were `delegate_to: localhost` which meant `ansible_control_node_external_to_cluster` evaluated to `false` since localhost is by definition local.

With this fix we calculate `ansible_control_node_external_to_cluster` based on the target node, which means it will evaluate to the same value even when some of the tasks are delegated to localhost.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
<!-- Do your changes add or modify user roles? Do they impact the data users are able to see, or the actions they are able to take? Could a user modify a REST API path and see data they aren't supposed to see? Were you mindful of least privilege? -->
N/A

##### Appsec
<!-- Did you review your changes with application security in mind? See the [OWASP list](https://github.com/0xRadi/OWASP-Web-Checklist). -->
N/A
### Performance
<!-- At what scale do we expect this to operate? How have you verified that it can do so? -->
N/A
### Data
<!-- Did you consider any edge cases around input data (e.g., DICOM type 2 elements are required to be present but may be empty)? Are you gracefully handling errors from "bad data," e.g., non-conforming DICOM? -->
N/A
### Backward compatibility
<!-- Any changes to the data model, APIs, dependencies? -->
N/A
## Testing
<!-- Detail the testing you have performed to ensure that these changes function as intended. Include information about the test automation you've added, as well as the manual testing you've performed. Be sure to reference areas of impact, above. -->
Installed to `dev01`, which had been blocked by this issue but was unblocked by this change.

## Note for reviewers
<!-- Any additional information or direction for reviewers. -->

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
