### PR TITLE
fix(launchpad): strip launchpad subdomain when building app URLs

### DIFF
--- a/launchpad/src/app/HomeClient.tsx
+++ b/launchpad/src/app/HomeClient.tsx
@@ -236,9 +236,10 @@ const ContentGrid = ({ enableChat, enablePlaybooks }: ContentGridProps) => {
     const protocol = window.location.protocol;
     const host = window.location.host;
 
+    const baseDomain = host.replace(/^launchpad\./, '');
     const getUrl = (subdomain: string, path: string = '') => {
       const normalizedPath = path ? (path.startsWith('/') ? path : `/${path}`) : '';
-      return `${protocol}//${subdomain}.${host}${normalizedPath}`;
+      return `${protocol}//${subdomain}.${baseDomain}${normalizedPath}`;
     };
 
     setSubdomainUrls({


### PR DESCRIPTION
## Summary
- `getUrl()` in `HomeClient.tsx` was prepending the target subdomain to the full `window.location.host`, so from `launchpad.dev.embarklabs.ai` it produced `temporal.launchpad.dev.embarklabs.ai` instead of `temporal.dev.embarklabs.ai`.
- Strip the leading `launchpad.` from the host before prepending the target subdomain.

Before (broken):
- `host = launchpad.dev.embarklabs.ai`
- `getUrl('temporal')` → `https://temporal.launchpad.dev.embarklabs.ai` ❌

After (fixed):
- `baseDomain = dev.embarklabs.ai`
- `getUrl('temporal')` → `https://temporal.dev.embarklabs.ai` ✓

## Test plan
- [ ] Load Launchpad on `launchpad.dev.embarklabs.ai` and verify Temporal/Superset/JupyterHub/MinIO/Grafana/Keycloak links resolve to `<app>.dev.embarklabs.ai` (not `<app>.launchpad.dev.embarklabs.ai`)
- [ ] Local dev (`launchpad.localhost` / `localhost`): confirm unchanged behavior when host has no `launchpad.` prefix