### PR TITLE
Set up authentication for Grafana sidecar provisioning reloads and pause disabled Grafana alerts

### DIFF
--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -72,6 +72,7 @@ k3s_cluster:
     prometheus_storage_size: 1Gi
     loki_storage_size: 1Gi
     grafana_storage_size: 1Gi
+    grafana_admin_password: ci-grafana-admin-password
     grafana_alerts_enabled: false
 
     # Jupyter config

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -405,6 +405,28 @@ jobs:
           sudo -E kubectl rollout status statefulset/loki -n scout-monitoring --timeout=180s
           echo "=== All pods ==="
           sudo -E kubectl get pods -A
+      # Verify Grafana sidecars can authenticate for provisioning reloads.
+      # Grafana auto-reloads dashboards via filesystem polling, but alerts and
+      # datasources require an explicit API call from the sidecar. All sidecars
+      # share the same admin credentials, so testing the dashboard sidecar's
+      # auth validates that the alerts sidecar (disabled in CI) would also work.
+      - name: 'Grafana sidecar auth check'
+        shell: bash
+        run: |
+          echo "=== Checking grafana-sc-dashboard sidecar can reload ==="
+          LOGS=$(sudo -E kubectl logs -n scout-monitoring deployment/grafana -c grafana-sc-dashboard 2>&1)
+          if echo "$LOGS" | grep -q "provisioning/dashboards/reload.*401"; then
+            echo "FAIL: Dashboard sidecar got 401 on provisioning reload"
+            echo "$LOGS"
+            exit 1
+          fi
+          if echo "$LOGS" | grep -q "provisioning/dashboards/reload"; then
+            echo "PASS: Dashboard sidecar called provisioning reload endpoint"
+          else
+            echo "FAIL: Dashboard sidecar never called provisioning/dashboards/reload (missing admin credentials?)"
+            echo "$LOGS"
+            exit 1
+          fi
       # Trino connectivity check
       - name: 'Trino connectivity check'
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -405,26 +405,31 @@ jobs:
           sudo -E kubectl rollout status statefulset/loki -n scout-monitoring --timeout=180s
           echo "=== All pods ==="
           sudo -E kubectl get pods -A
-      # Verify Grafana sidecars can authenticate for provisioning reloads.
+      # Verify Grafana sidecar can authenticate for provisioning reloads.
       # Grafana auto-reloads dashboards via filesystem polling, but alerts and
-      # datasources require an explicit API call from the sidecar. All sidecars
-      # share the same admin credentials, so testing the dashboard sidecar's
-      # auth validates that the alerts sidecar (disabled in CI) would also work.
-      - name: 'Grafana sidecar auth check'
+      # datasources require an explicit API call from the sidecar. This test
+      # triggers a reload by creating a labeled ConfigMap, then checks that the
+      # sidecar's reload call succeeds (not 401 Unauthorized).
+      - name: 'Grafana sidecar reload check'
         shell: bash
         run: |
-          echo "=== Checking grafana-sc-dashboard sidecar can reload ==="
-          LOGS=$(sudo -E kubectl logs -n scout-monitoring deployment/grafana -c grafana-sc-dashboard 2>&1)
+          echo "=== Triggering dashboard sidecar reload ==="
+          sudo -E kubectl create configmap sidecar-reload-test \
+            -n scout-monitoring --from-literal='sidecar-reload-test.json={}'
+          sudo -E kubectl label configmap sidecar-reload-test \
+            -n scout-monitoring grafana_dashboard=1
+          sleep 5
+          LOGS=$(sudo -E kubectl logs -n scout-monitoring deployment/grafana \
+            -c grafana-sc-dashboard --since=10s 2>&1)
+          echo "$LOGS"
           if echo "$LOGS" | grep -q "provisioning/dashboards/reload.*401"; then
-            echo "FAIL: Dashboard sidecar got 401 on provisioning reload"
-            echo "$LOGS"
+            echo "FAIL: Dashboard sidecar got 401 Unauthorized on reload"
             exit 1
           fi
           if echo "$LOGS" | grep -q "provisioning/dashboards/reload"; then
-            echo "PASS: Dashboard sidecar called provisioning reload endpoint"
+            echo "PASS: Dashboard sidecar reload succeeded"
           else
