### PR TITLE
Add trino-rw RW Trino instance and harden Trino secret handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -415,6 +415,10 @@ jobs:
       - name: 'Auth curl tests'
         shell: bash
         run: bash tests/auth/auth-curl-tests.sh scout.test
+      # NetworkPolicy tests — verify trino-rw ingress restrictions
+      - name: 'NetworkPolicy tests'
+        shell: bash
+        run: KUBECTL='sudo -E kubectl' bash tests/network/network-policy-tests.sh
       # Diagnostic logging on failure
       - name: 'Debug - pod status'
         if: failure()

--- a/ansible/roles/extractor/templates/hl7-transformer.values.yaml.j2
+++ b/ansible/roles/extractor/templates/hl7-transformer.values.yaml.j2
@@ -41,6 +41,16 @@ env:
     value: default
   - name: REPORT_DELTA_TABLE_NAME
     value: '{{ report_delta_table_name }}'
+  - name: TRINO_HOST
+    value: '{{ trino_rw_endpoint_host }}'
+  - name: TRINO_PORT
+    value: '{{ trino_rw_endpoint_port | string }}'
+  - name: TRINO_USER
+    value: '{{ trino_user }}'
+  - name: TRINO_CATALOG
+    value: delta
+  - name: TRINO_SCHEME
+    value: http
 resources:
   requests:
     cpu: '{{ hl7_transformer_cpu_request }}'

--- a/ansible/roles/scout_common/defaults/main.yaml
+++ b/ansible/roles/scout_common/defaults/main.yaml
@@ -102,6 +102,10 @@ extractor_namespace: '{{ scout_extractor_namespace }}'
 
 # Analytics & user services
 trino_namespace: '{{ scout_analytics_namespace }}'
+trino_rw_namespace: '{{ scout_extractor_namespace }}'
+trino_rw_release_name: trino-rw
+trino_rw_endpoint_host: '{{ trino_rw_release_name }}.{{ trino_rw_namespace }}'
+trino_rw_endpoint_port: 8080
 superset_namespace: '{{ scout_analytics_namespace }}'
 jupyter_namespace: '{{ scout_analytics_namespace }}'
 chatbot_namespace: '{{ scout_analytics_namespace }}'
@@ -182,7 +186,10 @@ ingest_postgres_table_name: ingest
 hive_metastore_instance: hive-metastore
 hive_metastore_instance_readonly: hive-metastore-readonly
 
-# Trino - this is a dummy username since all Trino access is RO
+# Trino RO username — the user-facing Trino has no authN; writes are blocked
+# at the connector level (delta.security=READ_ONLY) and by the read-only
+# metastore + S3 credentials. The RW Trino instance (trino-rw) accepts
+# writes and is gated to the hl7-transformer pod via NetworkPolicy.
 trino_user: trino
 
 # Shared environment for Kubernetes operations on cluster nodes

--- a/ansible/roles/trino/defaults/main.yaml
+++ b/ansible/roles/trino/defaults/main.yaml
@@ -43,6 +43,31 @@ trino_worker_resources:
     cpu: '{{ trino_worker_cpu_limit }}'
     memory: '{{ trino_worker_max_heap | jvm_memory_to_k8s(4) }}'
 
+# RW Trino (admin) — small instance used by hl7-transformer for view DDL
+# Note: trino_rw_release_name lives in scout_common because the extractor
+# role's values template references it (via trino_rw_endpoint_host) and
+# does not load the trino role's defaults.
+trino_rw_enabled: true
+trino_rw_worker_count: 1
+trino_rw_worker_max_heap: 1G
+trino_rw_coordinator_max_heap: 512M
+
+trino_rw_coordinator_resources:
+  requests:
+    cpu: 100m
+    memory: '{{ trino_rw_coordinator_max_heap | jvm_memory_to_k8s }}'
+  limits:
+    cpu: 500m
+    memory: '{{ trino_rw_coordinator_max_heap | jvm_memory_to_k8s(4) }}'
+
+trino_rw_worker_resources:
+  requests:
+    cpu: 100m
+    memory: '{{ trino_rw_worker_max_heap | jvm_memory_to_k8s }}'
+  limits:
+    cpu: 500m
+    memory: '{{ trino_rw_worker_max_heap | jvm_memory_to_k8s(4) }}'
+
 # Trino MCP server configuration
 mcp_trino_repo_url: https://github.com/tuannvm/mcp-trino.git
 mcp_trino_repo_version: 'v{{ mcp_trino_version }}'

