### PR TITLE
Dependency CVE updates

### DIFF
--- a/extractor/hl7log-extractor/build.gradle
+++ b/extractor/hl7log-extractor/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 def temporalVersion = "1.34.0"
 def s3Version = "2.20.0"
-def checkstyleVersion = "10.21.2"
+def checkstyleVersion = "13.4.2"
 
 // TODO: Remove once Spring Boot ships a release that manages postgresql >= 42.7.11.
 // Overrides the Spring Boot BOM's pinned 42.7.10 to address GHSA-98qh-xjc8-98pq

--- a/extractor/hl7log-extractor/build.gradle
+++ b/extractor/hl7log-extractor/build.gradle
@@ -34,6 +34,10 @@ ext['postgresql.version'] = '42.7.11'
 // netty-codec-http2, netty-codec-dns, and netty-transport-native-epoll.
 ext['netty.version'] = '4.1.133.Final'
 
+// TODO: Remove once Spring Boot 3.5.x manages commons-lang3 >= 3.18.0.
+// Overrides the Spring Boot BOM's pinned 3.16.0 to address GHSA-j288-q9x7-2f5v.
+ext['commons-lang3.version'] = '3.18.0'
+
 // TODO: Remove once Temporal ships a release that brings opentelemetry >= 1.62.0.
 // Pins the io.opentelemetry:* family (transitively from temporal-sdk) to 1.62.0
 // to address the opentelemetry-api vulnerability CVE-2026-45292. Imported via

--- a/extractor/hl7log-extractor/build.gradle
+++ b/extractor/hl7log-extractor/build.gradle
@@ -36,7 +36,7 @@ ext['netty.version'] = '4.1.133.Final'
 
 // TODO: Remove once Spring Boot 3.5.x manages commons-lang3 >= 3.18.0.
 // Overrides the Spring Boot BOM's pinned 3.16.0 to address GHSA-j288-q9x7-2f5v.
-ext['commons-lang3.version'] = '3.18.0'
+ext['commons-lang3.version'] = '3.20.0'
 
 // TODO: Remove once Temporal ships a release that brings opentelemetry >= 1.62.0.
 // Pins the io.opentelemetry:* family (transitively from temporal-sdk) to 1.62.0

--- a/extractor/hl7log-extractor/build.gradle
+++ b/extractor/hl7log-extractor/build.gradle
@@ -34,6 +34,17 @@ ext['postgresql.version'] = '42.7.11'
 // netty-codec-http2, netty-codec-dns, and netty-transport-native-epoll.
 ext['netty.version'] = '4.1.133.Final'
 
+// TODO: Remove once Temporal ships a release that brings opentelemetry >= 1.62.0.
+// Pins the io.opentelemetry:* family (transitively from temporal-sdk) to 1.62.0
+// to address the opentelemetry-api vulnerability CVE-2026-45292. Imported via
+// the Spring dependency-management plugin so the BOM wins against Maven-style
+// nearest-version resolution (a plain platform() import loses to transitives).
+dependencyManagement {
+	imports {
+		mavenBom 'io.opentelemetry:opentelemetry-bom:1.62.0'
+	}
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework:spring-aspects'

--- a/keycloak/event-listener/build.gradle
+++ b/keycloak/event-listener/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 def kcVersion = "26.6.1"
 def jbossLoggingVersion = "3.6.1.Final"
-def checkstyleVersion = "10.21.2"
+def checkstyleVersion = "13.4.2"
 
 dependencies {
     implementation("org.keycloak:keycloak-core:${kcVersion}")

--- a/tests/ingest/build.gradle
+++ b/tests/ingest/build.gradle
@@ -23,7 +23,7 @@ repositories {
 }
 
 final String vQuerySpec = '1.2-SNAPSHOT'
-final String vCheckstyle = '10.21.2'
+final String vCheckstyle = '13.4.2'
 final String vLog4j2Bridge = '2.24.2'
 final String vSparkSql = '3.5.4'
 final String vDeltaSpark = '3.1.0'


### PR DESCRIPTION
## Description

### Product
N/A

### Technical
Simple update of checkstyle in all subprojects. Also includes bump of `commons-lang3` from 3.16.0 to 3.20.0 and rather aggressive pinning of `io.opentelemetry` stack from 1.49.0 to 1.62.0.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
N/A

##### Appsec
Dependencies are upgraded to remove some transitive vulnerabilities.

### Performance
N/A

### Data
N/A

### Backward compatibility
Should be backwards compatible.

## Testing
Checkstyle worked successfully for me locally in all 3 subprojects. I'm leaning on CI tests to check that in the ingest tests the extractor is still working properly.

## Note for reviewers
<!-- Any additional information or direction for reviewers. -->

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
