### PR TITLE
Add online / non-air-gapped nvidia repo setup

### DIFF
--- a/ansible/roles/k3s/tasks/nvidia_repo_setup.yaml
+++ b/ansible/roles/k3s/tasks/nvidia_repo_setup.yaml
@@ -1,0 +1,10 @@
+---
+# NVIDIA Container Toolkit Repository Setup (online mode only)
+# Adds the upstream NVIDIA repository to /etc/yum.repos.d/ so dnf can find the packages.
+# In proxy mode this is not needed — Nexus yum proxy repos are configured by ensure_packages.
+
+- name: Add NVIDIA container toolkit repository
+  ansible.builtin.get_url:
+    url: https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo
+    dest: /etc/yum.repos.d/nvidia-container-toolkit.repo
+    mode: '0644'


### PR DESCRIPTION
## Description

### Product
N/A

### Technical
Adds the `nvidia_repo_setup.yaml` task file that I neglected to check in for PR #339 (Nexus package proxy setup). In air-gapped mode we configure the yum repo to pull from the nexus proxy; this works on `main` right now. But in online (non-air-gapped) mode, this task file is supposed to configure the NVIDIA container toolkit yum repo so `dnf` can find the packages.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A — restores expected behavior for online-mode NVIDIA yum/dnf package installation.

## Testing
When I was testing #339 I did verify that the online-mode installation works, including with a GPU node. I haven't re-tested since noticing this file wasn't checked in.

## Note for reviewers
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
