### PR TITLE
Fix release workflow for 3.0.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,8 +24,11 @@ concurrency:
 
 permissions:
   contents: write
+  packages: write
   pull-requests: read
   actions: read
+  attestations: write
+  id-token: write
 
 jobs:
   validate:
@@ -201,6 +204,7 @@ jobs:
     if: ${{ !inputs.dry_run && always() && !cancelled() && (needs.version-bump.result == 'success' || needs.version-bump.result == 'skipped') }}
     outputs:
       commit_sha: ${{ steps.target.outputs.sha }}
+      ci_run_id: ${{ steps.wait.outputs.run_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -219,6 +223,7 @@ jobs:
           echo "sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Wait for CI workflow
+        id: wait
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -258,6 +263,7 @@ jobs:
             case "$STATUS" in
               completed:success)
                 echo "CI workflow completed successfully"
+                echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
                 exit 0
                 ;;
               completed:*)
@@ -275,11 +281,51 @@ jobs:
           echo "::error::Timed out waiting for CI workflow"
           exit 1
 
+  publish:
+    name: Publish Images
+    runs-on: ubuntu-latest
+    needs: [wait-for-build]
+    # On main, CI's publish job pushes images. On non-main branches, CI runs but its
+    # publish job is gated to main only, so we push images here instead.
+    # always() is required because version-bump (a transitive dependency) may be skipped
+    # on re-runs, and GitHub Actions propagates skip status through the dependency graph.
+    if: >-
+      always() && !cancelled()
+      && github.ref_name != 'main'
+      && !inputs.dry_run
+      && needs.wait-for-build.result == 'success'
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download and push all images
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ needs.wait-for-build.outputs.ci_run_id }}
+        run: |
+          IMAGES="hl7log-extractor hl7-transformer pyspark-notebook launchpad superset keycloak"
+          for IMAGE in $IMAGES; do
+            echo "=== Publishing $IMAGE ==="
+            gh run download "$RUN_ID" -n "$IMAGE" -D "${{ runner.temp }}/$IMAGE"
+            FULL_TAG=$(docker load --input "${{ runner.temp }}/$IMAGE/$IMAGE.tar" | sed 's/.*: //g')
+            rm -f "${{ runner.temp }}/$IMAGE/$IMAGE.tar"
+            docker push "$FULL_TAG"
+            docker rmi "$FULL_TAG"
+          done
+
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [validate, wait-for-build]
-    if: ${{ !inputs.dry_run && always() && !cancelled() && needs.wait-for-build.result == 'success' && needs.validate.outputs.release_exists != 'true' }}
+    needs: [validate, wait-for-build, publish]
+    if: >-
+      !inputs.dry_run && always() && !cancelled()
+      && needs.wait-for-build.result == 'success'
+      && (needs.publish.result == 'success' || needs.publish.result == 'skipped')
+      && needs.validate.outputs.release_exists != 'true'
     steps:
       - name: Generate token from GitHub App
         id: app_token

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,7 +181,7 @@ jobs:
         run: |
           git add -A
           git commit -m "Update to version ${{ inputs.version }}"
-          git push origin main
+          git push origin ${{ github.ref_name }}
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   wait-for-build:
@@ -208,7 +208,7 @@ jobs:
           # The release should include everything on main at this point — not just
           # the version bump commit, but also any fixes pushed after it (e.g., if a
           # previous release attempt failed and we pushed a fix before re-running).
-          git pull origin main
+          git pull origin ${{ github.ref_name }}
           HEAD_SHA=$(git rev-parse HEAD)
           echo "Waiting for build on commit: $HEAD_SHA"
           echo "sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
@@ -230,7 +230,7 @@ jobs:
             if [[ -z "$RUN_ID" ]]; then
               RUN_ID=$(gh run list \
                 --workflow=ci.yaml \
-                --branch=main \
+                --branch=${{ github.ref_name }} \
                 --json databaseId,headSha,status \
                 --jq ".[] | select(.headSha == \"$TARGET_SHA\") | .databaseId" \
                 | head -1)
@@ -318,7 +318,7 @@ jobs:
           token: ${{ steps.app_token.outputs.token }}
 
       - name: Pull latest
-        run: git pull origin main
+        run: git pull origin ${{ github.ref_name }}
 
       - name: Configure git
         run: |
@@ -345,6 +345,6 @@ jobs:
             echo "No changes to commit (already at dev versions)"
           else
             git commit -m "Reset to dev versions"
-            git push origin main
+            git push origin ${{ github.ref_name }}
             echo "::notice::Reset to dev versions complete"
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -310,7 +310,7 @@ jobs:
           IMAGES="hl7log-extractor hl7-transformer pyspark-notebook launchpad superset keycloak"
           for IMAGE in $IMAGES; do
             echo "=== Publishing $IMAGE ==="
