### PR TITLE
Taint GPU workers, set tolerations for appropriate services

### DIFF
--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -227,6 +227,13 @@ k3s_cluster:
     #---------------------------------------------------------------------------
     k3s_token: $(openssl rand -hex 16 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
 
+    # GPU node taint - on by default. Taints every host in `gpu_workers` with
+    # `nvidia.com/gpu=present:NoSchedule` so only GPU-needing workloads
+    # (Ollama, Jupyter singleuser) and cluster-wide storage that spans every
+    # node by design (MinIO) land there. Disable on small/dev clusters where
+    # the GPU node's spare capacity is genuinely useful for non-GPU pods.
+    # enable_gpu_node_taint: false
+
     # CoreDNS custom DNS configuration (see docs/source/technical/inventory.md)
     # When air_gapped: true, CoreDNS automatically gets deny-all + cluster.local blocks
     #

--- a/ansible/inventory.example.yaml
+++ b/ansible/inventory.example.yaml
@@ -227,11 +227,10 @@ k3s_cluster:
     #---------------------------------------------------------------------------
     k3s_token: $(openssl rand -hex 16 | ansible-vault encrypt_string --vault-password-file vault/pwd.sh)
 
-    # GPU node taint - on by default. Taints every host in `gpu_workers` with
-    # `nvidia.com/gpu=present:NoSchedule` so only GPU-needing workloads
-    # (Ollama, Jupyter singleuser) and cluster-wide storage that spans every
-    # node by design (MinIO) land there. Disable on small/dev clusters where
-    # the GPU node's spare capacity is genuinely useful for non-GPU pods.
+    # GPU node taint - on by default. Taints every host in `gpu_workers`
+    # with `nvidia.com/gpu=present:NoSchedule`. Disable on small/dev
+    # clusters where the GPU node's spare capacity is needed for non-GPU
+    # pods.
     # enable_gpu_node_taint: false
 
     # CoreDNS custom DNS configuration (see docs/source/technical/inventory.md)

--- a/ansible/roles/jupyter/templates/values.yaml.j2
+++ b/ansible/roles/jupyter/templates/values.yaml.j2
@@ -95,6 +95,14 @@ ingress:
     - '*.jupyter.{{ server_hostname }}'
 
 prePuller:
+  # Tolerate the GPU-node taint so the hook image-puller DaemonSet pre-pulls
+  # singleuser images onto the GPU node too — singleuser pods are pinned
+  # there (ADR 0006) so a cold pull would otherwise hit every first spawn.
+  # Harmless when the taint isn't present.
+  extraTolerations:
+    - key: nvidia.com/gpu
+      value: present
+      effect: NoSchedule
   hook:
     enabled: {{ jupyter_prepuller_hook | default(true) }}
   continuous:
@@ -121,8 +129,10 @@ singleuser:
   # Tolerate the GPU-node taint. Singleuser pods are pinned to the GPU
   # node via nodeSelector above (ADR 0006) so they MUST tolerate when
   # enable_gpu_node_taint is set, or no pod will ever schedule. Harmless
-  # when the taint isn't present.
-  tolerations:
+  # when the taint isn't present. Field name is `extraTolerations` — the
+  # Z2JH chart reads only that key for singleuser pods (plain
+  # `tolerations` is silently ignored).
+  extraTolerations:
     - key: nvidia.com/gpu
       value: present
       effect: NoSchedule

--- a/ansible/roles/jupyter/templates/values.yaml.j2
+++ b/ansible/roles/jupyter/templates/values.yaml.j2
@@ -118,6 +118,14 @@ singleuser:
   nodeSelector:
     kubernetes.io/hostname: '{{ jupyter_target_node_name }}'
 {% endif %}
+  # Tolerate the GPU-node taint. Singleuser pods are pinned to the GPU
+  # node via nodeSelector above (ADR 0006) so they MUST tolerate when
+  # enable_gpu_node_taint is set, or no pod will ever schedule. Harmless
+  # when the taint isn't present.
+  tolerations:
+    - key: nvidia.com/gpu
+      value: present
+      effect: NoSchedule
   cmd: null
   initContainers:
     - name: spark-config-setup

--- a/ansible/roles/jupyter/templates/values.yaml.j2
+++ b/ansible/roles/jupyter/templates/values.yaml.j2
@@ -95,10 +95,8 @@ ingress:
     - '*.jupyter.{{ server_hostname }}'
 
 prePuller:
-  # Tolerate the GPU-node taint so the hook image-puller DaemonSet pre-pulls
-  # singleuser images onto the GPU node too — singleuser pods are pinned
-  # there (ADR 0006) so a cold pull would otherwise hit every first spawn.
-  # Harmless when the taint isn't present.
+  # Pre-pull singleuser images onto the GPU node too, since that's where
+  # they actually run (ADR 0006).
   extraTolerations:
     - key: nvidia.com/gpu
       value: present
@@ -126,12 +124,8 @@ singleuser:
   nodeSelector:
     kubernetes.io/hostname: '{{ jupyter_target_node_name }}'
 {% endif %}
-  # Tolerate the GPU-node taint. Singleuser pods are pinned to the GPU
-  # node via nodeSelector above (ADR 0006) so they MUST tolerate when
-  # enable_gpu_node_taint is set, or no pod will ever schedule. Harmless
-  # when the taint isn't present. Field name is `extraTolerations` — the
-  # Z2JH chart reads only that key for singleuser pods (plain
-  # `tolerations` is silently ignored).
+  # Required when enable_gpu_node_taint is set — singleuser pods are pinned
+  # to the GPU node (ADR 0006).
   extraTolerations:
     - key: nvidia.com/gpu
       value: present

--- a/ansible/roles/k3s/tasks/main.yaml
+++ b/ansible/roles/k3s/tasks/main.yaml
@@ -53,25 +53,17 @@
   ansible.builtin.include_tasks: agent.yaml
   when: "'agents' in group_names"
 
-################################################################################
-# GPU node taint - Reserves GPU nodes for GPU-needing workloads (Ollama,
-# Jupyter singleuser) and cluster-wide storage that spans every node by
-# design (MinIO). Non-GPU workloads avoid the GPU node so it always has
-# memory headroom for the things that actually need it. See
-# enable_gpu_node_taint in scout_common/defaults for the toggle; taints
-# flip with the var (state=present/absent) so disabling it converges
-# either way. Runs after agent install so every GPU node is registered
-# with the API server by the time we taint.
-################################################################################
-# delegate_to: localhost + run_once together — task fires once per
-# playbook run from the jump node, using the fetched `local_kubeconfig_yaml`
-# (Scout's standard kubernetes.core convention). Loops over the gpu_workers
-# group to taint each GPU node.
+# Taint every gpu_workers node (see enable_gpu_node_taint in
+# scout_common/defaults). Flips with the var, so disabling it converges.
+# Runs after agent install so GPU nodes are registered with the API
+# server. Skipped on single-node clusters — same reason server.yaml
+# skips the control-plane taint there. Delegates to the first server so
+# the cluster kubeconfig path is stable regardless of which host triggers
+# run_once, matching the pattern used by the control-plane taint.
 - name: Apply GPU node taints
-  delegate_to: localhost
+  delegate_to: "{{ groups['server'][0] }}"
   run_once: true
   kubernetes.core.k8s_taint:
-    kubeconfig: '{{ local_kubeconfig_yaml }}'
     name: '{{ item }}'
     state: "{{ 'present' if enable_gpu_node_taint else 'absent' }}"
     taints:
@@ -79,3 +71,4 @@
         value: present
         effect: NoSchedule
   loop: "{{ groups['gpu_workers'] | default([]) }}"
+  when: (groups['k3s_cluster'] | default([]) | length) > 1

--- a/ansible/roles/k3s/tasks/main.yaml
+++ b/ansible/roles/k3s/tasks/main.yaml
@@ -63,12 +63,13 @@
 # either way. Runs after agent install so every GPU node is registered
 # with the API server by the time we taint.
 ################################################################################
-# Scoped to the server iteration so `local_kubeconfig_yaml` resolves to
-# the server's fetched kubeconfig on the jump node (Scout's standard
-# kubernetes.core convention). Loops over groups['gpu_workers'] inside
-# the task to taint each GPU node.
+# delegate_to: localhost + run_once together — task fires once per
+# playbook run from the jump node, using the fetched `local_kubeconfig_yaml`
+# (Scout's standard kubernetes.core convention). Loops over the gpu_workers
+# group to taint each GPU node.
 - name: Apply GPU node taints
   delegate_to: localhost
+  run_once: true
   kubernetes.core.k8s_taint:
     kubeconfig: '{{ local_kubeconfig_yaml }}'
     name: '{{ item }}'
@@ -78,4 +79,3 @@
         value: present
         effect: NoSchedule
   loop: "{{ groups['gpu_workers'] | default([]) }}"
-  when: inventory_hostname in groups['server']

--- a/ansible/roles/k3s/tasks/main.yaml
+++ b/ansible/roles/k3s/tasks/main.yaml
@@ -52,3 +52,30 @@
 - name: Install k3s agent
   ansible.builtin.include_tasks: agent.yaml
   when: "'agents' in group_names"
+
+################################################################################
+# GPU node taint - Reserves GPU nodes for GPU-needing workloads (Ollama,
+# Jupyter singleuser) and cluster-wide storage that spans every node by
+# design (MinIO). Non-GPU workloads avoid the GPU node so it always has
+# memory headroom for the things that actually need it. See
+# enable_gpu_node_taint in scout_common/defaults for the toggle; taints
+# flip with the var (state=present/absent) so disabling it converges
+# either way. Runs after agent install so every GPU node is registered
+# with the API server by the time we taint.
+################################################################################
+# Scoped to the server iteration so `local_kubeconfig_yaml` resolves to
+# the server's fetched kubeconfig on the jump node (Scout's standard
+# kubernetes.core convention). Loops over groups['gpu_workers'] inside
+# the task to taint each GPU node.
+- name: Apply GPU node taints
+  delegate_to: localhost
+  kubernetes.core.k8s_taint:
+    kubeconfig: '{{ local_kubeconfig_yaml }}'
+    name: '{{ item }}'
+    state: "{{ 'present' if enable_gpu_node_taint else 'absent' }}"
+    taints:
+      - key: nvidia.com/gpu
+        value: present
+        effect: NoSchedule
+  loop: "{{ groups['gpu_workers'] | default([]) }}"
+  when: inventory_hostname in groups['server']

--- a/ansible/roles/minio/tasks/deploy.yaml
+++ b/ansible/roles/minio/tasks/deploy.yaml
@@ -92,6 +92,14 @@
               - key: 'node-role.kubernetes.io/control-plane'
                 operator: Exists
                 effect: PreferNoSchedule
+              # Tolerate the GPU-node taint — MinIO pool spans every cluster
+              # node by design (one server per host for EC topology), so the
+              # GPU node is an intentional pool member. Harmless when the
+              # taint isn't present (see enable_gpu_node_taint in
+              # scout_common defaults).
+              - key: nvidia.com/gpu
+                value: present
+                effect: NoSchedule
             affinity:
               podAntiAffinity:
                 requiredDuringSchedulingIgnoredDuringExecution:

--- a/ansible/roles/minio/tasks/deploy.yaml
+++ b/ansible/roles/minio/tasks/deploy.yaml
@@ -92,11 +92,8 @@
               - key: 'node-role.kubernetes.io/control-plane'
                 operator: Exists
                 effect: PreferNoSchedule
-              # Tolerate the GPU-node taint — MinIO pool spans every cluster
-              # node by design (one server per host for EC topology), so the
-              # GPU node is an intentional pool member. Harmless when the
-              # taint isn't present (see enable_gpu_node_taint in
-              # scout_common defaults).
+              # Allows the MinIO pool to include the GPU node when
+              # `minio_hosts` lists it.
               - key: nvidia.com/gpu
                 value: present
                 effect: NoSchedule

--- a/ansible/roles/open-webui/templates/values.yaml.j2
+++ b/ansible/roles/open-webui/templates/values.yaml.j2
@@ -34,6 +34,13 @@ ollama:
                 values:
                   - '{{ ollama_min_gpu_memory_gb }}'
 {% endif %}
+  # Tolerate the GPU-node taint so Ollama can schedule on reserved GPU
+  # nodes (see scout_common defaults `enable_gpu_node_taint`). Harmless
+  # when the taint isn't present.
+  tolerations:
+    - key: nvidia.com/gpu
+      value: present
+      effect: NoSchedule
   extraEnv:
     - name: OLLAMA_KEEP_ALIVE
       value: '-1'

--- a/ansible/roles/open-webui/templates/values.yaml.j2
+++ b/ansible/roles/open-webui/templates/values.yaml.j2
@@ -34,9 +34,7 @@ ollama:
                 values:
                   - '{{ ollama_min_gpu_memory_gb }}'
 {% endif %}
-  # Tolerate the GPU-node taint so Ollama can schedule on reserved GPU
-  # nodes (see scout_common defaults `enable_gpu_node_taint`). Harmless
-  # when the taint isn't present.
+  # Required so Ollama can schedule on the reserved GPU node.
   tolerations:
     - key: nvidia.com/gpu
       value: present

--- a/ansible/roles/scout_common/defaults/main.yaml
+++ b/ansible/roles/scout_common/defaults/main.yaml
@@ -216,6 +216,15 @@ keycloak_subdomain: keycloak
 enable_chat: false
 enable_playbooks: false
 
+# Reserve GPU nodes for workloads that either need GPU hardware (Ollama,
+# Jupyter singleuser) or are cluster-wide storage layers that span every
+# node by design (MinIO pool). With this on, the GPU node gets
+# `nvidia.com/gpu=present:NoSchedule` and the above workloads carry
+# matching tolerations; everything else avoids the GPU node. Disable
+# for small/dev clusters where the GPU node's spare capacity is
+# genuinely useful for non-GPU pods.
+enable_gpu_node_taint: true
+
 # Superset dashboard bundles to install. Built-in bundles: core, quality,
 # followup. Override in inventory to add more (e.g. [core, quality]).
 scout_dashboard_bundles:

--- a/docs/source/technical/inventory.md
+++ b/docs/source/technical/inventory.md
@@ -180,6 +180,8 @@ gpu_workers:
 
 The NVIDIA GPU Operator will be automatically deployed on these nodes.
 
+By default, every host in `gpu_workers` is tainted with `nvidia.com/gpu=present:NoSchedule` so the node stays reserved for workloads that need it (Ollama, Jupyter singleuser) and cluster-wide storage that spans every node by design (MinIO). Set `enable_gpu_node_taint: false` in `k3s_cluster.vars` to disable — useful for small or dev clusters where the GPU node's spare capacity should be available to general workloads.
+
 ### MinIO Hosts Group
 
 Nodes where MinIO object storage will run. MinIO requires direct disk access:


### PR DESCRIPTION
## Description

### Product
On clusters with a GPU node, GPU-needing services (Ollama, Jupyter notebooks) were sometimes failing to schedule because the GPU node had filled up with unrelated workloads. This change reserves GPU nodes for the services that actually need them.

### Technical
Adds an `nvidia.com/gpu=present:NoSchedule` taint to every host in the `gpu_workers` inventory group, applied from the `k3s` role after agent install. Tolerations are added to the workloads that belong on a GPU node: Ollama (GPU-bound), Jupyter `singleuser` (pinned to the GPU node per ADR 0006, plus `prePuller` so images pre-pull there), and the MinIO pool (so it can include the GPU node when `minio_hosts` lists it). 

Controlled by `enable_gpu_node_taint` (default `true`) in `scout_common` defaults. The taint task uses `state: "{{ 'present' if enable_gpu_node_taint else 'absent' }}"` so flipping the flag converges either way on the next `install-k3s`. The task is skipped on single-node clusters, mirroring the control-plane taint guard in `server.yaml`. 

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
On existing clusters, the next `make install-k3s` applies the taint. Because the effect is `NoSchedule` (not `NoExecute`), already-running pods on the GPU node are **not** evicted: they stay until their next restart, at which point they reschedule onto a non-GPU node. 

To apply immediately, you must `kubectl delete pod` the non-GPU workloads currently on the GPU node after running the k3s playbook. 

## Testing
- Run k3s install on cluster with `gpu_workers`
  - Confirmed the taint appears on the GPU node and Ollama / Jupyter singleuser still schedule there.
  - Confirmed non-GPU workloads land off the GPU node.

## Note for reviewers
- The MinIO pool tolerates the taint even though the example inventory doesn't put `gpu_workers` in `minio_hosts`, this seemed most straightforward with no cost since `minio_hosts` ultimately controls scheduling

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
