### PR TITLE
Add wait-for-temporal-dns init container to hl7-transformer

### DIFF
--- a/ansible/roles/extractor/templates/hl7-transformer.values.yaml.j2
+++ b/ansible/roles/extractor/templates/hl7-transformer.values.yaml.j2
@@ -1,6 +1,32 @@
 image:
   repository: '{{ hl7_transformer_image_repository }}'
   tag: '{{ hl7_transformer_image_tag }}'
+initContainers:
+  # Avoid a startup race where the main process tries to connect to
+  # Temporal before cluster networking/DNS is fully ready for this pod.
+  # Reuses the transformer image (already pulled, glibc resolver) so we
+  # exercise the same DNS code path the main app uses.
+  #
+  # imagePullPolicy must be set explicitly here. The chart's main
+  # container values default to IfNotPresent, but init containers
+  # specified via values get the K8s default — which is Always for
+  # :latest tags and breaks in environments (e.g. K3s in CI) that have
+  # the image loaded locally but no registry to pull from.
+  - name: wait-for-temporal-dns
+    image: '{{ hl7_transformer_image_repository }}:{{ hl7_transformer_image_tag }}'
+    imagePullPolicy: IfNotPresent
+    command:
+      - python3
+      - -c
+      - |
+        import socket, time
+        while True:
+            try:
+                socket.gethostbyname('temporal-internal-frontend')
+                break
+            except OSError:
+                print('waiting for dns...', flush=True)
+                time.sleep(2)
 envFrom:
   - secretRef:
       name: s3-secret

--- a/helm/extractor/hl7-transformer/templates/deployment.yaml
+++ b/helm/extractor/hl7-transformer/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       serviceAccountName: {{ include "hl7-transformer.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.image.args }}


### PR DESCRIPTION
The Temporal Rust client is fail-fast on its initial DNS resolution, so a brief startup-time race (cluster networking not yet ready for the pod) puts the pod in CrashLoopBackOff with no recovery. Add a small init container that polls socket.gethostbyname until the Temporal service resolves before the main container starts.

Implementation notes:
- Uses the transformer image rather than busybox so the resolver call goes through the same glibc code path the main app uses (busybox's nslookup has known issues against CoreDNS).
- imagePullPolicy=IfNotPresent matches the chart's main container override; without it, K8s defaults to Always for :latest tags and fails in CI's K3s environment, which loads the image locally and has no registry to pull from.
- Extends the chart template to surface initContainers from values.

## Description

### Product
N/A

### Technical
- Uses the transformer image rather than busybox so the resolver call goes through the same code path the main app uses.
- imagePullPolicy=IfNotPresent matches the chart's main container override; without it, K8s defaults to Always for :latest tags and fails in CI's K3s environment.
- Extends the chart template to surface initContainers from values.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
Adding this allowed the hl7-transformer to come up correctly once I added trino-rw

## Note for reviewers
This was required to get the hl7-transformer pod to work correctly once I added trino-rw. The hypothesis is that there's a race condition that's always been present that only actually gets hit once trino-rw adds the extra networking constraints with the new NetworkPolicy .

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