-            echo "FAIL: Dashboard sidecar never called provisioning/dashboards/reload (missing admin credentials?)"
-            echo "$LOGS"
+            echo "FAIL: No reload call found in sidecar logs"
             exit 1
           fi
       # Trino connectivity check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -405,33 +405,6 @@ jobs:
           sudo -E kubectl rollout status statefulset/loki -n scout-monitoring --timeout=180s
           echo "=== All pods ==="
           sudo -E kubectl get pods -A
-      # Verify Grafana sidecar can authenticate for provisioning reloads.
-      # Grafana auto-reloads dashboards via filesystem polling, but alerts and
-      # datasources require an explicit API call from the sidecar. This test
-      # triggers a reload by creating a labeled ConfigMap, then checks that the
-      # sidecar's reload call succeeds (not 401 Unauthorized).
-      - name: 'Grafana sidecar reload check'
-        shell: bash
-        run: |
-          echo "=== Triggering dashboard sidecar reload ==="
-          sudo -E kubectl create configmap sidecar-reload-test \
-            -n scout-monitoring --from-literal='sidecar-reload-test.json={}'
-          sudo -E kubectl label configmap sidecar-reload-test \
-            -n scout-monitoring grafana_dashboard=1
-          sleep 5
-          LOGS=$(sudo -E kubectl logs -n scout-monitoring deployment/grafana \
-            -c grafana-sc-dashboard --since=10s 2>&1)
-          echo "$LOGS"
-          if echo "$LOGS" | grep -q "provisioning/dashboards/reload.*401"; then
-            echo "FAIL: Dashboard sidecar got 401 Unauthorized on reload"
-            exit 1
-          fi
-          if echo "$LOGS" | grep -q "provisioning/dashboards/reload"; then
-            echo "PASS: Dashboard sidecar reload succeeded"
-          else
-            echo "FAIL: No reload call found in sidecar logs"
-            exit 1
-          fi
       # Trino connectivity check
       - name: 'Trino connectivity check'
         shell: bash

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -408,6 +408,7 @@ k3s_cluster:
     #---------------------------------------------------------------------------
     # Grafana
     #---------------------------------------------------------------------------
