### PR TITLE
Bump Spring Boot and Temporal SDK in extractor/hl7log-extractor

### DIFF
--- a/docs/internal/ci-security-scanning.md
+++ b/docs/internal/ci-security-scanning.md
@@ -131,9 +131,10 @@ Dependabot handles two concerns:
 
 **Required GitHub settings** (**Settings > Security > Advanced Security**):
 
-1. **Dependency graph** — must be enabled. GitHub automatically detects manifest files (`package.json`, `pyproject.toml`, `requirements.txt`, `build.gradle`, `Dockerfile`, etc.) and builds the dependency graph. This is the foundation for all Dependabot features.
-2. **Dependabot alerts** — must be enabled. Matches the dependency graph against the GitHub Advisory Database and creates alerts for known CVEs.
-3. **Dependabot security updates** — enable this to have Dependabot automatically open PRs to fix every alert with an available patch. For more granular control (e.g., auto-dismiss low-severity alerts, target specific ecosystems), leave this disabled and configure **Dependabot rules** instead (**Settings > Security > Advanced Security > Dependabot rules**).
+1. **Dependency graph** — must be enabled. GitHub automatically detects manifest files (`package.json`, `pyproject.toml`, `requirements.txt`, `Dockerfile`, etc.) and builds the dependency graph. This is the foundation for all Dependabot features.
+2. **Automatic dependency submission** — must be enabled (**Settings > Code security > Dependency graph > Automatic dependency submission**). Gradle cannot be statically parsed like npm or pip, so GitHub runs the `gradle/actions/dependency-submission` action automatically on each push to the default branch to resolve and submit the full dependency tree. Without this, Dependabot has no visibility into Gradle dependencies.
+3. **Dependabot alerts** — must be enabled. Matches the dependency graph against the GitHub Advisory Database and creates alerts for known CVEs.
+4. **Dependabot security updates** — enable this to have Dependabot automatically open PRs to fix every alert with an available patch. For more granular control (e.g., auto-dismiss low-severity alerts, target specific ecosystems), leave this disabled and configure **Dependabot rules** instead (**Settings > Security > Advanced Security > Dependabot rules**).
 
 Dependabot does **not** monitor `ansible/group_vars/all/versions.yaml` — that file uses custom YAML keys that no standard package ecosystem can parse, so it is handled by Renovate (see below).
 

--- a/extractor/hl7log-extractor/.trivyignore.yaml
+++ b/extractor/hl7log-extractor/.trivyignore.yaml
@@ -3,3 +3,4 @@ vulnerabilities:
   - id: CVE-2026-22184 # zlib
   # Alpine base image not yet rebuilt with openssl 3.5.6-r0 — check amazoncorretto:21-alpine on Docker Hub for rebuild
   - id: CVE-2026-28390 # openssl 3.5.5-r0 → 3.5.6-r0
+  - id: CVE-2026-40200 # musl 1.2.5-r21 → 1.2.5-r23

--- a/extractor/hl7log-extractor/.trivyignore.yaml
+++ b/extractor/hl7log-extractor/.trivyignore.yaml
@@ -1,11 +1,5 @@
 vulnerabilities:
-  # Transitive dependency from Temporal SDK — awaiting upstream fix
-  - id: CVE-2025-55163 # grpc-netty-shaded
-  # Transitive dependency from Spring Boot BOM — awaiting upstream fix
-  - id: GHSA-72hv-8253-57qq # jackson-core
   # Alpine base image not yet rebuilt with zlib 1.3.2-r0 — check amazoncorretto:21-alpine on Docker Hub for rebuild after 2026-03-05
   - id: CVE-2026-22184 # zlib
