### PR TITLE
Public access for Chat models

### DIFF
--- a/ansible/roles/open-webui/defaults/main.yaml
+++ b/ansible/roles/open-webui/defaults/main.yaml
@@ -229,9 +229,7 @@ open_webui_task_model_id: 'gemma4-31b-long:latest'
 # as admin even when ENABLE_SIGNUP is false; once any user exists the endpoint
 # self-blocks via the `has_users or not ENABLE_INITIAL_ADMIN_SIGNUP` check in
 # OWUI's auths router (signup handler in backend/open_webui/routers/auths.py),
-# so the env var is safe to leave on permanently. The bootstrap password is
-# derived deterministically from open_webui_secret_key (already vault-secured)
-# so we don't need to track another secret.
+# so the env var is safe to leave on permanently.
 #
 # `.local` is reserved (RFC 6762, mDNS) — guaranteed not to collide with a
 # real public domain and passes email-validator's strict checks if upstream

--- a/helm/open-webui-bootstrap/templates/configmap.yaml
+++ b/helm/open-webui-bootstrap/templates/configmap.yaml
@@ -50,6 +50,7 @@ data:
     {{- $defaults := .Values.scoutDefaults -}}
     {{- $profile := printf "data:image/png;base64,%s" ($.Files.Get (printf "files/payloads/%s" $defaults.profileImageFile)) -}}
     {{- $hideBase := dig "hideBaseModels" true $defaults -}}
+    {{- $publicRead := list (dict "principal_type" "user" "principal_id" "*" "permission" "read") -}}
     {{- $models := list -}}
     {{- range $m := .Values.scoutModels -}}
     {{- if $m.ui -}}
@@ -76,6 +77,7 @@ data:
             "keep_alive" (default $keepDefault $m.ui.keep_alive)
         )
         "is_active" true
+        "access_grants" $publicRead
     ) -}}
     {{- if and $hideBase (ne $m.base $modelId) -}}
     {{- $models = append $models (dict
@@ -85,6 +87,7 @@ data:
         "meta" (dict)
         "params" (dict)
         "is_active" false
+        "access_grants" $publicRead
     ) -}}
     {{- end -}}
     {{- end -}}


### PR DESCRIPTION
## Description

### Product
Make the Scout Explorer models public in Chat.

### Technical
Updates the model's access control grants to make the model public / reable. 

<img width="2672" height="1438" alt="Screenshot 2026-05-18 at 2 37 36 PM" src="https://github.com/user-attachments/assets/6280ebbd-a824-4e71-90c0-b0115d861c65" />


## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security 

##### Authorization
Opens the 3 Scout Explorer models to all authenticated OWUI users, matching the design intent of #371.

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
Re-ran `make install-chat` against dev02. Bootstrap helm release went to revision 2 and the Scout Explorer models now show public access in Admin Panel > Workspace > Models.

See screenshot above, too, I manually enabled public access and verified the REST call with what Claude wrote.

## Note for reviewers
I setup #371 on dev02 and the Scout Explorer models were setup with private access.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
