### PR TITLE
Parameterize spark.sql.shuffle.partitions; reduce to 8 for CI

### DIFF
--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -119,6 +119,11 @@ k3s_cluster:
     trino_worker_max_heap: 512M
     trino_coordinator_max_heap: 512M
 
+    # Spark default of 200 shuffle partitions is far too many for CI's
+    # small test data — each shuffle spawns 200 tasks, most processing
+    # zero rows, and scheduling overhead dominates.
+    spark_sql_shuffle_partitions: 8
+
     # Valkey (single shared password for all services)
     valkey_password: valkey123
 

--- a/ansible/roles/scout_common/templates/spark-defaults.conf.j2
+++ b/ansible/roles/scout_common/templates/spark-defaults.conf.j2
@@ -15,6 +15,7 @@ spark.sql.catalog.spark_catalog org.apache.spark.sql.delta.catalog.DeltaCatalog
 spark.hadoop.fs.s3a.path.style.access {{ 'true' if not aws_deployment else 'false' }}
 spark.hadoop.hive.metastore.uris {{ spark_hive_metastore_uri | default(hive_metastore_endpoint_readonly) }}
 spark.sql.warehouse.dir {{ delta_lake_path }}
+spark.sql.shuffle.partitions {{ spark_sql_shuffle_partitions | default(200) }}
 spark.driver.extraJavaOptions -Divy.cache.dir=/tmp -Divy.home=/tmp
 spark.executor.memory {{ spark_memory | default('1G') }}
 spark.driver.memory {{ spark_memory | default('1G') }}


### PR DESCRIPTION
This came up as an optimization to make in the tests when adding a new test for patient IDs. By overriding `spark.sql.shuffle.partitions` for the very small test data used in CI, we get significantly faster performance. The default stays at 200 (no production behavior change).

## Description

### Product
N/A

### Technical
Trivial ansible template tweak

## Type of change
- [X] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
Should be a no-op change in production, but enable faster CI.

### Data
N/A

### Backward compatibility
N/A

## Testing
Previous CI tests on branch with bigger scope gave promising results. Test run when submitting this PR will be the real test.

## Note for reviewers
<!-- Any additional information or direction for reviewers. -->

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
