### PR TITLE
Renovate workflow: react to PR edits and closes

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -5,6 +5,8 @@ on:
     - cron: '0 6 * * 1' # Weekly Monday 6am UTC
   issues:
     types: [edited]
+  pull_request:
+    types: [edited, closed]
   workflow_dispatch:
 
 permissions: {}
@@ -12,9 +14,18 @@ permissions: {}
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    # Default-allow events; only narrow `issues` and `pull_request`:
+    #   - issues: only the Dependency Dashboard (approval clicks).
+    #   - pull_request: any close (so merging any PR — Renovate or not —
+    #     prompts a re-evaluation, including rebasing open Renovate PRs
+    #     against the new main); plus edits to Renovate-authored PRs (so
+    #     ticking the "rebase this PR" checkbox fires promptly).
+    # Edits on non-Renovate PRs are filtered out — they're noise here.
     if: >-
-      github.event_name != 'issues' ||
-      github.event.issue.title == 'Dependency Dashboard'
+      (github.event_name != 'issues' && github.event_name != 'pull_request') ||
+      (github.event_name == 'issues' && github.event.issue.title == 'Dependency Dashboard') ||
+      (github.event_name == 'pull_request' && github.event.action == 'closed') ||
+      (github.event_name == 'pull_request' && github.event.action == 'edited' && startsWith(github.event.pull_request.head.ref, 'renovate/'))
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Quick change to renovate bot triggers.

Before:
- Trigger on any non-issue event
- For issue events, trigger only on edits to dependency dashboard 

After:
- Trigger on any non-issue, non-pr event
- For issue events, trigger only on edits to dependency dashboard 
- For PR events, trigger on any PR close (including merge) + edits to any renovate PR

Context on why I'm adding the PR triggers: I had multiple renovate PRs open and merged one. The auto-generated PRs all say
```
♻ Rebasing: Whenever PR is behind base branch, or you tick the rebase/retry checkbox.
```
I expected that to happen to the other PRs when I merged the first PR but it didn't, nor did it happen when I checked the "please rebase" box on one of the PRs. Those rebases / dashboard updates only get processed when the renovate workflow runs, and there was nothing triggering it to run. 

That's why I want to add the PR event triggers. When we merge any PR the renovate workflow will run; it will process any changes to dependencies that need to go on the dashboard, and it will rebase any open renovate PRs. And whenever an open renovate PR is edited (say, by a person checking the "please rebase me" box) the workflow will run so it can rebase the PR.
