### PR TITLE
Postgres CVE fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,13 @@ updates:
       github-actions:
         patterns:
           - '*'
+
+  # Gradle: security PRs only (open-pull-requests-limit: 0 disables routine
+  # version updates but still allows security updates), per ADR 0015.
+  # Requires resolved deps in the GitHub dependency graph — see
+  # .github/workflows/gradle-dependency-submission.yaml.
+  - package-ecosystem: 'gradle'
+    directory: '/extractor/hl7log-extractor'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 0

--- a/.github/workflows/gradle-dependency-submission.yaml
+++ b/.github/workflows/gradle-dependency-submission.yaml
@@ -1,0 +1,30 @@
+name: Gradle Dependency Submission
+
+# Submits resolved Gradle dependencies to the GitHub dependency graph so that
+# Dependabot can detect CVEs in transitive Java deps (including Spring Boot
+# BOM-managed versions, which static manifest parsing cannot resolve).
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  JAVA_DIST: 'zulu'
+  JAVA_VERSION: '21'
+
+jobs:
+  hl7log-extractor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # required to submit to the dependency graph
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: ${{ env.JAVA_DIST }}
+          java-version: ${{ env.JAVA_VERSION }}
+      - uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          build-root-directory: extractor/hl7log-extractor

--- a/extractor/hl7log-extractor/build.gradle
+++ b/extractor/hl7log-extractor/build.gradle
@@ -22,6 +22,11 @@ def temporalVersion = "1.34.0"
 def s3Version = "2.20.0"
 def checkstyleVersion = "10.21.2"
 
+// TODO: Remove once Spring Boot ships a release that manages postgresql >= 42.7.11.
+// Overrides the Spring Boot BOM's pinned 42.7.10 to address GHSA-98qh-xjc8-98pq
+// (CVE-2026-42198, HIGH: pgjdbc SCRAM PBKDF2 DoS).
+ext['postgresql.version'] = '42.7.11'
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework:spring-aspects'


### PR DESCRIPTION
## Description

### Product
N/A — internal CI/security plumbing, no user-visible changes.

### Technical
Fixes the [failing Trivy image scan for `hl7log-extractor`](https://github.com/washu-tag/scout/actions/runs/25446462363/job/74652650159) (CVE-2026-42198 / GHSA-98qh-xjc8-98pq, HIGH: pgjdbc SCRAM PBKDF2 DoS) by overriding the Spring Boot BOM's pinned `org.postgresql:postgresql` 42.7.10 with 42.7.11 via `ext['postgresql.version']`. Also closes the gap that let this CVE reach `main` undetected: adds a workflow that submits resolved Gradle deps to GitHub's dependency graph (which previously contained 0 maven/gradle packages) and enables the `gradle` ecosystem in `dependabot.yml` with `open-pull-requests-limit: 0` so security PRs flow but routine version bumps don't, matching ADR 0015.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
N/A

##### Appsec
Direct fix for a HIGH-severity CVE in a runtime dependency. The dep-submission workflow uses `permissions: contents: write` (required by `gradle/actions/dependency-submission` to upload to the dep graph) and is scoped to that single job; the third-party action is SHA-pinned per repo convention.

### Performance
N/A

### Data
N/A

### Backward compatibility
The postgres override is forward-compatible — pgjdbc 42.7.11 is a patch release with no API changes. The TODO comment flags the override for removal once Spring Boot manages 42.7.11+.

## Testing
Verified locally with `./gradlew dependencyInsight --dependency org.postgresql:postgresql --configuration runtimeClasspath` — runtime resolves to 42.7.11 (selected by constraint, overriding the BOM's 42.7.10). The Trivy image scan in CI on this branch should now pass.

## Note for reviewers
- The `gradle-dependency-submission` workflow only takes effect after merging to `main`, so the postgresql alert won't fire retroactively — but commit 1 already fixes the CVE, so future Java CVEs are what this enables.
- Scoped to `extractor/hl7log-extractor` only. `tests/ingest/` is also a Gradle project and could be added later if desired.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
