### PR TITLE
Bump open-webui chart to 13.3.1 and Ollama to 0.20.6

### DIFF
--- a/ansible/group_vars/all/versions.yaml
+++ b/ansible/group_vars/all/versions.yaml
@@ -91,7 +91,9 @@ jupyter_helm_chart_version: ~4.3.0
 
 # AI & ML
 # renovate: datasource=helm registryUrl=https://helm.openwebui.com/ depName=open-webui
-open_webui_helm_chart_version: ~8.22.0
+open_webui_helm_chart_version: ~13.3.1
+# renovate: datasource=docker depName=ollama/ollama
+ollama_image_tag: 0.20.6
 
 # Monitoring & Observability - Prometheus
 # renovate: datasource=helm registryUrl=https://prometheus-community.github.io/helm-charts depName=kube-prometheus-stack

--- a/ansible/roles/open-webui/README.md
+++ b/ansible/roles/open-webui/README.md
@@ -110,7 +110,7 @@ exit
 
 Configure the Trino MCP external tool to enable SQL querying:
 
-1. Navigate to **Admin Panel → Settings → External Tools** (requires admin access)
+1. Navigate to **Admin Panel → Settings → Integrations** (requires admin access)
 2. Click **+ (Add Server)**
 3. Configure the tool:
    - **Type**: `MCP (Streamable HTTP)`

--- a/ansible/roles/open-webui/defaults/main.yaml
+++ b/ansible/roles/open-webui/defaults/main.yaml
@@ -12,6 +12,9 @@ open_webui_helm_release_name: open-webui
 ollama_name: ollama
 open_webui_name: open-webui
 
+# Ollama image (tag pinned in group_vars/all/versions.yaml)
+ollama_image_repository: ollama/ollama
+
 # Storage configuration
 ollama_storage_size: 5Gi
 ollama_storage_class: ''

--- a/ansible/roles/open-webui/templates/pull_models_job.yaml.j2
+++ b/ansible/roles/open-webui/templates/pull_models_job.yaml.j2
@@ -17,7 +17,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: ollama
-          image: 'ollama/ollama:{{ ollama_version | default("latest") }}'
+          image: '{{ ollama_image_repository }}:{{ ollama_image_tag }}'
           env:
 {% if _pull_air_gapped %}
             - name: OLLAMA_MODELS

--- a/ansible/roles/open-webui/templates/values.yaml.j2
+++ b/ansible/roles/open-webui/templates/values.yaml.j2
@@ -5,6 +5,9 @@ ollama:
   enabled: true
   # -- If enabling embedded Ollama, update fullnameOverride to your desired Ollama name value, or else it will use the default ollama.name value from the Ollama chart
   fullnameOverride: ollama
+  image:
+    repository: '{{ ollama_image_repository }}'
+    tag: '{{ ollama_image_tag }}'
   ollama:
     gpu:
       enabled: {{ ollama_gpu_enabled }}
@@ -27,6 +30,8 @@ ollama:
   extraEnv:
     - name: OLLAMA_KEEP_ALIVE
       value: '-1'
+    - name: OLLAMA_NO_CLOUD
+      value: '1'
 {% if air_gapped | default(false) and ollama_nfs_path is defined and ollama_nfs_path | length > 0 %}
     # Air-gapped with NFS: mount pre-staged models read-only (ADR 0008)
     - name: OLLAMA_MODELS
@@ -118,12 +123,12 @@ enableOpenaiApi: false
 websocket:
   # -- Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT`
   enabled: true
-  # Use external Redis for websocket coordination
+  # Use external Valkey for websocket coordination
   manager: redis
-  # Set to empty - will be overridden by extraEnvVars below (which comes last in env list)
-  url: ''
+  existingSecret: open-webui-secrets
+  existingSecretKey: REDIS_URL
   redis:
-    # Disable embedded Redis - using external Redis Enterprise Database
+    # Disable embedded Redis - using external Valkey
     enabled: false
 
 # Load sensitive environment variables from Kubernetes Secret
@@ -205,16 +210,3 @@ extraEnvVars:
   # Logout redirect URL (OAuth2 Proxy signout)
   - name: WEBUI_AUTH_SIGNOUT_REDIRECT_URL
     value: '{{ oauth2_proxy_signout_url }}'
-
-  # Redis URLs with passwords - loaded from secret
-  # These override the chart's default WEBSOCKET_REDIS_URL (last env wins)
-  - name: WEBSOCKET_REDIS_URL
-    valueFrom:
-      secretKeyRef:
-        name: open-webui-secrets
-        key: REDIS_URL
-  - name: REDIS_URL
-    valueFrom:
-      secretKeyRef:
-        name: open-webui-secrets
-        key: REDIS_URL


### PR DESCRIPTION
## Description

### Product

Adds Gemma 4 model support to Chat for evaluation alongside gpt-oss.

### Technical

- Bumps Ollama to 0.20.6 (Gemma 4 architecture + tool support) and the open-webui Helm chart to 13.3.1. Chart now owns `REDIS_URL`/`WEBSOCKET_REDIS_URL` injection (open-webui/helm-charts#378).
- Pinned the Ollama image tag in `versions.yaml`, helm chart default is 0.19.0 and we need at least [v0.20.0 of Ollama for Gemma 4 support](https://github.com/ollama/ollama/releases/tag/v0.20.0).
- [Disables Ollama cloud features](https://docs.ollama.com/faq#how-do-i-disable-ollama’s-cloud-features) with `OLLAMA_NO_CLOUD`.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
The chart upgrade did not work so I did a helm uninstall of open-webui (but kept the db in CNPG). I think it's related to the `REDIS_URL` env / secret. 

## Testing
See backward compatibility for more info. I had to helm uninstall then make install-chat on dev02. Ollama 0.20.6 runs and gemma4 models load a run in Chat using same Open Web UI settings as gpt-oss. 

## Note for reviewers
Let me know your thoughts on backward compatibility. I could look into this more but we have just been starting fresh with Chat the last couple upgrade cycles. 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