-            gh run download "$RUN_ID" -n "$IMAGE" -D "${{ runner.temp }}/$IMAGE"
+            gh run download "$RUN_ID" --repo "${{ github.repository }}" -n "$IMAGE" -D "${{ runner.temp }}/$IMAGE"
             FULL_TAG=$(docker load --input "${{ runner.temp }}/$IMAGE/$IMAGE.tar" | sed 's/.*: //g')
             rm -f "${{ runner.temp }}/$IMAGE/$IMAGE.tar"
             docker push "$FULL_TAG"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_dev_reset:
+        description: 'Skip resetting versions back to dev after release (use for releases from non-main branches)'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: release
@@ -302,7 +307,7 @@ jobs:
     # Only reset after a successful release. If the release was skipped (e.g., build
     # failed) or failed (e.g., gh release create error), we preserve the version bump
     # commit so a re-run can reuse it.
-    if: ${{ !inputs.dry_run && always() && !cancelled() && needs.release.result == 'success' && needs.validate.outputs.reset_exists != 'true' }}
+    if: ${{ !inputs.dry_run && !inputs.skip_dev_reset && always() && !cancelled() && needs.release.result == 'success' && needs.validate.outputs.reset_exists != 'true' }}
     steps:
       - name: Generate token from GitHub App
         id: app_token

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
@@ -156,7 +156,7 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
@@ -285,7 +285,7 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Create GitHub release
@@ -313,7 +313,7 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout

--- a/docs/internal/versions-and-releases.md
+++ b/docs/internal/versions-and-releases.md
@@ -58,7 +58,7 @@ Developer                    GitHub                        CI
     |                           |          v                |
     |                           |     Version bump commit   |
     |                           |     (X.Y.Z in all files)  |
-    |                           |     Push to main          |
+    |                           |     Push to branch        |
     |                           |          |                |
     |                           |          v                |
     |                           |     Build Workflow runs   |
@@ -75,7 +75,7 @@ Developer                    GitHub                        CI
     |                           |          +<---------------+-----------+
     |                           |          v                |
     |                           |     Reset to dev versions |
-    |                           |     Push to main          |
+    |                           |     Push to branch        |
     |                           |                           |
     |<-- Release complete ------|                           |
 ```
@@ -94,7 +94,7 @@ Developer                    GitHub                        CI
 
 1. **Validates** the version format and checks the tag doesn't already exist
 2. **Searches git history** for an existing version bump commit (for idempotent re-runs)
-3. **Updates version files** and commits the version bump to `main` (if not already done)
+3. **Updates version files** and commits the version bump to the branch (if not already done)
 4. **Waits for the Build Workflow** to complete on HEAD (builds versioned artifacts)
 5. **Creates the GitHub release** with auto-generated changelog (if build succeeded)
 6. **Creates the `vX.Y.Z` tag** pointing at HEAD (if build succeeded)
@@ -105,7 +105,7 @@ Developer                    GitHub                        CI
 - Release `v2.1.0` is published with changelog
 - Docker images tagged `2.1.0` are available
 - Tag `v2.1.0` points to the commit that was actually built and released
-- `main` branch is back to dev versions
+- Branch is back to dev versions (unless `skip_dev_reset` was checked)
 
 ## Dry Run Mode
 
@@ -117,6 +117,34 @@ Before releasing, you can preview what the changelog will look like:
 4. Review the output in the workflow logs
 
 This is useful for verifying the changelog looks correct before committing to a release.
+
+## Releasing from a Non-Main Branch
+
+The usual release procedure runs the workflow from `main`. However, if you need to create a release from a different branch (e.g., a hotfix branch for a patch release), the workflow supports this.
+
+### Steps
+
+1. Go to **GitHub Actions** → **Release** workflow
+2. In the **"Use workflow from"** dropdown, select the branch you want to release from
+3. Check **skip_dev_reset** (this prevents an unnecessary commit resetting versions back to dev, and avoids an unneeded CI run on a branch that doesn't need dev versions)
+4. Enter the version and click **"Run workflow"**
+
+The end result is the same as a normal release: a tagged `vX.Y.Z` commit on the branch, with a GitHub release and changelog.
+
+### Branch Name Requirements
+
+The release workflow pushes a version bump commit to the branch and then waits for the CI workflow to build it. The CI workflow only runs on pushes to branches matching specific patterns: `main`, `ci-**`, and `demo**`. If you run the release from a branch that doesn't match any of these patterns, the workflow will time out waiting for a CI run that never starts.
+
+To release from a non-main branch, ensure the branch name starts with `ci-` (e.g., `ci-hotfix-3.0.1`).
+
+### Why Skip the Dev Reset?
+
+The `skip_dev_reset` option prevents the workflow from committing dev versions back to the branch after the release. This is recommended for non-main releases because:
+
+- It avoids an extra commit and CI run on a branch that doesn't need dev versions
+- While it might seem necessary to prevent publishing `latest` images from an older branch, this isn't actually a concern — the `publish` jobs in the CI workflow only run on `main`
+
+Skipping the reset is a good practice for non-main releases but not strictly required.
 
 ## Failure and Recovery
 
@@ -223,7 +251,7 @@ Both approaches are valid. If the alternative behavior is preferred, the `reset-
 
 **File**: Existing build workflows
 