--- a/ansible/roles/trino/tasks/deploy.yaml
+++ b/ansible/roles/trino/tasks/deploy.yaml
@@ -5,6 +5,30 @@
   ansible.builtin.set_fact:
     trino_helm_chart_values: "{{ lookup('template', 'values.yaml.j2') | from_yaml }}"
 
+- name: Ensure Trino namespace exists
+  ansible.builtin.include_role:
+    name: scout_common
+    tasks_from: namespace
+  vars:
+    ns: '{{ trino_namespace }}'
+  when: not aws_deployment
+
+- name: Create S3 credentials Secret for Trino
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: trino-s3
+        namespace: '{{ trino_namespace }}'
+      stringData:
+        S3_ACCESS_KEY: '{{ s3_lake_reader }}'
+        S3_SECRET_KEY: '{{ s3_lake_reader_secret }}'
+  environment: '{{ cluster_k8s_environment }}'
+  no_log: true
+  when: not aws_deployment
+
 - name: Create lake-reader ServiceAccount for Trino
   when: aws_deployment
   ansible.builtin.include_role:

--- a/ansible/roles/trino/tasks/deploy_rw.yaml
+++ b/ansible/roles/trino/tasks/deploy_rw.yaml
@@ -1,0 +1,45 @@
+---
+# Deploy a small RW Trino used only by the hl7-transformer for view DDL.
+# Ingress restriction (and the intra-release coordinator <-> worker rule)
+# is configured via the chart's built-in networkPolicy support — see
+# values-rw.yaml.j2.
+
+- name: Ensure RW Trino namespace exists
+  ansible.builtin.include_role:
+    name: scout_common
+    tasks_from: namespace
+  vars:
+    ns: '{{ trino_rw_namespace }}'
+
+- name: Create S3 credentials Secret for RW Trino
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: trino-rw-s3
+        namespace: '{{ trino_rw_namespace }}'
+      stringData:
+        S3_ACCESS_KEY: '{{ s3_lake_writer }}'
+        S3_SECRET_KEY: '{{ s3_lake_writer_secret }}'
+  environment: '{{ cluster_k8s_environment }}'
+  no_log: true
+  when: not aws_deployment
+
+- name: Parse RW Trino Helm values
+  ansible.builtin.set_fact:
+    trino_rw_helm_chart_values: "{{ lookup('template', 'values-rw.yaml.j2') | from_yaml }}"
+
+- name: Deploy RW Trino
+  ansible.builtin.include_role:
+    name: scout_common
+    tasks_from: deploy_helm_chart
+  vars:
+    helm_chart_name: '{{ trino_rw_release_name }}'
+    helm_chart_ref: '{{ trino_helm_repo_name }}/{{ trino_helm_chart_name }}'
+    helm_chart_version: '{{ trino_helm_chart_version }}'
+    helm_chart_namespace: '{{ trino_rw_namespace }}'
+    helm_repo_name: '{{ trino_helm_repo_name }}'
+    helm_repo_url: '{{ trino_helm_repo_url }}'
+    helm_chart_values: '{{ trino_rw_helm_chart_values }}'

--- a/ansible/roles/trino/tasks/main.yaml
+++ b/ansible/roles/trino/tasks/main.yaml
@@ -5,6 +5,10 @@
 - name: Include Trino deployment
   ansible.builtin.include_tasks: deploy.yaml
 
+- name: Include RW Trino deployment
+  ansible.builtin.include_tasks: deploy_rw.yaml
+  when: trino_rw_enabled | default(true) | bool
+
 - name: Include Trino MCP deployment
   ansible.builtin.include_tasks: mcp.yaml
   when: enable_chat | default(false) | bool

