### PR TITLE
Fix Temporal workflow failure alert/panel NoData when no failures

### DIFF
--- a/ansible/roles/grafana/templates/alerts/temporal-workflow-failure-alert.json.j2
+++ b/ansible/roles/grafana/templates/alerts/temporal-workflow-failure-alert.json.j2
@@ -21,7 +21,7 @@
               "datasourceUid": "prometheus_datasource_01",
               "model": {
                 "editorMode": "code",
-                "expr": "sum by (namespace) (rate(workflow_failed{operation=\"CompletionStats\", job=\"kubernetes-pods\"}[1h]))",
+                "expr": "sum by (namespace) (rate(workflow_failed{operation=\"CompletionStats\", job=\"kubernetes-pods\"}[1h])) or 0 * sum by (namespace) (rate(workflow_success{operation=\"CompletionStats\", job=\"kubernetes-pods\"}[1h]))",
                 "instant": true,
                 "intervalMs": 1000,
                 "legendFormat": "__auto",

--- a/ansible/roles/grafana/templates/dashboards/temporal-dashboard.json.j2
+++ b/ansible/roles/grafana/templates/dashboards/temporal-dashboard.json.j2
@@ -2386,7 +2386,7 @@
             "type": "prometheus",
             "uid": "prometheus_datasource_01"
           },
-          "expr": "sum(rate(workflow_failed{ operation=\"CompletionStats\"}[5m]))",
+          "expr": "sum(rate(workflow_failed{ operation=\"CompletionStats\"}[5m])) or vector(0)",
           "interval": "",
           "legendFormat": "failed",
           "refId": "B"
@@ -2396,7 +2396,7 @@
             "type": "prometheus",
             "uid": "prometheus_datasource_01"
           },
-          "expr": "sum(rate(workflow_timeout{ operation=\"CompletionStats\"}[5m]))",
+          "expr": "sum(rate(workflow_timeout{ operation=\"CompletionStats\"}[5m])) or vector(0)",
           "interval": "",
           "legendFormat": "timedout",
           "refId": "C"
@@ -2406,7 +2406,7 @@
             "type": "prometheus",
             "uid": "prometheus_datasource_01"
           },
-          "expr": "sum(rate(workflow_terminate{ operation=\"CompletionStats\"}[5m]))",
+          "expr": "sum(rate(workflow_terminate{ operation=\"CompletionStats\"}[5m])) or vector(0)",
           "interval": "",
           "legendFormat": "terminate",
           "refId": "D"
@@ -2416,7 +2416,7 @@
             "type": "prometheus",
             "uid": "prometheus_datasource_01"
           },
-          "expr": "sum(rate(workflow_cancel{ operation=\"CompletionStats\"}[5m]))",
+          "expr": "sum(rate(workflow_cancel{ operation=\"CompletionStats\"}[5m])) or vector(0)",
           "interval": "",
           "legendFormat": "cancelled",
           "refId": "E"
@@ -2610,7 +2610,7 @@
             "type": "prometheus",
             "uid": "prometheus_datasource_01"
           },
-          "expr": "sum by (namespace) (rate(workflow_failed{ operation=\"CompletionStats\"}[5m]))",
+          "expr": "sum by (namespace) (rate(workflow_failed{ operation=\"CompletionStats\"}[5m])) or 0 * sum by (namespace) (rate(workflow_success{ operation=\"CompletionStats\"}[5m]))",
           "interval": "",
           "legendFormat": "{{ namespace }} ",
           "refId": "A"
@@ -2707,7 +2707,7 @@
             "type": "prometheus",
             "uid": "prometheus_datasource_01"
           },
-          "expr": "sum by (namespace) (rate(workflow_timeout{ operation=\"CompletionStats\"}[5m]))",
+          "expr": "sum by (namespace) (rate(workflow_timeout{ operation=\"CompletionStats\"}[5m])) or 0 * sum by (namespace) (rate(workflow_success{ operation=\"CompletionStats\"}[5m]))",
           "interval": "",
           "legendFormat": "{{ namespace }} ",
           "refId": "A"
@@ -2804,7 +2804,7 @@
             "type": "prometheus",
             "uid": "prometheus_datasource_01"
           },
-          "expr": "sum by (namespace) (rate(workflow_terminate{ operation=\"CompletionStats\"}[5m]))",
+          "expr": "sum by (namespace) (rate(workflow_terminate{ operation=\"CompletionStats\"}[5m])) or 0 * sum by (namespace) (rate(workflow_success{ operation=\"CompletionStats\"}[5m]))",
           "interval": "",
           "legendFormat": "{{ namespace }} ",
           "refId": "A"
@@ -2901,7 +2901,7 @@
             "type": "prometheus",
             "uid": "prometheus_datasource_01"
           },
-          "expr": "sum by (namespace) (rate(workflow_cancel{ operation=\"CompletionStats\"}[5m]))",
+          "expr": "sum by (namespace) (rate(workflow_cancel{ operation=\"CompletionStats\"}[5m])) or 0 * sum by (namespace) (rate(workflow_success{ operation=\"CompletionStats\"}[5m]))",
           "interval": "",
           "legendFormat": "{{ namespace }} ",
           "refId": "A"


### PR DESCRIPTION
## Description

### Product
The Temporal workflow failure alert and dashboard panels no longer show "No Data" when there have been no workflow failures; they now correctly show zero.

### Technical
Updated the Prometheus expressions in the Temporal workflow failure alert and the Temporal dashboard panels (failed/timeout/terminate/cancel) to fall back to a zero vector when the `workflow_failed`/`workflow_timeout`/`workflow_terminate`/`workflow_cancel` series have no samples. Per-namespace panels use `or 0 * sum by (namespace) (rate(workflow_success...))` to preserve the namespace label; the aggregate dashboard queries use `or vector(0)`; the alert query uses the namespace-preserving form.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
N/A

##### Appsec
N/A

### Performance
Negligible. Adds a second rate query on `workflow_success` only as a label-preserving zero fallback.

### Data
N/A

### Backward compatibility
No data model or API changes. Existing alert/dashboard JSON is overwritten on next Grafana role deploy.

## Testing
Verified the updated PromQL expressions return zero (rather than empty) when no failure series are present, while still preserving the `namespace` label on per-namespace panels.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