-**Triggers**: Push to `main`
+**Triggers**: Push to `main`, `ci-**`, or `demo**` branches
 
 **Behavior**: Builds and publishes artifacts. Tags are derived from version files:
 - Dev versions (`latest`, `0.0.0-dev`, etc.) → publishes with `latest` tag
@@ -240,6 +268,7 @@ Both approaches are valid. If the alternative behavior is preferred, the `reset-
 |-------|-------------|----------|
 | `version` | Version to release (e.g., `2.1.0`) | Yes |
 | `dry_run` | Preview changelog without releasing | No (default: false) |
+| `skip_dev_reset` | Skip resetting versions back to dev after release (use for releases from non-main branches) | No (default: false) |
 
 **Responsibilities**:
 1. Validate version format and check tag doesn't exist

--- a/docs/internal/versions-and-releases.md
+++ b/docs/internal/versions-and-releases.md
@@ -68,6 +68,10 @@ Developer                    GitHub                        CI
     |                           |     Wait for build -------+---> [Build fails]
     |                           |          |                |           |
     |                           |          v                |           |
+    |                           |     Publish images        |           |
+    |                           |     (non-main only)       |           |
+    |                           |          |                |           |
+    |                           |          v                |           |
     |                           |     Create release        |           |
     |                           |     (auto-gen changelog)  |           |
     |                           |     Create vX.Y.Z tag     |           |
@@ -96,9 +100,10 @@ Developer                    GitHub                        CI
 2. **Searches git history** for an existing version bump commit (for idempotent re-runs)
 3. **Updates version files** and commits the version bump to the branch (if not already done)
 4. **Waits for the Build Workflow** to complete on HEAD (builds versioned artifacts)
-5. **Creates the GitHub release** with auto-generated changelog (if build succeeded)
-6. **Creates the `vX.Y.Z` tag** pointing at HEAD (if build succeeded)
-7. **Resets to dev versions** by running the update script and committing (always, regardless of build result)
+5. **Publishes Docker images** to GHCR (non-main branches only — on main, the CI workflow's publish job handles this)
+6. **Creates the GitHub release** with auto-generated changelog (if build succeeded)
+7. **Creates the `vX.Y.Z` tag** pointing at HEAD (if build succeeded)
+8. **Resets to dev versions** by running the update script and committing (always, regardless of build result)
 
 ### Result
 
@@ -137,12 +142,13 @@ The release workflow pushes a version bump commit to the branch and then waits f
 
 To release from a non-main branch, ensure the branch name starts with `ci-` (e.g., `ci-hotfix-3.0.1`).
 
+### Image Publishing
+
+The CI workflow's `publish` job only runs on `main`. For non-main releases, the release workflow handles image publishing directly: after the CI build succeeds, it downloads the built image artifacts from the CI run and pushes them to GHCR with the release version tag (e.g., `3.0.1`). This ensures versioned images are available regardless of which branch the release is made from, without affecting the `latest` tag.
+
 ### Why Skip the Dev Reset?
 
-The `skip_dev_reset` option prevents the workflow from committing dev versions back to the branch after the release. This is recommended for non-main releases because:
-
-- It avoids an extra commit and CI run on a branch that doesn't need dev versions
-- While it might seem necessary to prevent publishing `latest` images from an older branch, this isn't actually a concern — the `publish` jobs in the CI workflow only run on `main`
+The `skip_dev_reset` option prevents the workflow from committing dev versions back to the branch after the release. This is recommended for non-main releases because it avoids an extra commit and CI run on a branch that doesn't need dev versions.
 
 Skipping the reset is a good practice for non-main releases but not strictly required.
 
@@ -253,9 +259,11 @@ Both approaches are valid. If the alternative behavior is preferred, the `reset-
 
 **Triggers**: Push to `main`, `ci-**`, or `demo**` branches
 
-**Behavior**: Builds and publishes artifacts. Tags are derived from version files:
-- Dev versions (`latest`, `0.0.0-dev`, etc.) → publishes with `latest` tag
-- Release versions (`2.1.0`) → publishes with `2.1.0` tag
+**Behavior**: Builds and tests artifacts. Tags are derived from version files:
+- Dev versions (`latest`, `0.0.0-dev`, etc.) → publishes with `latest` tag (main only)
+- Release versions (`2.1.0`) → publishes with `2.1.0` tag (main only)
+
+The CI workflow's `publish` job only runs on `main`. For non-main branches, the release workflow handles image publishing directly (see below).
 
 ### 2. Release Workflow (New)
 