-  # Transitive dependency via Spring Boot WebFlux (Reactor Netty) — actuator-only server, not externally reachable.
-  # Remove when Spring Boot upgrades to Netty >= 4.1.132.Final (or override via ext['netty.version'] in build.gradle).
-  - id: CVE-2026-33870 # netty-codec-http: HTTP request smuggling via chunked extension parsing
-  - id: CVE-2026-33871 # netty-codec-http2: DoS via HTTP/2 CONTINUATION frame flood
+  # Alpine base image not yet rebuilt with openssl 3.5.6-r0 — check amazoncorretto:21-alpine on Docker Hub for rebuild
+  - id: CVE-2026-28390 # openssl 3.5.5-r0 → 3.5.6-r0

--- a/extractor/hl7log-extractor/build.gradle
+++ b/extractor/hl7log-extractor/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.13'
+	id 'org.springframework.boot' version '3.5.13'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'checkstyle'
 }
@@ -18,7 +18,7 @@ repositories {
 	mavenCentral()
 }
 
-def temporalVersion = "1.32.1"
+def temporalVersion = "1.34.0"
 def s3Version = "2.20.0"
 def checkstyleVersion = "10.21.2"
 

--- a/launchpad/.trivyignore.yaml
+++ b/launchpad/.trivyignore.yaml
@@ -2,3 +2,4 @@ vulnerabilities:
   # Fixes available in Alpine repos but alpine:3.23 base image not rebuilt since 2026-01-28 — check https://github.com/alpinelinux/docker-alpine for updates
   - id: CVE-2026-22184 # zlib 1.3.1-r2 → 1.3.2-r0
   - id: CVE-2026-28390 # openssl 3.5.5-r0 → 3.5.6-r0
+  - id: CVE-2026-40200 # musl 1.2.5-r21 → 1.2.5-r23


### PR DESCRIPTION
Bumps dependencies in the /extractor/hl7log-extractor directory to resolve fixable image vulnerabilities.                                                                                                                       

Updates org.springframework.boot from 3.4.13 to 3.5.13                                                                                                                                                                          
- https://github.com/spring-projects/spring-boot/releases/tag/v3.5.13
- https://github.com/spring-projects/spring-boot/compare/v3.4.13...v3.5.13                                                                                                                                                      

Updates io.temporal:temporal-sdk from 1.32.1 to 1.34.0                                                                                                                                                                          
- https://github.com/temporalio/sdk-java/releases/tag/v1.34.0
- https://github.com/temporalio/sdk-java/compare/v1.32.1...v1.34.0                                                                                                                                                              
                                                                  
Resolves the following fixable CVEs:                                                                                                                                                                                            
- CVE-2025-55163 — grpc-netty-shaded: MadeYouReset HTTP/2 DDoS (fixed by Temporal SDK 1.33.0+ → gRPC 1.75.0)                                                                                                                    
- GHSA-72hv-8253-57qq — jackson-core: async parser number length bypass DoS (fixed by Spring Boot 3.5+ → Jackson 2.21.1)                                                                                                        
- CVE-2026-33870 — netty-codec-http: HTTP request smuggling via chunked extension parsing (fixed by Spring Boot 3.5+ → Netty 4.1.132.Final)                                                                                     
- CVE-2026-33871 — netty-codec-http2: DoS via HTTP/2 CONTINUATION frame flood (fixed by Spring Boot 3.5+ → Netty 4.1.132.Final)                                                                                                 
                                                                                                                                                                                                                                
Adds suppression for CVE-2026-28390 (openssl 3.5.5 → 3.5.6) and CVE-2026-40200 (musl 1.2.5-r21 → 1.2.5-r23) — Alpine base image not yet rebuilt upstream.                                                                                                                       
                                                                                                                                                                                                                                
Note: Spring Boot 3.4.x is now [EOL](https://spring.io/blog/2025/12/18/spring-boot-3-4-13-available-now/). 3.5.x is the current supported line.                                                                                        
                                                                                                                                                                                                                                
---updated-dependencies:                                                                                                                                                                                                        
- dependency-name: org.springframework.boot
dependency-version: 3.5.13                 
dependency-type: direct:production
- dependency-name: io.temporal:temporal-sdk                                                                                                                                                                                     
dependency-version: 1.34.0                 
dependency-type: direct:production