### PR TITLE
Make temporal scheduled job creation task idempotent

### DIFF
--- a/ansible/roles/temporal/tasks/deploy.yaml
+++ b/ansible/roles/temporal/tasks/deploy.yaml
@@ -46,10 +46,24 @@
   set_fact:
     scheduled_ingest_cron: '0 {{ scheduled_ingest_hour }} * * *'
 
+- name: Delete previous prospective indexing job
+  when: scheduled_ingest_cron is defined
+  kubernetes.core.k8s:
+    state: absent
+    api_version: batch/v1
+    kind: Job
+    name: 'add-prospective-indexing'
+    namespace: '{{ scout_extractor_namespace }}'
+
 - name: Add scheduled task for prospective report indexing
   when: scheduled_ingest_cron is defined
   kubernetes.core.k8s:
     state: present
+    wait: true
+    wait_timeout: 120
+    wait_condition:
+      type: Complete
+      status: "True"
     definition:
       apiVersion: batch/v1
       kind: Job
@@ -73,16 +87,21 @@
                   - name: TEMPORAL_ADDRESS
                     value: 'temporal-internal-frontend.{{ scout_extractor_namespace }}:7236'
                 command:
-                  - temporal
-                  - schedule
-                  - create
-                  - '--schedule-id'
-                  - ScheduledReportIngest
-                  - '--workflow-id'
-                  - ScheduledReportIngest
-                  - '--task-queue'
-                  - ingest-hl7-log
-                  - '--type'
-                  - IngestHl7LogWorkflow
-                  - '--cron'
-                  - '{{ scheduled_ingest_cron }}'
+                  - /bin/sh
+                  - -c
+                  - |
+                    if temporal schedule describe --schedule-id ScheduledReportIngest 2>/dev/null; then
+                      temporal schedule update \
+                        --schedule-id ScheduledReportIngest \
+                        --workflow-id ScheduledReportIngest \
+                        --task-queue ingest-hl7-log \
+                        --type IngestHl7LogWorkflow \
+                        --cron '{{ scheduled_ingest_cron }}'
+                    else
+                      temporal schedule create \
+                        --schedule-id ScheduledReportIngest \
+                        --workflow-id ScheduledReportIngest \
+                        --task-queue ingest-hl7-log \
+                        --type IngestHl7LogWorkflow \
+                        --cron '{{ scheduled_ingest_cron }}'
+                    fi

--- a/ansible/roles/temporal/tasks/deploy.yaml
+++ b/ansible/roles/temporal/tasks/deploy.yaml
@@ -63,7 +63,7 @@
     wait_timeout: 120
     wait_condition:
       type: Complete
-      status: "True"
+      status: 'True'
     definition:
       apiVersion: batch/v1
       kind: Job

--- a/ansible/roles/temporal/tasks/deploy.yaml
+++ b/ansible/roles/temporal/tasks/deploy.yaml
@@ -46,15 +46,6 @@
   set_fact:
     scheduled_ingest_cron: '0 {{ scheduled_ingest_hour }} * * *'
 
-- name: Delete previous prospective indexing job
-  when: scheduled_ingest_cron is defined
-  kubernetes.core.k8s:
-    state: absent
-    api_version: batch/v1
-    kind: Job
-    name: 'add-prospective-indexing'
-    namespace: '{{ scout_extractor_namespace }}'
-
 - name: Add scheduled task for prospective report indexing
   when: scheduled_ingest_cron is defined
   kubernetes.core.k8s:
@@ -68,11 +59,12 @@
       apiVersion: batch/v1
       kind: Job
       metadata:
-        name: 'add-prospective-indexing'
+        generateName: 'add-prospective-indexing-'
         namespace: '{{ scout_extractor_namespace }}'
         labels:
           app: prospective-indexing
       spec:
+        ttlSecondsAfterFinished: 3600
         backoffLimit: 5
         template:
           metadata:


### PR DESCRIPTION
## Description