@@ -274,9 +282,10 @@ Both approaches are valid. If the alternative behavior is preferred, the `reset-
 1. Validate version format and check tag doesn't exist
 2. Update version files and commit
 3. Wait for Build Workflow to complete
-4. Create GitHub release with auto-generated changelog
-5. Create version tag
-6. Reset to dev versions and commit
+4. Publish Docker images to GHCR (non-main branches only)
+5. Create GitHub release with auto-generated changelog
+6. Create version tag
+7. Reset to dev versions and commit
 
 ### 3. Version Update Script
 


### PR DESCRIPTION
## Description

I want to make a `v3.0.1` commit/tag pointing to something closer to what was actually deployed, i.e. including #335. To do that I've created a new branch off commit `de08d0a9`; I want to run the release workflow from that branch. The end state will be a small branch off of `main` with a single commit bumping the versions to `3.0.1`, and that commit will be tagged with `v3.0.1`. However, there are a couple problems with this that the release workflow doesn't currently handle (and which this PR is intended to fix).

1. The release workflow already has a parameter to dispatch it from a non-`main` branch. ✅ . But there are several hard-coded `main` branches within the workflow's operations. ❌ 
2. The release workflow will create the version bump commit and tag it. ✅ . But it will also reset the versions back to dev. ~~This will cause images to be pushed with~~ `latest` ~~tags which are built from old code.~~ I initially thought this would happen, but it doesn't. The CI workflow only publishes from `main`. But that leads to our next problem...
3. Once we get a version bump commit on a non-`main` branch built and tagged, we would want it to publish the images. But the CI workflow only publishes from `main`. We would have a tagged commit pointing to versions of the images that don't exist.

### Product
<!-- Provide a summary explanation of your changes from a product/user perspective. More details should be found in your updates to the user docs. -->
N/A

### Technical
<!-- Provide a summary explanation of your changes from a technical perspective. More details should be found in your updates to the technical docs. -->

Updates to release workflow
1. Removes the hard-coded `main` references in the workflow and points them at whatever branch the workflow was dispatched from.
2. Add an option at workflow launch time to skip the "reset to dev" commit. (This isn't strictly necessary since, as I found, the `latest` images won't be published from this branch anyway. But it does avoid running CI on an additional "reset to dev" commit we don't need.)
3. Add a `publish` step to the release workflow that only triggers if the branch is not `main`. That way, in a typical release from `main`, we let the CI workflow handle publishing the images. But in the special case of a release from a non-`main` branch, instead of trying to jam logic into the CI workflow to know when to publish from other branches or have CI publish from tags (which would mean we publish twice on tagged commits to `main`) I just had the release workflow do it.

An incidental / side change: I was getting deprecation warnings in the workflow logs about an `app-id` param being renamed to `client-id`, so I fixed those too.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [X] Documentation update
- [ ] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
<!-- Do your changes add or modify user roles? Do they impact the data users are able to see, or the actions they are able to take? Could a user modify a REST API path and see data they aren't supposed to see? Were you mindful of least privilege? -->
N/A

##### Appsec
<!-- Did you review your changes with application security in mind? See the [OWASP list](https://github.com/0xRadi/OWASP-Web-Checklist). -->
N/A

### Performance
<!-- At what scale do we expect this to operate? How have you verified that it can do so? -->
N/A

### Data
<!-- Did you consider any edge cases around input data (e.g., DICOM type 2 elements are required to be present but may be empty)? Are you gracefully handling errors from "bad data," e.g., non-conforming DICOM? -->
N/A

### Backward compatibility
<!-- Any changes to the data model, APIs, dependencies? -->
N/A

## Testing
<!-- Detail the testing you have performed to ensure that these changes function as intended. Include information about the test automation you've added, as well as the manual testing you've performed. Be sure to reference areas of impact, above. -->
I ran this release workflow from a non-`main` branch on my fork. I had previously stubbed out the CI workflow to immediately pass. I had to update that CI stub so it would create some image artifacts that could be grabbed and published by the release workflow. But once I did that, it was able to do everything correctly: create the version bump commit, tag it and create the release, publish the images from the CI workflow artifacts, and skip the reset-to-dev commit.

## Note for reviewers
<!-- Any additional information or direction for reviewers. -->
Once this is merged, I plan to cherry pick it back to branch `v3.0.1-rc` (currently pointing to commit de08d0a, i.e. after merging #335) and run a `v3.0.1` release from that branch.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [X] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