+    grafana_admin_password: $(openssl rand -hex 16 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
     grafana_alert_contact_point: slack # email or slack
     # Slack configuration
     slack_token: $(echo $SLACK_TOKEN | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)

--- a/ansible/roles/grafana/defaults/main.yaml
+++ b/ansible/roles/grafana/defaults/main.yaml
@@ -11,6 +11,10 @@ grafana_helm_chart_name: grafana
 grafana_storage_size: 5Gi
 grafana_storage_class: ''
 
+# Internal admin password used by sidecars for API reload calls.
+# Login form is disabled so this account is not user-accessible.
+grafana_admin_password: ''
+
 # Alert configuration
 grafana_alerts_enabled: true
 grafana_alert_contact_point: slack # email or slack

--- a/ansible/roles/grafana/tasks/deploy.yaml
+++ b/ansible/roles/grafana/tasks/deploy.yaml
@@ -93,7 +93,7 @@
           vars:
             alert_name: "{{ item.path | basename | regex_replace('.json.j2$', '') }}"
             alert_filename: '{{ alert_name }}.json'
-            alert_is_disabled: "{{ alert_name in grafana_disabled_alerts }}"
+            alert_is_disabled: '{{ alert_name in grafana_disabled_alerts }}'
             alert_content_b64: >-
               {{ (lookup("template", item.path, variable_start_string="[%", variable_end_string="%]") | b64encode) }}
           kubernetes.core.k8s:

--- a/ansible/roles/grafana/tasks/deploy.yaml
+++ b/ansible/roles/grafana/tasks/deploy.yaml
@@ -198,6 +198,21 @@
           data:
             pg-db.yaml: '{{ postgres_datasource_content_b64 }}'
 
+- name: Create Grafana admin credentials secret
+  no_log: true
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: grafana-admin-credentials
+        namespace: '{{ grafana_namespace }}'
+      type: Opaque
+      stringData:
+        admin-user: admin
+        admin-password: '{{ grafana_admin_password }}'
+
 - name: Deploy Grafana
   ansible.builtin.include_role:
     name: scout_common

--- a/ansible/roles/grafana/tasks/deploy.yaml
+++ b/ansible/roles/grafana/tasks/deploy.yaml
@@ -84,10 +84,16 @@
             patterns: '*.json.j2'
           register: alert_templates
 
+        # Disabled alerts are provisioned with `isPaused: true` rather than
+        # being skipped. Grafana's provisioning reload is import-only and
+        # never purges rules whose files disappear, so pause-based disabling
+        # avoids a separate cleanup path.
         - name: Create ConfigMap for each Grafana alert
           no_log: true
           vars:
-            alert_filename: '{{ item.path | basename | regex_replace(".json.j2$", ".json") }}'
+            alert_name: "{{ item.path | basename | regex_replace('.json.j2$', '') }}"
+            alert_filename: '{{ alert_name }}.json'
+            alert_is_disabled: "{{ alert_name in grafana_disabled_alerts }}"
             alert_content_b64: >-
               {{ (lookup("template", item.path, variable_start_string="[%", variable_end_string="%]") | b64encode) }}
           kubernetes.core.k8s:
@@ -96,7 +102,7 @@
               apiVersion: v1
               kind: ConfigMap
               metadata:
-                name: '{{ item.path | basename | regex_replace(".json.j2$", "") }}'
+                name: '{{ alert_name }}'
                 namespace: '{{ grafana_namespace }}'
                 labels:
                   grafana_alert: '1'
@@ -104,16 +110,6 @@
           loop: '{{ alert_templates.files }}'
           loop_control:
             label: '{{ item.path | basename }}'
-          when: (item.path | basename | regex_replace('.json.j2$', '')) not in grafana_disabled_alerts
-
-        - name: Remove ConfigMaps for disabled Grafana alerts
-          kubernetes.core.k8s:
-            state: absent
-            kind: ConfigMap
-            name: '{{ item }}'
-            namespace: '{{ grafana_namespace }}'
-          loop: '{{ grafana_disabled_alerts }}'
-          when: grafana_disabled_alerts | length > 0
 
         - name: Create Grafana notification policy as ConfigMap
           vars:

--- a/ansible/roles/grafana/tasks/deploy.yaml
+++ b/ansible/roles/grafana/tasks/deploy.yaml
@@ -1,4 +1,13 @@
 ---
+- name: Verify required variables are defined
+  ansible.builtin.assert:
+    that:
+      - grafana_admin_password | default('') | length > 0
+    fail_msg: >-
+      grafana_admin_password must be set in inventory. Sidecars use it
+      to authenticate to /api/admin/provisioning/*/reload; an empty
+      value disables hot-reload of alerts and datasources.
+
 - name: Create namespace
   ansible.builtin.include_role:
     name: scout_common

--- a/ansible/roles/grafana/templates/alerts/high-node-cpu-iowait-usage-alert.json.j2
+++ b/ansible/roles/grafana/templates/alerts/high-node-cpu-iowait-usage-alert.json.j2
@@ -78,7 +78,7 @@
             "URL": "[% server_hostname %]"
           },
           "labels": {},
-          "isPaused": false,
+          "isPaused": [% alert_is_disabled | default(false) | bool | tojson %],
           "notification_settings": {
             "receiver": "[% grafana_alert_contact_point %]"
           }

--- a/ansible/roles/grafana/templates/alerts/high-node-cpu-usage-alert.json.j2
+++ b/ansible/roles/grafana/templates/alerts/high-node-cpu-usage-alert.json.j2
@@ -78,7 +78,7 @@
             "URL": "[% server_hostname %]"
           },
           "labels": {},
-          "isPaused": false,
+          "isPaused": [% alert_is_disabled | default(false) | bool | tojson %],
           "notification_settings": {
             "receiver": "[% grafana_alert_contact_point %]"
           }

--- a/ansible/roles/grafana/templates/alerts/high-node-disk-usage-alert.json.j2
+++ b/ansible/roles/grafana/templates/alerts/high-node-disk-usage-alert.json.j2
@@ -78,7 +78,7 @@
             "URL": "[% server_hostname %]"
           },
           "labels": {},
-          "isPaused": false,
+          "isPaused": [% alert_is_disabled | default(false) | bool | tojson %],
           "notification_settings": {
             "receiver": "[% grafana_alert_contact_point %]"
           }

--- a/ansible/roles/grafana/templates/alerts/high-node-memory-usage-alert.json.j2
+++ b/ansible/roles/grafana/templates/alerts/high-node-memory-usage-alert.json.j2
@@ -78,7 +78,7 @@
             "URL": "[% server_hostname %]"
           },
           "labels": {},
-          "isPaused": false,
+          "isPaused": [% alert_is_disabled | default(false) | bool | tojson %],
           "notification_settings": {
             "receiver": "[% grafana_alert_contact_point %]"
           }

--- a/ansible/roles/grafana/templates/alerts/high-node-mount-inode-usage-alert.json.j2
+++ b/ansible/roles/grafana/templates/alerts/high-node-mount-inode-usage-alert.json.j2
@@ -78,7 +78,7 @@
             "URL": "[% server_hostname %]"
           },
           "labels": {},
-          "isPaused": false,
+          "isPaused": [% alert_is_disabled | default(false) | bool | tojson %],
           "notification_settings": {
             "receiver": "[% grafana_alert_contact_point %]"
           }

--- a/ansible/roles/grafana/templates/alerts/high-node-system-load-alert.json.j2
+++ b/ansible/roles/grafana/templates/alerts/high-node-system-load-alert.json.j2
@@ -78,7 +78,7 @@
             "URL": "[% server_hostname %]"
           },
           "labels": {},
-          "isPaused": false,
+          "isPaused": [% alert_is_disabled | default(false) | bool | tojson %],
           "notification_settings": {
             "receiver": "[% grafana_alert_contact_point %]"
           }

--- a/ansible/roles/grafana/templates/alerts/high-postgres-connections-usage-alert.json.j2
+++ b/ansible/roles/grafana/templates/alerts/high-postgres-connections-usage-alert.json.j2
@@ -80,7 +80,7 @@
             "URL": "[% server_hostname %]"
           },
           "labels": {},
-          "isPaused": false,
+          "isPaused": [% alert_is_disabled | default(false) | bool | tojson %],
           "notification_settings": {
             "receiver": "[% grafana_alert_contact_point %]"
           }

--- a/ansible/roles/grafana/templates/alerts/high-postgres-transaction-times-alert.json.j2
+++ b/ansible/roles/grafana/templates/alerts/high-postgres-transaction-times-alert.json.j2
@@ -80,7 +80,7 @@
             "URL": "[% server_hostname %]"
           },
           "labels": {},
-          "isPaused": false,
+          "isPaused": [% alert_is_disabled | default(false) | bool | tojson %],
           "notification_settings": {
             "receiver": "[% grafana_alert_contact_point %]"
           }

--- a/ansible/roles/grafana/templates/alerts/keycloak-pod-not-ready-alert.json.j2
+++ b/ansible/roles/grafana/templates/alerts/keycloak-pod-not-ready-alert.json.j2
@@ -78,7 +78,7 @@
             "URL": "[% server_hostname %]"
           },
           "labels": {},
-          "isPaused": false,
+          "isPaused": [% alert_is_disabled | default(false) | bool | tojson %],
           "notification_settings": {
             "receiver": "[% grafana_alert_contact_point %]"
           }

--- a/ansible/roles/grafana/templates/alerts/no-hl7-processed-alert.json.j2
+++ b/ansible/roles/grafana/templates/alerts/no-hl7-processed-alert.json.j2
@@ -85,7 +85,7 @@
             "URL": "[% server_hostname %]"
           },
           "labels": {},
-          "isPaused": false,
+          "isPaused": [% alert_is_disabled | default(false) | bool | tojson %],
           "notification_settings": {
             "receiver": "[% grafana_alert_contact_point %]"
           }

--- a/ansible/roles/grafana/templates/alerts/oauth2-proxy-pod-not-ready-alert.json.j2
+++ b/ansible/roles/grafana/templates/alerts/oauth2-proxy-pod-not-ready-alert.json.j2
@@ -78,7 +78,7 @@
             "URL": "[% server_hostname %]"
           },
           "labels": {},
-          "isPaused": false,
+          "isPaused": [% alert_is_disabled | default(false) | bool | tojson %],
           "notification_settings": {
             "receiver": "[% grafana_alert_contact_point %]"
           }

--- a/ansible/roles/grafana/templates/alerts/temporal-workflow-failure-alert.json.j2
+++ b/ansible/roles/grafana/templates/alerts/temporal-workflow-failure-alert.json.j2
@@ -81,7 +81,7 @@
             "URL": "[% server_hostname %]"
           },
           "labels": {},
-          "isPaused": false,
+          "isPaused": [% alert_is_disabled | default(false) | bool | tojson %],
           "notification_settings": {
             "receiver": "[% grafana_alert_contact_point %]"
           }

--- a/ansible/roles/grafana/templates/grafana.values.yaml.j2
+++ b/ansible/roles/grafana/templates/grafana.values.yaml.j2
@@ -47,8 +47,10 @@ grafana.ini:
     preinstall_disabled: true
 {% endif %}
 
-env:
-  GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION: true
+admin:
+  existingSecret: grafana-admin-credentials
+  userKey: admin-user
+  passwordKey: admin-password
 
 extraSecretMounts:
   - name: keycloak-grafana-client-secret
@@ -192,12 +194,10 @@ sidecar:
     enabled: {{ grafana_alerts_enabled | default(true) | bool | lower }}
     label: grafana_alert
     labelValue: '1'
-    watchMethod: SLEEP
   dashboards:
     enabled: true
     label: grafana_dashboard
     labelValue: '1'
-    watchMethod: SLEEP
     provider:
       folder: Scout
   datasources:

--- a/ansible/roles/k3s/tasks/agent.yaml
+++ b/ansible/roles/k3s/tasks/agent.yaml
@@ -3,17 +3,32 @@
 # Installs k3s agent and joins it to the k3s server
 # Only runs on hosts in the 'agents' group
 
+# The install script does `systemctl start` and checks status once. If the
+# first start attempt fatals on a transient race (TLS tunnel EOF when
+# multiple agents join simultaneously), the script exits 1 even though
+# systemd's Restart=always brings the service up seconds later. Rescue by
+# waiting for systemd to report active; genuine failures still propagate.
 - name: Install k3s agent
-  ansible.builtin.command:
-    cmd: '{{ k3s_install_script_path }}'
-    creates: /usr/local/bin/k3s-agent-uninstall.sh
-  environment:
-    INSTALL_K3S_SKIP_DOWNLOAD: "{{ 'true' if air_gapped | default(false) | bool else omit }}"
-    INSTALL_K3S_VERSION: '{{ k3s_version | default("") }}'
-    K3S_URL: 'https://{{ groups["server"][0] }}:6443'
-    K3S_TOKEN: '{{ k3s_token }}'
-    UNINSTALL_K3S_SH: /usr/local/bin/k3s-agent-uninstall.sh
-  register: k3s_agent_install_result
+  block:
+    - name: Run k3s agent install script
+      ansible.builtin.command:
+        cmd: '{{ k3s_install_script_path }}'
+        creates: /usr/local/bin/k3s-agent-uninstall.sh
+      environment:
+        INSTALL_K3S_SKIP_DOWNLOAD: "{{ 'true' if air_gapped | default(false) | bool else omit }}"
+        INSTALL_K3S_VERSION: '{{ k3s_version | default("") }}'
+        K3S_URL: 'https://{{ groups["server"][0] }}:6443'
+        K3S_TOKEN: '{{ k3s_token }}'
+        UNINSTALL_K3S_SH: /usr/local/bin/k3s-agent-uninstall.sh
+      register: k3s_agent_install_result
+  rescue:
+    - name: Wait for k3s-agent to reach active state
+      ansible.builtin.systemd:
+        name: k3s-agent
+      register: k3s_agent_state
+      until: k3s_agent_state.status.ActiveState == "active"
+      retries: 12
+      delay: 5
 
 - name: Restart k3s-agent to pick up registry config changes
   ansible.builtin.systemd:

--- a/ansible/roles/voila/tasks/deploy.yaml
+++ b/ansible/roles/voila/tasks/deploy.yaml
@@ -91,4 +91,4 @@
     helm_chart_values_files:
       - '{{ scout_repo_dir }}/helm/voila/values.yaml'
     helm_chart_values: '{{ voila_helm_chart_values }}'
-    wait_timeout: 10m
+    helm_chart_timeout: 15m


### PR DESCRIPTION
## Description

### Product
<!-- Provide a summary explanation of your changes from a product/user perspective. More details should be found in your updates to the user docs. -->
Grafana alert and datasource configuration changes now take effect immediately when ConfigMaps/Secrets are updated. Previously, the sidecar's reload call failed with `401 Unauthorized`, and because alerts and datasources have no filesystem polling fallback, provisioning changes could fail to take effect entirely (even across pod restarts).

Disabling an alert via `grafana_disabled_alerts` now pauses the rule (still visible in the UI, marked Paused) rather than removing its ConfigMap.

### Technical
<!-- Provide a summary explanation of your changes from a technical perspective. More details should be found in your updates to the technical docs. -->
The Grafana sidecar containers call Grafana's `/api/admin/provisioning/*/reload` endpoint after detecting ConfigMap/Secret changes. These endpoints require Basic Auth with a server admin account. Setting `GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION: true` prevented any admin user from being created, and also suppressed the Helm chart from injecting `REQ_URL/REQ_USERNAME/REQ_PASSWORD` into sidecars, so reload calls were never attempted.
                                                                                                                                                                                                                                  
The fix replaces that env var with an `admin.existingSecret` reference to a Kubernetes Secret containing an internal admin password. The login form is already disabled (`disable_login_form: true`) and OAuth auto-login is enabled, so the local admin account is not user-accessible; it exists solely for sidecar API authentication.                                                                                                                   
                  
This change also removes explicit `watchMethod: SLEEP` from sidecar config, reverting to the chart default `WATCH` for real-time change detection instead of 60-second polling.

**Disabled alerts** are now provisioned with `isPaused: true` at the rule level rather than skipped during render. Provisioning reload in Grafana is import-only — rules whose source files disappear are never purged — so a delete-based approach would have required a separate `deleteRules` ConfigMap plus fragile UID extraction from Jinja-templated JSON. Pausing sidesteps that cleanup path entirely; `grafana_disabled_alerts` now flips `isPaused` via an `alert_is_disabled` template variable.

**This branch also includes two unrelated fixes that surfaced during multiple deploys to dev04**                                                                                                 
- Tolerate transient start race in k3s agent install: wraps the install in `block/rescue` so a transient TLS tunnel EOF at agent join doesn't fail the play.                                                    
- Rename voila `wait_timeout` to `helm_chart_timeout`: bugfix to use the proper `deploy_helm_chart` variable.  

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
<!-- Do your changes add or modify user roles? Do they impact the data users are able to see, or the actions they are able to take? Could a user modify a REST API path and see data they aren't supposed to see? Were you mindful of least privilege? -->
Restores a local Grafana admin account, but it is not accessible via the UI. The password is vault-encrypted in inventory and only used internally by sidecar containers.

##### Appsec
<!-- Did you review your changes with application security in mind? See the [OWASP list](https://github.com/0xRadi/OWASP-Web-Checklist). -->
I don't love having a Grafana admin account + password. However, I think it's reasonably safe:
- The login form is disabled (`disable_login_form: true`) so the account is not accessible via the Grafana UI                                                                                                                                                                                                
- Grafana's ingress is behind OAuth2 Proxy, so API calls from outside the cluster require a valid Keycloak session. It's unclear whether OAuth2 Proxy would pass through a Basic Auth header alongside a session cookie, but if it did, a valid user would have to grab their cookie and apply it to an API call, while also knowing the Grafana admin password.                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                  
Claude suggests: A zero-credential alternative (using `skipReload` with init containers) would eliminate the admin account but sacrifice hot-reload for alerts and datasources, requiring a pod restart for provisioning changes to take effect. 

### Performance
<!-- At what scale do we expect this to operate? How have you verified that it can do so? -->
N/A

### Data
<!-- Did you consider any edge cases around input data (e.g., DICOM type 2 elements are required to be present but may be empty)? Are you gracefully handling errors from "bad data," e.g., non-conforming DICOM? -->
N/A

### Backward compatibility
<!-- Any changes to the data model, APIs, dependencies? -->
Compatible

## Testing
<!-- Detail the testing you have performed to ensure that these changes function as intended. Include information about the test automation you've added, as well as the manual testing you've performed. Be sure to reference areas of impact, above. -->
[Tested via CI](https://github.com/washu-tag/scout/actions/runs/24365177179/job/71155434211)

Verified on dev04: installed with all alerts active, then added to inventory:
```
grafana_disabled_alerts:
  - no-hl7-processed-alert
  - temporal-workflow-failure-alert
```
and reran. Verified alerts are paused:
<img width="1364" height="521" alt="Screenshot 2026-04-21 at 3 27 20 PM" src="https://github.com/user-attachments/assets/20f311dd-91fa-49d6-a2b8-7eae15d34937" />

Also verified no 401s in Grafana logs on reload.

## Note for reviewers
<!-- Any additional information or direction for reviewers. -->
- Corresponding [scout-inventory PR](https://github.com/washu-tag/scout-inventory/pull/29) 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