### Product
<!-- Provide a summary explanation of your changes from a product/user perspective. More details should be found in your updates to the user docs. -->
Fixes a deployment failure when rerunning the main Ansible playbook (e.g., during upgrades). Previously, the Temporal scheduled ingestion job would fail on the second run because it tried to create a schedule that already existed. This would block use of the `main` playbook for upgrade.

### Technical
<!-- Provide a summary explanation of your changes from a technical perspective. More details should be found in your updates to the technical docs. -->
The `add-prospective-indexing` K8s Job in the temporal role used `temporal schedule create`, which fails if the schedule already exists. Additionally, K8s Jobs are immutable, so the existing completed Job prevented a new one from being created.
                                                                                                                                                                                                                                
Two fixes:      
1. ~~Delete the previous K8s Job before creating a new one~~ Use `generateName` plus `ttlSecondsAfterFinished` to ensure no job collision (with cleanup)
2. Replace the bare `temporal schedule create` command with a shell script that checks if the schedule exists via `temporal schedule describe`, then calls `update` or `create` accordingly
                                                                                                                                                                                 
This also means changes to `scheduled_ingest_hour`/`scheduled_ingest_cron` in inventory are picked up on upgrade (previously, they were not applied).

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
<!-- Do your changes add or modify user roles? Do they impact the data users are able to see, or the actions they are able to take? Could a user modify a REST API path and see data they aren't supposed to see? Were you mindful of least privilege? -->
N/A

##### Appsec
<!-- Did you review your changes with application security in mind? See the [OWASP list](https://github.com/0xRadi/OWASP-Web-Checklist). -->
N/A

### Performance
<!-- At what scale do we expect this to operate? How have you verified that it can do so? -->
N/A

### Data
<!-- Did you consider any edge cases around input data (e.g., DICOM type 2 elements are required to be present but may be empty)? Are you gracefully handling errors from "bad data," e.g., non-conforming DICOM? -->
N/A

### Backward compatibility
<!-- Any changes to the data model, APIs, dependencies? -->
Compatible

## Testing
<!-- Detail the testing you have performed to ensure that these changes function as intended. Include information about the test automation you've added, as well as the manual testing you've performed. Be sure to reference areas of impact, above. -->
*Temporarily* added a CI idempotency test in the `deploy-and-test` job to run the orchestrator playbook twice and then  confirm the Temporal schedule exists with the correct workflow type, task queue, and cron spec after the second run. [Review result](https://github.com/washu-tag/scout/actions/runs/24261168443/job/70845677013), and note that the scan-images failures are because all images are rebuilt when CI changes, and this is picking up new CVEs on unchanged services.

The test:
```
      - name: 'Install orchestrator (idempotency)'
        shell: bash
        run: |
          cd ansible && sudo -E /opt/pipx_bin/ansible-playbook -i inventory.yaml --diff playbooks/orchestrator.yaml
      - name: 'Verify Temporal schedule after rerun'
        shell: bash
        run: |
          sudo -E kubectl run temporal-schedule-check -n scout-extractor --rm -i --restart=Never \
            --image=temporalio/admin-tools \
            --env="TEMPORAL_ADDRESS=temporal-internal-frontend.scout-extractor:7236" \
            -- temporal schedule describe --schedule-id ScheduledReportIngest \
            | tee /tmp/schedule-describe.txt
          grep -q 'IngestHl7LogWorkflow' /tmp/schedule-describe.txt
          grep -q 'ingest-hl7-log' /tmp/schedule-describe.txt
          fgrep -q '[{"second":"0","minute":"0","hour":"6","dayOfMonth":"1-31","month":"1-12","dayOfWeek":"0-6"}]' /tmp/schedule-describe.txt
```

## Note for reviewers
<!-- Any additional information or direction for reviewers. -->
I removed the CI change because I don't think it's all that valuable (if it is, we should deploy all services twice). Open to thoughts.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
