### PR TITLE
Renovate: auto-open patch PRs, add 14-day release-age delay

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,14 +7,23 @@
 
   // Require manual approval on the Dependency Dashboard before opening PRs.
   // This lets the dashboard list all available updates (visibility) without
-  // creating PR noise. CVE PRs bypass this via vulnerabilityAlerts below.
+  // creating PR noise. CVE PRs bypass this via vulnerabilityAlerts below,
+  // and patch updates bypass this via the packageRules entry below.
   "dependencyDashboardApproval": true,
 
-  // CVE PRs are created automatically (no dashboard approval needed)
+  // Wait 14 days after a release before considering an update. Lets upstream
+  // ship a follow-up patch for any regressions before we adopt the version,
+  // and pairs with the patch-auto-open rule below to keep that flow safe.
+  // Overridden to 0 for CVE alerts so security fixes aren't delayed.
+  "minimumReleaseAge": "14 days",
+
+  // CVE PRs are created automatically (no dashboard approval needed,
+  // no release-age delay)
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["dependencies", "security"],
-    "dependencyDashboardApproval": false
+    "dependencyDashboardApproval": false,
+    "minimumReleaseAge": "0 days"
   },
 
   // Dependency dashboard (GitHub issue) for overview of all detected dependencies
@@ -34,6 +43,14 @@
 
   // Remind reviewers about coupled dependencies
   "packageRules": [
+    // Patch updates bypass dashboard approval and get a PR opened directly.
+    // CI exercises every deployed service end-to-end, so green CI is a
+    // sufficient gate for patch-level changes. Minor/major still require
+    // dashboard approval (the global default).
+    {
+      "matchUpdateTypes": ["patch"],
+      "dependencyDashboardApproval": false
+    },
     // k3s uses non-standard versioning (v1.34.1+k3s1); regex versioning
     // keeps the +k3s suffix locked and tracks the build number
     {


### PR DESCRIPTION
## Description

### Product
<!-- Provide a summary explanation of your changes from a product/user perspective. More details should be found in your updates to the user docs. -->

### Technical

Two related changes to the Renovate config:

- Patch updates no longer require dashboard approval. CI now exercises every deployed service end-to-end (deploy-and-test + smoke-test), which is a sufficient gate for patch-level bumps. Minor/major still go through the dashboard.
- Add `minimumReleaseAge: 14 days` globally so a release has time to shake out before we adopt it. Overridden to 0 days inside `vulnerabilityAlerts` so CVE fixes still ship promptly.

Auto-merge remains off; humans still review every PR.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update
- [X] Infrastructure

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
<!-- Do your changes add or modify user roles? Do they impact the data users are able to see, or the actions they are able to take? Could a user modify a REST API path and see data they aren't supposed to see? Were you mindful of least privilege? -->
N/A

##### Appsec
<!-- Did you review your changes with application security in mind? See the [OWASP list](https://github.com/0xRadi/OWASP-Web-Checklist). -->
The aim is to improve security through timely application of CVE and patch updates without a human needing to remember to go through the renovate dashboard. The minimum age setting delays opening PRs for these updates for 14 days to avoid any supply-chain attacks by giving upstream maintainers time to notice them and pull the offending malicious updates.

### Performance
<!-- At what scale do we expect this to operate? How have you verified that it can do so? -->
N/A

### Data
<!-- Did you consider any edge cases around input data (e.g., DICOM type 2 elements are required to be present but may be empty)? Are you gracefully handling errors from "bad data," e.g., non-conforming DICOM? -->
N/A

### Backward compatibility
<!-- Any changes to the data model, APIs, dependencies? -->
N/A

## Testing
<!-- Detail the testing you have performed to ensure that these changes function as intended. Include information about the test automation you've added, as well as the manual testing you've performed. Be sure to reference areas of impact, above. -->
None

## Note for reviewers
<!-- Any additional information or direction for reviewers. -->
I haven't added or amended any ADRs, but I will if we think it is warranted.

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
