### PR TITLE
fix(launchpad): make sign-out actually sign the user out

### DIFF
--- a/launchpad/src/app/HomeClient.tsx
+++ b/launchpad/src/app/HomeClient.tsx
@@ -447,12 +447,45 @@ export default function HomeClient({ enableChat, enablePlaybooks }: HomeClientPr
   const skipAuth =
     process.env.NODE_ENV === 'development' && process.env.NEXT_PUBLIC_SKIP_AUTH === 'true';
 
-  // Auto-login: redirect to sign in if not authenticated
+  // After an explicit sign-out we suppress auto-login so the user stays signed out
+  // — otherwise the upstream IdP (e.g. GitHub) silently re-federates the session.
+  const [justLoggedOut, setJustLoggedOut] = useState(false);
   useEffect(() => {
-    if (!skipAuth && status !== 'loading' && !session) {
+    if (typeof window === 'undefined') return;
+    if (sessionStorage.getItem('justLoggedOut') === '1') {
+      setJustLoggedOut(true);
+      sessionStorage.removeItem('justLoggedOut');
+    }
+  }, []);
+
+  // Auto-login: redirect to sign in if not authenticated (unless user just signed out)
+  useEffect(() => {
+    if (!skipAuth && !justLoggedOut && status !== 'loading' && !session) {
       signIn('keycloak');
     }
-  }, [status, session, skipAuth]);
+  }, [status, session, skipAuth, justLoggedOut]);
+
+  // Signed out: render a simple landing page with a Sign in button
+  if (!skipAuth && !session && justLoggedOut) {
+    return (
+      <div className="min-h-screen w-full bg-gradient-to-br from-slate-50 via-white to-blue-50 dark:bg-gradient-to-br dark:from-gray-900 dark:via-gray-900 dark:to-gray-800 flex items-center justify-center">
+        <div className="text-center">
+          <div className="inline-block p-1 rounded-2xl bg-gradient-to-br from-blue-500 to-indigo-600 mb-4 shadow-lg shadow-blue-200 dark:shadow-blue-900/50">
+            <img src="/scout.png" alt="Scout" className="h-16 rounded-xl bg-white p-2" />
+          </div>
+          <h1 className="text-2xl font-semibold text-gray-800 dark:text-gray-200 mb-6">
+            You are signed out
+          </h1>
+          <button
+            onClick={() => signIn('keycloak')}
+            className="px-6 py-3 rounded-lg bg-gradient-to-br from-blue-500 to-indigo-600 text-white font-medium shadow-lg hover:shadow-xl transition-all"
+          >
+            Sign in
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   // Show loading state while checking auth or redirecting to login
   if (!skipAuth && (status === 'loading' || !session)) {

--- a/launchpad/src/app/api/auth/signout/route.ts
+++ b/launchpad/src/app/api/auth/signout/route.ts
@@ -1,5 +1,15 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
 
-export async function POST() {
-  return NextResponse.json({ redirectUrl: process.env.OAUTH2_PROXY_SIGN_OUT_URL || null });
+export async function POST(req: NextRequest) {
+  const baseUrl = process.env.OAUTH2_PROXY_SIGN_OUT_URL;
+  if (!baseUrl) {
+    return NextResponse.json({ redirectUrl: null });
+  }
+  const token = await getToken({ req });
+  const url = new URL(baseUrl);
+  if (token?.idToken) {
+    url.searchParams.set('id_token_hint', token.idToken);
+  }
+  return NextResponse.json({ redirectUrl: url.toString() });
 }

--- a/launchpad/src/components/UserDropdown.tsx
+++ b/launchpad/src/components/UserDropdown.tsx
@@ -57,6 +57,8 @@ export default function UserDropdown() {
           <button
             onClick={async () => {
               setIsDropdownOpen(false);
+              // Flag so HomeClient skips auto-signIn after the IdP round-trip.
+              sessionStorage.setItem('justLoggedOut', '1');
               // First sign out from NextAuth
               await signOut({ redirect: false });
 

--- a/launchpad/src/lib/auth.ts
+++ b/launchpad/src/lib/auth.ts
@@ -15,6 +15,7 @@ export const authOptions: NextAuthOptions = {
       if (account) {
         token.accessToken = account.access_token;
         token.refreshToken = account.refresh_token;
+        token.idToken = account.id_token;
       }
       if (profile) {
         token.username = profile.preferred_username as string;

--- a/launchpad/src/types/next-auth.d.ts
+++ b/launchpad/src/types/next-auth.d.ts
@@ -26,6 +26,7 @@ declare module 'next-auth/jwt' {
   interface JWT {
     accessToken?: string;
     refreshToken?: string;
+    idToken?: string;
     username?: string;
     groups?: string[];
   }


### PR DESCRIPTION
## Summary

Clicking "Sign out" in Launchpad destroyed the NextAuth session and the Keycloak realm session, but the user landed back on `/` still appearing signed in. Root cause was three compounding issues:

1. **HomeClient auto-re-federated** — `HomeClient.tsx` unconditionally calls `signIn('keycloak')` whenever there's no NextAuth session. So the moment the user returned from Keycloak's logout endpoint, launchpad immediately bounced them back to Keycloak, which silently re-federated via the upstream IdP (GitHub session is still alive — we can't kill it).

2. **No `id_token_hint` in the logout URL** — the `/api/auth/signout` route just returned `OAUTH2_PROXY_SIGN_OUT_URL` unchanged. Without `id_token_hint`, Keycloak shows a "Do you want to sign out?" confirmation page (RP-initiated logout spec). Minor UX wart.

3. **Id token wasn't being captured** — the NextAuth `jwt` callback only stored `access_token` and `refresh_token`, so the signout route had no id token to work with.

## Changes

| File | What changed |
|---|---|
| `launchpad/src/lib/auth.ts` | jwt callback also stores `account.id_token` |
| `launchpad/src/types/next-auth.d.ts` | JWT interface gains optional `idToken?: string` |
| `launchpad/src/app/api/auth/signout/route.ts` | Reads the JWT server-side via `getToken()`; appends `id_token_hint` to the logout URL when available |
| `launchpad/src/app/HomeClient.tsx` | Reads a `justLoggedOut` flag from `sessionStorage`; when set, skips the auto-`signIn` and renders a "You are signed out" landing page with an explicit Sign in button |
| `launchpad/src/components/UserDropdown.tsx` | Sets `sessionStorage.setItem('justLoggedOut','1')` before invoking `signOut()` so the flag survives the round-trip to Keycloak |

## Why `sessionStorage` vs a URL query param?

- Survives the full `launchpad → Keycloak → launchpad` browser redirect within the same tab
- Doesn't leak into analytics or bookmarked URLs (like `?loggedOut=1` would)
- Cleared on first read so subsequent page refreshes behave normally (auto-login kicks back in)

## Test plan

- [ ] Sign in via GitHub IdP, click Sign out → land on launchpad with a "You are signed out" page, **no automatic redirect**
- [ ] Click "Sign in" button → normal OIDC flow, user can re-authenticate
- [ ] Refresh the "You are signed out" page → auto-login resumes (flag is single-use)
- [ ] `kcadm get events -r scout -q type=LOGOUT` shows a LOGOUT event for `launchpad-client` after sign-out
- [ ] With Keycloak 18+ and `id_token_hint` passed, the Keycloak confirmation page is skipped (direct redirect)
- [ ] Dev mode (`NEXT_PUBLIC_SKIP_AUTH=true`) still works unchanged

## Related

Depends on the gitops side already setting `OAUTH2_PROXY_SIGN_OUT_URL` to Keycloak's `end_session_endpoint` and the `launchpad-client` having `post.logout.redirect.uris` configured (done in embarklabs-ai/gitops).