### PR TITLE
Do not apply GPU node taints when running on the staging node

### DIFF
--- a/ansible/roles/k3s/tasks/main.yaml
+++ b/ansible/roles/k3s/tasks/main.yaml
@@ -71,4 +71,6 @@
         value: present
         effect: NoSchedule
   loop: "{{ groups['gpu_workers'] | default([]) }}"
-  when: (groups['k3s_cluster'] | default([]) | length) > 1
+  when:
+    - "'staging' not in group_names"
+    - (groups['k3s_cluster'] | default([]) | length) > 1


### PR DESCRIPTION
When deploying Scout with a staging node and `air_gapped: true`, the GPU node taints was being applied to the single-node staging cluster and causing the deploy to fail. This change causes the GPU taints to be skipped on the staging cluster but still applied later during the main cluster deploy.