--- a/ansible/roles/trino/templates/values-rw.yaml.j2
+++ b/ansible/roles/trino/templates/values-rw.yaml.j2
@@ -1,0 +1,123 @@
+# Trino RW (admin) instance — small Trino used by the hl7-transformer
+# to issue view DDL. Ingress is restricted via the chart's built-in
+# NetworkPolicy support (see networkPolicy section below).
+#
+# Differences from the user-facing Trino:
+#   - delta.security is NOT read-only (writes allowed)
+#   - Uses writable Hive metastore endpoint
+#   - Single small worker (DDL workload only)
+
+# Make resource names match the release name exactly. Without this, the
+# chart's fullname helper produces "<release>-trino" because our release
+# name doesn't equal the chart name (it only dedupes when they're equal).
+fullnameOverride: '{{ trino_rw_release_name }}'
+
+{% if not aws_deployment %}
+# Inject S3 credentials from a Secret. The Secret is created by
+# deploy_rw.yaml before this chart is installed. The catalog config below
+# references these via Trino's ${ENV:VAR} substitution syntax, so the
+# rendered catalog ConfigMap contains only references, not credentials.
+envFrom:
+  - secretRef:
+      name: trino-rw-s3
+{% endif %}
+
+server:
+  workers: {{ trino_rw_worker_count }}
+  config:
+    query:
+      maxMemory: "{{ trino_rw_worker_max_heap | multiply_memory(trino_rw_worker_count * trino_per_node_query_memory_fraction) }}B"
+
+# JMX exporter for Prometheus (parity with the user-facing Trino)
+jmx:
+  enabled: true
+  registryPort: 9080
+  serverPort: 9081
+  exporter:
+    enabled: true
+    image: bitnamilegacy/jmx-exporter:{{ trino_jmx_exporter_version }}
+    pullPolicy: IfNotPresent
+    port: 5556
+    configProperties: |
+      hostPort: localhost:9080
+      startDelaySeconds: 30
+      ssl: false
+      lowercaseOutputName: false
+
+coordinator:
+  jvm:
+    maxHeapSize: {{ trino_rw_coordinator_max_heap }}
+  config:
+    memory:
+      heapHeadroomPerNode: ""
+    query:
+      maxMemoryPerNode: "{{ trino_rw_coordinator_max_heap | multiply_memory(trino_per_node_query_memory_fraction) }}B"
+  resources: {{ trino_rw_coordinator_resources | to_json }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '5556'
+    prometheus.io/path: '/metrics'
+
+worker:
+  jvm:
+    maxHeapSize: {{ trino_rw_worker_max_heap }}
+  config:
+    memory:
+      heapHeadroomPerNode: ""
+    query:
+      maxMemoryPerNode: "{{ trino_rw_worker_max_heap | multiply_memory(trino_per_node_query_memory_fraction) }}B"
+  resources: {{ trino_rw_worker_resources | to_json }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '5556'
+    prometheus.io/path: '/metrics'
+
+catalogs:
+  delta: |
+    connector.name=delta_lake
+    hive.metastore.uri={{ hive_metastore_endpoint }}
+    fs.native-s3.enabled=true
+    s3.region={{ s3_region }}
+{% if not aws_deployment %}
+    s3.aws-access-key=${ENV:S3_ACCESS_KEY}
+    s3.aws-secret-key=${ENV:S3_SECRET_KEY}
+    s3.endpoint={{ s3_endpoint }}
+    s3.path-style-access=true
+{% else %}
+    s3.path-style-access=false
+{% endif %}
+
+# Restrict ingress to trino-rw pods. The chart automatically allows
+# Trino pods to communicate with each other when networkPolicy is enabled,
+# so we only need to declare external allowances here. Two of them:
+#   - hl7-transformer pods in the extractor namespace (port 8080)
+#   - prometheus server pod in the monitoring namespace (port 5556)
+#
+# The Prometheus rule assumes the prometheus-community/prometheus chart's
+# labeling (server pod has app.kubernetes.io/component=server). If
+# swapped to kube-prometheus-stack, that component value differs and
+# scrapes will silently break — re-check the labels at that time.
+networkPolicy:
+  enabled: true
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: '{{ extractor_namespace }}'
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: hl7-transformer
+      ports:
+        - port: 8080
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: '{{ prometheus_namespace }}'
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+              app.kubernetes.io/component: server
+      ports:
+        - port: 5556
+          protocol: TCP

--- a/ansible/roles/trino/templates/values.yaml.j2
+++ b/ansible/roles/trino/templates/values.yaml.j2
@@ -10,6 +10,14 @@ server:
 serviceAccount:
   create: false
   name: '{{ lake_reader_service_account_name }}'
+{% else %}
+# Inject S3 credentials from a Secret. The Secret is created by deploy.yaml
+# before this chart is installed. The catalog config below references these
+# via Trino's ${ENV:VAR} substitution syntax, so the rendered catalog
+# ConfigMap contains only references, not credentials.
+envFrom:
+  - secretRef:
+      name: trino-s3
 {% endif %}
 
 # JMX exporter configuration for Prometheus metrics
@@ -71,8 +79,8 @@ catalogs:
     fs.native-s3.enabled=true
     s3.region={{ s3_region }}
 {% if not aws_deployment %}
-    s3.aws-access-key={{ s3_lake_reader }}
-    s3.aws-secret-key={{ s3_lake_reader_secret }}
+    s3.aws-access-key=${ENV:S3_ACCESS_KEY}
+    s3.aws-secret-key=${ENV:S3_SECRET_KEY}
     s3.endpoint={{ s3_endpoint }}
     s3.path-style-access=true
 {% else %}

--- a/docs/internal/adr/0019-trino-rw-instance-for-views.md
+++ b/docs/internal/adr/0019-trino-rw-instance-for-views.md
@@ -1,0 +1,136 @@
+# ADR 0019: Read-Write Trino Instance for Transformer-Issued View DDL
+
+**Date**: 2026-05-07
+**Status**: Accepted
+**Decision Owner**: TAG Team
+
+## Context
+
+The HL7 transformer needs to make joined views of derivative tables (curated, latest, dx) with the report-patient mapping table available to **every Trino consumer in Scout**. The mapping table contains `scout_patient_id`, `resolved_epic_mrn`, and `resolved_mpi` columns that materialize the result of transitive patient-ID resolution; users want to query these alongside derivative tables without having to write the join themselves every time.
+
+Trino is the shared query layer for several Scout services — not just one user-facing tool. Consumers in production today:
+
+- **Superset**: SQL Lab text editor, virtual datasets, charts and dashboards
+- **Voilà / Playbooks**: notebooks served as web apps, querying Trino directly
+- **Open WebUI / MCP Trino tool**: natural-language SQL via chat (when the optional chat feature is enabled)
+- **JupyterHub**: notebooks that go through the Trino Python client (`trino.dbapi.connect`) rather than PySpark
+
+Any solution to the joined-view problem has to serve all of them — not just one. A view that exists only for a subset of these consumers ends up forcing the others to either re-implement the join in client code or remain unable to query the resolved patient IDs at all.
+
+The natural way to expose a "join + filter" via SQL is a view. The transformer's natural place to create one is `spark.sql("CREATE OR REPLACE VIEW ...")` from inside the ingest activity. That works for PySpark consumers in JupyterHub, but **Trino cannot read Spark-created views**: Spark writes a `VIRTUAL_VIEW` row to the Hive Metastore using Spark's own format, while Trino expects either a Trino-native view (`/* Presto View */` payload + base64-encoded JSON) or a Hive-format view that translates cleanly. Querying a Spark view through Trino's Delta Lake connector produces `UNSUPPORTED_TABLE_TYPE`.
+
+### The user-facing Trino is read-only by intentional design
+
+Per `ansible/roles/trino/templates/values.yaml.j2` and the comment at `ansible/roles/scout_common/defaults/main.yaml:185`, the user-facing Trino in `scout-analytics` enforces read-only at three layers:
+
+- `delta.security=READ_ONLY` on the Delta connector
+- `hive_metastore_endpoint_readonly` (separate metastore Deployment with read-only PostgreSQL role)
+- `s3_lake_reader` credentials (read-only MinIO bucket policy)
+
+Even if Trino had no authentication (which it doesn't — it accepts any caller as user `trino`), the connector and underlying credentials prevent writes. This means notebook users or anyone else inside the cluster who can reach `trino.scout-analytics:8080` cannot mutate Delta tables, metastore objects, or S3 contents.
+
+`CREATE OR REPLACE VIEW` is a metastore write, so it's blocked at all three layers.
+
+### The transformer cannot reuse the existing Trino
+
+To issue view DDL, the transformer would need either:
+1. A Trino instance willing to accept its writes, or
+2. A way to put Trino-readable views into the metastore without going through Trino.
+
+Option 2 (writing Trino-format view payloads directly via the Hive Thrift API or PostgreSQL) is undocumented and brittle — the on-disk format isn't a stable interface. So the realistic options are about how to provide a writable Trino without compromising the read-only posture for everyone else.
+
+## Decision
+
+**Stand up a separate small Trino Helm release (`trino-rw`) in the `scout-extractor` namespace. Gate it to the hl7-transformer pod via the chart's built-in NetworkPolicy support. Keep the user-facing Trino read-only.**
+
+The transformer's view-creation activity (`add_epic_views` in `dataextraction.py`) will issue DDL against `trino-rw.scout-extractor:8080`. The user-facing Trino's metastore reads pick up the resulting `VIRTUAL_VIEW` rows automatically (both Trinos share the same Hive metastore database; only the metastore *Deployment* differs in PostgreSQL role).
+
+## Alternatives Considered
+
+### Materialize derivative-with-mapping joins as Delta tables instead of views
+
+For each derivative table, write the joined output as `*_curated_epic`, `*_latest_epic`, etc.
+
+**Rejected**: Roughly doubles the storage of derivative tables; the join must be re-materialized on every ingest; downstream users querying the derivative tables would have parallel "with-epic" and "without-epic" copies to choose between. Storage and consistency cost outweighs the simplicity benefit.
+
+### Use Trino's Hive connector with view translation
+
+Add a `hive` catalog alongside `delta` on the existing user-facing Trino, configured with `hive.hive-views.enabled=true` and `hive.delta-lake-catalog-name=delta` for table redirection. Spark-created views would be readable through the Hive catalog.
+
+**Rejected**: Spark and Trino disagree on type representations. Specifically, Spark writes `timestamp(3) with time zone` columns into the view's stored schema, but Hive's type system has no equivalent. Both Trino's modern translator (rejects with "Unsupported Hive type") and legacy translator (silently downgrades to `timestamp(3)`, then fails at read time with `VIEW_IS_STALE` because the projected column type doesn't match) fail on the report tables, which contain multiple timestamp-with-timezone columns. Salvaging the path would require enumerating timestamp columns and emitting explicit `CAST(... AS TIMESTAMP)` expressions in every view body — a fragile, schema-coupled workaround.
+
+### Loosen `delta.security` on the existing Trino, add Trino access control
+
+Drop `delta.security=READ_ONLY`, enable Trino's file-based or system access control to deny writes to non-transformer users.
+
+**Rejected**: Requires real authentication (Trino currently has none — every caller authenticates as user `trino`), which means integrating Keycloak with Trino, distributing per-service tokens, etc. That is a multi-week change with broad blast radius. Compared to standing up a small second Trino with NetworkPolicy gating, the security gain is theoretical (file ACLs vs. K8s NetworkPolicy enforce roughly equivalent boundaries) and the implementation cost is much higher.
+
+### Use Superset virtual datasets, no Trino views
+
+Define the join as a Superset virtual dataset. Superset users see a "table" in Superset's metadata catalog that's actually a saved SQL query Superset injects when the dataset is referenced.
+
+**Rejected**: Virtual datasets are a Superset-side abstraction only — they exist as rows in Superset's PostgreSQL metadata DB, not in the Hive metastore that Trino reads. So they're invisible to every other Trino consumer. Voilà playbooks issuing `SELECT * FROM reports_curated_epic_view` against Trino get a "table not found" error; same for the MCP Trino tool, JupyterHub notebooks using the Trino Python client, and any future direct consumer. Even within Superset, virtual datasets aren't queryable by name in SQL Lab's text editor — they only surface in chart/dashboard authoring. So this approach covers a fraction of one consumer's use cases and leaves the rest with no joined-view access at all.
+
+### Skip Spark views, only create Trino views
+
+Drop the `spark.sql(CREATE VIEW)` call entirely; only create Trino views via the new RW instance. Provide a PySpark helper for notebook users.
+
+**Rejected**: Forces all PySpark consumers to switch from `spark.read.table(...)` to a custom helper. Existing notebooks break. Worse user experience for the JupyterHub side. The current implementation creates **both** views with distinct names (`*_spark_epic_view` for Spark, `*_epic_view` for Trino) so each engine sees a view it can natively consume.
+
+## Consequences
+
+### Positive
+
+- **Existing read-only posture preserved.** No change to the user-facing Trino's authentication or security model. Notebook and Superset users see the same Trino they always have.
+- **Security boundary is K8s-enforced and auditable.** The chart's NetworkPolicy gates ingress to trino-rw to only the hl7-transformer pod (port 8080) and Prometheus (port 5556). Defense in depth: Jupyter user pods already have an egress policy that doesn't allow `scout-extractor:8080`.
+- **Reuses existing infrastructure.** Same chart, same metastore database, same MinIO storage. The trino-rw release uses `s3_lake_writer` credentials — already provisioned, already trusted by the transformer's Spark side. No new credentials are introduced.
+- **Both views available simultaneously.** PySpark users continue using `spark.read.table("default.reports_curated_spark_epic_view")`; SQL Lab users query `default.reports_curated_epic_view`. Each engine sees the view format it understands.
+
+### Negative
+
+- **Two Trino releases to maintain.** Chart upgrades, configuration changes, and operational drift now apply to both. Mitigated by sharing version variables (`trino_helm_chart_version`, `trino_jmx_exporter_version`) so a single Renovate annotation covers both releases per ADR 0015.
+- **Resource overhead for an infrequent workload.** trino-rw exists primarily to issue a small batch of DDL per ingest. We size it minimally (1 worker, 512MiB coordinator heap), but it's still a coordinator + worker pod sitting mostly idle.
+- **Transformer pod carries TRINO_HOST/PORT env vars.** Even when the activity isn't running, the pod has these. Inert and harmless, but visible in `kubectl describe`.
+- **Test environments must mirror the topology** to exercise the RW path. CI's `deploy_and_test` job doesn't deploy `analytics`, so a future feature flag will let the transformer skip the Trino-side view creation in those CI runs without compromising production behavior.
+
+### Comparison to the auth model from ADR 0005
+
+ADR 0005 established that on-prem deployments use static MinIO access keys (because Hadoop S3A can't use a custom STS endpoint). trino-rw inherits that pattern:
+- **On-prem**: Reuses `s3_lake_writer` static keys, injected via a Kubernetes Secret (`trino-rw-s3`) and Trino's `${ENV:VAR}` substitution rather than inlined into the catalog ConfigMap.
+- **AWS**: Currently not implemented for trino-rw. The user-facing Trino has an IRSA `lake-reader` ServiceAccount; trino-rw would need a parallel `lake-writer` SA. Flagged as future work; the chart's `aws_deployment` branch in `values-rw.yaml.j2` falls through to no S3 credentials, which would fail at runtime if anyone enabled it on AWS without first wiring IRSA.
+
+## Implementation Notes
+
+### Chart configuration
+
+Per `ansible/roles/trino/templates/values-rw.yaml.j2`:
+- `fullnameOverride: trino-rw` so Service names match the release name (the chart's default fullname helper produces `trino-rw-trino` because the release name doesn't equal the chart name).
+- No `delta.security` setting — the catalog accepts writes.
+- `hive.metastore.uri` points at `hive_metastore_endpoint` (writable instance).
+- `envFrom: [secretRef: name: trino-rw-s3]`; catalog uses `s3.aws-access-key=${ENV:S3_ACCESS_KEY}` etc.
+- `networkPolicy.enabled: true` with explicit ingress allowances for the transformer pod and Prometheus server. The chart automatically allows coordinator↔worker traffic.
+
+### Secret handling
+
+Both the new RW Trino and the existing user-facing Trino now inject S3 credentials via `envFrom` from a Kubernetes Secret rather than inlining them into the catalog config string (which Helm renders into a plaintext ConfigMap). The Secret is created by the deploy task before the helm install. This change applies to both Trino releases for consistency — see `ansible/roles/trino/tasks/deploy.yaml` and `deploy_rw.yaml`.
+
+### CI tests
+
+`tests/network/network-policy-tests.sh` runs in the smoke-test job and verifies the NetworkPolicy denies ingress from pods in `scout-analytics` and from mislabeled pods in `scout-extractor`, while allowing pods labeled `app.kubernetes.io/name: hl7-transformer` in `scout-extractor`. The script uses retry-loops to handle kube-router's ipset reconciliation lag.
+
+### Renovate coverage
+
+Both Trino releases share `trino_helm_chart_version` and `trino_jmx_exporter_version` (in `ansible/group_vars/all/versions.yaml`), each annotated with a `# renovate:` comment per ADR 0015. CVE-driven version bumps apply to both releases automatically. No new annotations were needed for trino-rw.
+
+## Future Considerations
+
+- **AWS IRSA for trino-rw**: When deploying to AWS, a `lake-writer` ServiceAccount and IAM role would replace the static-key path. Mirrors what the user-facing Trino already does with `lake-reader`. Not blocking for current on-prem deployments.
+- **Mapping derivation cost**: The view body (`SELECT r.*, m.scout_patient_id, p.resolved_epic_mrn, p.resolved_mpi FROM ...`) joins against the mapping table, which is itself the product of a non-trivial recursive ID resolution. The cost of the *view definition* is negligible; the cost of the *underlying mapping table* is part of the ingest pipeline and is addressed separately.
+- **Per-environment toggle**: A `trino_view_enabled` flag (env var on the transformer) lets test environments without trino-rw skip the Trino-side DDL while still creating the Spark view. CI uses this to keep `deploy_and_test` from depending on the analytics playbook.
+
+## References
+
+- ADR 0005: MinIO STS Authentication Decision — establishes the static-key pattern for on-prem
+- ADR 0011: Deployment Portability via Layered Architecture — service-mode pattern that informs cross-environment configuration
+- ADR 0012: Security Scan Response and Hardening — Traefik security headers, related security posture
+- ADR 0015: Dependency CVE Monitoring via Renovate and Dependabot — explains why sharing `trino_helm_chart_version` is sufficient

--- a/tests/network/network-policy-tests.sh
+++ b/tests/network/network-policy-tests.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# network-policy-tests.sh — Verify trino-rw NetworkPolicy is enforced
+#
+# Spins up short-lived pods in different namespaces / with different labels
+# and confirms each can or can't reach trino-rw on port 8080. Runs all test
+# pods in parallel and aggregates results, so total runtime is dominated by
+# the slowest single test (~20s) rather than the sum of all retries.
+#
+# Each test pod uses a retry loop because kube-router takes a few seconds
+# to incorporate new pod IPs into its allow-ipset, so we want the test to
+# express "succeeds when it eventually succeeds" rather than rely on a
+# fixed sleep.
+#
+# Expected matrix:
+#   - pod in scout-analytics (any labels)                     → denied (000)
+#   - pod in scout-extractor without transformer labels       → denied (000)
+#   - pod in scout-extractor with hl7-transformer label       → allowed (200)
+#
+# Exit 0 if all tests pass, non-zero on any failure.
+
+set -euo pipefail
+
+# ── Colors ────────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# ── Config ────────────────────────────────────────────────────────────────────
+TRINO_RW_HOST=trino-rw.scout-extractor
+TRINO_RW_PORT=8080
+TRINO_RW_PATH=/v1/info
+KUBECTL=${KUBECTL:-kubectl}
+
+# Retry curl up to 20 times so kube-router has time to update its ipset
+# for new pods. Allowed pods exit fast; denied pods exhaust retries.
+# curl writes "000" via -w on connection failure and exits non-zero, so
+# we suppress the exit with || true and let curl produce the code.
+RETRY_LOOP='for i in $(seq 1 20); do
+  code=$(curl -sS -o /dev/null --max-time 2 -w "%{http_code}" \
+    "http://__HOST__:__PORT____PATH__" 2>/dev/null) || true
+  if [ "$code" = "200" ]; then
+    echo "RESULT=200"
+    exit 0
+  fi
+  sleep 1
+done
+echo "RESULT=$code"
+exit 1'
+RETRY_LOOP=${RETRY_LOOP//__HOST__/$TRINO_RW_HOST}
+RETRY_LOOP=${RETRY_LOOP//__PORT__/$TRINO_RW_PORT}
+RETRY_LOOP=${RETRY_LOOP//__PATH__/$TRINO_RW_PATH}
+
+# ── Test queue ────────────────────────────────────────────────────────────────
+# Parallel arrays: NAMES[i], NAMESPACES[i], EXPECTED[i], LABELS[i]
+NAMES=()
+NAMESPACES=()
+EXPECTED=()
+LABELS=()
+
+queue_test() {
+  NAMES+=("$1")
+  NAMESPACES+=("$2")
+  EXPECTED+=("$3")
+  LABELS+=("${4:-}")
+}
+
+queue_test nb-test               scout-analytics 000
+queue_test chat-test              scout-analytics 000 'app.kubernetes.io/name=open-webui'
+queue_test extractor-rando        scout-extractor 000
+queue_test transformer-impostor   scout-extractor 200 'app.kubernetes.io/name=hl7-transformer'
+
+# ── Workspace + cleanup ───────────────────────────────────────────────────────
+RESULTS_DIR=$(mktemp -d)
+cleanup() {
+  # Kill any still-running kubectl processes
+  jobs -p | xargs -r kill 2>/dev/null || true
+  # Best-effort delete any pods that --rm didn't catch (e.g. on signal)
+  for i in "${!NAMES[@]}"; do
+    $KUBECTL delete pod -n "${NAMESPACES[$i]}" "${NAMES[$i]}" \
+      --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  done
+  rm -rf "$RESULTS_DIR"
+}
+trap cleanup EXIT
+
+# ── Launch all in parallel ────────────────────────────────────────────────────
+echo -e "${BOLD}Running trino-rw NetworkPolicy tests in parallel...${RESET}"
+echo
+
+for i in "${!NAMES[@]}"; do
+  name=${NAMES[$i]}
+  namespace=${NAMESPACES[$i]}
+  labels=${LABELS[$i]}
+
+  echo "  launching $name (namespace=$namespace labels=${labels:-<none>})"
+
+  label_arg=()
+  [ -n "$labels" ] && label_arg=(--labels="$labels")
+
+  (
+    $KUBECTL run "$name" -n "$namespace" --restart=Never --rm --attach=true \
+      "${label_arg[@]}" --image=curlimages/curl --command -- \
+      sh -c "$RETRY_LOOP" >"$RESULTS_DIR/$name.out" 2>&1 || true
+  ) &
+done
+
+echo
+echo "  waiting for all tests to complete..."
+wait
+echo
+
+# ── Aggregate results ─────────────────────────────────────────────────────────
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+for i in "${!NAMES[@]}"; do
+  name=${NAMES[$i]}
+  expected=${EXPECTED[$i]}
+  out_file="$RESULTS_DIR/$name.out"
+
+  actual=$(grep -oE 'RESULT=[0-9]+' "$out_file" 2>/dev/null | tail -1 | cut -d= -f2)
+  actual=${actual:-no-result}
+
+  if [ "$actual" = "$expected" ]; then
+    echo -e "  ${GREEN}PASS${RESET} $name (got RESULT=$actual)"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${RESET} $name (got RESULT=$actual, expected RESULT=$expected)"
+    echo "  --- Pod output ---"
+    sed 's/^/    /' "$out_file"
+    echo "  ------------------"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+done
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo
+echo -e "${BOLD}Results:${RESET} ${GREEN}$PASS passed${RESET}, ${RED}$FAIL failed${RESET}"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "${RED}Failed tests:${RESET} ${FAILED_NAMES[*]}"
+  exit 1
+fi


### PR DESCRIPTION
## Description

### Product
Changes nothing from user perspective.

### Technical
Two related changes:

1. Stand up a small read-write Trino release (trino-rw) in scout-extractor so the hl7-transformer (in a future PR) can issue write DDL like CREATE OR REPLACE VIEW. The user-facing Trino in scout-analytics is read-only by design (delta.security=READ_ONLY, read-only metastore endpoint, reader S3 creds), so the transformer can't reuse it.

   - Single-coordinator/1-worker Helm release reusing s3_lake_writer and the writable Hive metastore endpoint — no new credentials.
   - fullnameOverride keeps Service names matching the release name.
   - Catalog config injects S3 credentials via envFrom + ${ENV:VAR} substitution, so the rendered ConfigMap holds only references.
   - Chart-native networkPolicy.enabled gates ingress: hl7-transformer in scout-extractor (port 8080) and Prometheus server in scout-monitoring (port 5556). Coordinator <-> worker traffic is allowed automatically by the chart.
   - Pre-wires TRINO_HOST/PORT/USER/CATALOG/SCHEME env vars on the transformer pod. Inert until the add_epic_views Trino integration ships in a follow-up PR.

2. Apply the same Secret-based S3 credential handling to the existing user-facing Trino in scout-analytics. Previously its catalog config inlined s3_lake_reader_secret directly, which the chart rendered into a ConfigMap (not encrypted at rest, broader RBAC visibility than Secrets). Now reader creds also flow through a trino-s3 Secret via envFrom + ${ENV:VAR}, matching the new RW deployment.

CI tests (tests/network/network-policy-tests.sh):
- Verifies the trino-rw NetworkPolicy: pods in scout-analytics or mislabeled pods in scout-extractor are denied; transformer-labeled pods in scout-extractor are allowed. Uses kubectl run + retry-loops to handle kube-router's ipset reconciliation lag, runs in parallel for ~25s total.

## Type of change
- [X] Work behind a feature flag
- [X] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [X] Test update

## Impact

### Security 

##### Authorization
N/A

##### Appsec
This is the part of this change that is most significant to think about. This adds a new trino instance that can be used to make arbitrary writes, without auth. However, it should be locked down by NetworkPolicy such that only prometheus and hl7-transformer can talk to it. I ran some `kubectl` commands manually to verify that which then became the new network tests to verify it in CI.

### Performance
Usage of new trino instance is trivial in scale.

### Data
N/A

### Backward compatibility
Should be backwards compatible

## Testing
Tested manually with upcoming work.

## Note for reviewers
Please double check the security aspect here.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [X] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [X] I have added end-to-end tests, if appropriate
