### PR TITLE
Trino AuthZ: OWUI MCP per-user identity (PASSWORD authenticator + OIDC inbound)

### DIFF
--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -174,14 +174,13 @@ k3s_cluster:
     # these in scout-inventory; CI sets fixed test values so the
     # smoke-test deploy doesn't fail at template render.
     trino_internal_shared_secret: ci-trino-internal-shared-secret
-    trino_openwebui_mcp_svc_password: ci-trino-mcp-svc-pw
     # Bcrypt-hashed at deploy time via htpasswd (see roles/trino/
-    # templates/password.db.j2). The data-authorization tests don't
+    # templates/password.db.j2) into the openwebui_mcp_svc entry the
+    # role's defaults wire up. The data-authorization tests don't
     # exercise the PASSWORD auth path -- they use service-principal
     # JWT with X-Trino-User -- but mcp-trino's HTTP Basic outbound
     # requires the entry to exist.
-    trino_password_authenticator_users:
-      openwebui_mcp_svc: '{{ trino_openwebui_mcp_svc_password }}'
+    trino_openwebui_mcp_svc_password: ci-trino-mcp-svc-pw
 
     # Valkey (single shared password for all services)
     valkey_password: valkey123

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -535,31 +535,6 @@ jobs:
         run: |
           sudo -E kubectl exec -n scout-analytics deployment/trino-coordinator -- \
             curl -sk -f https://localhost:8443/v1/info
-      # MCP→Trino auth smoke. Exercises the PASSWORD authenticator + the
-      # service-principal X-Trino-User impersonation pattern mcp-trino
-      # uses (ADR 0022). A successful query confirms: the password.db
-      # file authenticator loaded openwebui_mcp_svc, the bcrypt hash
-      # matches the configured password, and OPA permits the principal
-      # to impersonate end users. Doesn't invoke mcp-trino itself - that
-      # adds OIDC-inbound + Go HTTP plumbing on top of the same path; if
-      # this passes and mcp-trino is Ready, the chain is sound. (A full
-      # mcp-trino → Trino smoke that mints + forwards a real chat-user
-      # JWT is deferred; the existing data-auth tests cover the broader
-      # JWT identity flow on the JWT authenticator.)
-      - name: 'MCP→Trino PASSWORD auth smoke'
-        if: matrix.side == 'analytics'
-        shell: bash
-        run: |
-          set -euo pipefail
-          PW=$(yq '.k3s_cluster.vars.trino_openwebui_mcp_svc_password' ansible/inventory.yaml)
-          sudo -E kubectl exec -n scout-analytics deployment/trino-coordinator -- \
-            curl -sk -f \
-              -u "openwebui_mcp_svc:${PW}" \
-              -H "X-Trino-User: testuser.jupyter" \
-              -H "Content-Type: text/plain" \
-              -X POST --data 'SELECT 1' \
-              https://localhost:8443/v1/statement \
-            | grep -q '"infoUri"'
       # Data authorization tests. Seeds a synthetic
       # delta.default.test_reports table, then exercises the end-to-end
       # AuthZ pipeline (Keycloak admin -> SPI listener -> MinIO bundle ->
@@ -614,6 +589,7 @@ jobs:
           set -euo pipefail
           KC_ADMIN_PW=$(yq '.k3s_cluster.vars.keycloak_bootstrap_admin_password' ansible/inventory.yaml)
           SUPERSET_SVC_SECRET=$(yq '.k3s_cluster.vars.keycloak_superset_svc_client_secret' ansible/inventory.yaml)
+          MCP_SVC_PW=$(yq '.k3s_cluster.vars.trino_openwebui_mcp_svc_password' ansible/inventory.yaml)
 
           # Script in a ConfigMap (kubectl handles file content
           # correctly), secrets in a Secret. The Job manifest
@@ -627,6 +603,7 @@ jobs:
             -n scout-analytics \
             --from-literal=KC_ADMIN_PASSWORD="$KC_ADMIN_PW" \
             --from-literal=SUPERSET_SVC_CLIENT_SECRET="$SUPERSET_SVC_SECRET" \
+            --from-literal=MCP_SVC_PASSWORD="$MCP_SVC_PW" \
             --dry-run=client -o yaml | sudo -E kubectl apply -f -
 
           sudo -E kubectl apply -f tests/data-authorization/authz-tests/job.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -248,6 +248,11 @@ jobs:
       - name: Install Python dependencies for Ansible Kubernetes modules
         run: |
           /opt/pipx/venvs/ansible-core/bin/python -m pip install kubernetes
+      - name: Install apache2-utils for htpasswd
+        # roles/trino/templates/password.db.j2 shells out to `htpasswd -bnBC 10`
+        # to bcrypt-hash the file-PASSWORD-authenticator entries. ubuntu-latest
+        # doesn't include it by default.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends apache2-utils
       - name: 'Install k3s'
         shell: bash
         run: |
@@ -369,7 +374,7 @@ jobs:
             subdomains: superset,chat,keycloak,auth,minio
             san_extra: ''
             playbooks: k3s traefik postgres valkey auth lake trino superset chatbot launchpad
-            netpol_include: '--include trino-rw,opa-trino'
+            netpol_include: '--include trino-rw,opa-trino,mcp-trino-ingress'
           - side: notebooks
             # testuser.jupyter is the per-user singleuser pod ingress
             subdomains: jupyter,grafana,keycloak,auth,playbooks,testuser.jupyter
@@ -427,6 +432,11 @@ jobs:
         run: cd ansible && sudo -E /opt/pipx_bin/ansible-galaxy install -r collections/requirements.yaml
       - name: Install Python dependencies for Ansible Kubernetes modules
         run: /opt/pipx/venvs/ansible-core/bin/python -m pip install kubernetes
+      - name: Install apache2-utils for htpasswd
+        # roles/trino/templates/password.db.j2 shells out to `htpasswd -bnBC 10`
+        # to bcrypt-hash the file-PASSWORD-authenticator entries. ubuntu-latest
+        # doesn't include it by default.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends apache2-utils
       - name: 'Install k3s'
         shell: bash
         run: cd ansible && sudo -E /opt/pipx_bin/ansible-playbook -v -i inventory.yaml --diff playbooks/k3s.yaml
@@ -495,6 +505,10 @@ jobs:
           echo "=== Checking Trino ==="
           sudo -E kubectl rollout status deployment/trino-coordinator -n scout-analytics --timeout=180s
           sudo -E kubectl rollout status deployment/trino-worker -n scout-analytics --timeout=180s
+          if [ "$SIDE" = "analytics" ]; then
+            echo "=== Checking MCP Trino ==="
+            sudo -E kubectl rollout status deployment/mcp-trino -n scout-analytics --timeout=180s
+          fi
           if [ "$SIDE" = "notebooks" ]; then
             echo "=== Checking Voila ==="
             sudo -E kubectl rollout status deployment/voila -n scout-analytics --timeout=180s
@@ -521,6 +535,31 @@ jobs:
         run: |
           sudo -E kubectl exec -n scout-analytics deployment/trino-coordinator -- \
             curl -sk -f https://localhost:8443/v1/info
+      # MCP→Trino auth smoke. Exercises the PASSWORD authenticator + the
+      # service-principal X-Trino-User impersonation pattern mcp-trino
+      # uses (ADR 0022). A successful query confirms: the password.db
+      # file authenticator loaded openwebui_mcp_svc, the bcrypt hash
+      # matches the configured password, and OPA permits the principal
+      # to impersonate end users. Doesn't invoke mcp-trino itself - that
+      # adds OIDC-inbound + Go HTTP plumbing on top of the same path; if
+      # this passes and mcp-trino is Ready, the chain is sound. (A full
+      # mcp-trino → Trino smoke that mints + forwards a real chat-user
+      # JWT is deferred; the existing data-auth tests cover the broader
+      # JWT identity flow on the JWT authenticator.)
+      - name: 'MCP→Trino PASSWORD auth smoke'
+        if: matrix.side == 'analytics'
+        shell: bash
+        run: |
+          set -euo pipefail
+          PW=$(yq '.k3s_cluster.vars.trino_openwebui_mcp_svc_password' ansible/inventory.yaml)
+          sudo -E kubectl exec -n scout-analytics deployment/trino-coordinator -- \
+            curl -sk -f \
+              -u "openwebui_mcp_svc:${PW}" \
+              -H "X-Trino-User: testuser.jupyter" \
+              -H "Content-Type: text/plain" \
+              -X POST --data 'SELECT 1' \
+              https://localhost:8443/v1/statement \
+            | grep -q '"infoUri"'
       # Data authorization tests. Seeds a synthetic
       # delta.default.test_reports table, then exercises the end-to-end
       # AuthZ pipeline (Keycloak admin -> SPI listener -> MinIO bundle ->

--- a/ansible/roles/open-webui/defaults/main.yaml
+++ b/ansible/roles/open-webui/defaults/main.yaml
@@ -190,7 +190,14 @@ tool_server_connections:
     # the MCP tool itself works regardless, but the admin UI doesn't.
     path: '' # openapi-spec path; meaningless for MCP but required by the model
     key: null # API key for openapi/oauth tool servers; null for MCP-anonymous
-    auth_type: none
+    # system_oauth forwards the logged-in user's Keycloak access token as
+    # `Authorization: Bearer <token>` on every MCP call. mcp-trino validates
+    # the token, extracts preferred_username, and sets X-Trino-User on the
+    # outbound Trino call (TRINO_ENABLE_IMPERSONATION=true). Requires users
+    # to authenticate via OAuth (OWUI's OIDC login flow); locally-authed
+    # users have no IdP token to forward and the Authorization header is
+    # silently omitted.
+    auth_type: system_oauth
     config:
       enable: true
     info:

--- a/ansible/roles/trino/defaults/main.yaml
+++ b/ansible/roles/trino/defaults/main.yaml
@@ -15,6 +15,25 @@ trino_helm_chart_name: trino
 # loading the trino role.
 trino_keystore_password: trinokeystorepass # protects the in-pod keystore; not a network secret
 
+# === Password authenticator (interim) =======================================
+# File-based PASSWORD authenticator user map. Each entry becomes a
+# `username:bcrypt-hash` line in the password file the coordinator loads
+# (refreshed every 30s, no pod restart for add/rotate). The only entry is
+# `openwebui_mcp_svc` because the only HTTP-Basic-outbound client is
+# upstream `tuannvm/mcp-trino`; the structure is fixed, only the secret
+# value (trino_openwebui_mcp_svc_password) is inventory-provided.
+#
+# Removal trigger: when the custom MCP tool replaces upstream mcp-trino
+# (target: one quarter from ADR 0022 acceptance), drop this map entirely
+# and remove `PASSWORD` from `authenticationType` in values.yaml.j2.
+#
+# bcrypt hashing happens at deploy time via `htpasswd -bnBC 10` shelled
+# out from the Ansible controller (see password.db.j2). We don't use
+# Ansible's `password_hash` filter because passlib's bcrypt path breaks
+# on modern bcrypt >=4.x / Python 3.14. `htpasswd` ships on macOS
+# (built-in) and on Linux via apache2-utils / httpd-tools.
+trino_password_authenticator_users:
+  openwebui_mcp_svc: '{{ trino_openwebui_mcp_svc_password }}'
 trino_keycloak_jwks_url: '{{ keycloak_internal_url }}/realms/{{ keycloak_realm_name }}/protocol/openid-connect/certs'
 trino_keycloak_required_audience: trino
 trino_opa_endpoint: 'http://opa-trino.{{ trino_namespace }}:8181'

--- a/ansible/roles/trino/defaults/main.yaml
+++ b/ansible/roles/trino/defaults/main.yaml
@@ -15,25 +15,6 @@ trino_helm_chart_name: trino
 # loading the trino role.
 trino_keystore_password: trinokeystorepass # protects the in-pod keystore; not a network secret
 
-# === Password authenticator (interim) =======================================
-# File-based PASSWORD authenticator user map. Each entry becomes a
-# `username:bcrypt-hash` line in the password file the coordinator loads
-# (refreshed every 30s, no pod restart for add/rotate). The only entry is
-# `openwebui_mcp_svc` because the only HTTP-Basic-outbound client is
-# upstream `tuannvm/mcp-trino`; the structure is fixed, only the secret
-# value (trino_openwebui_mcp_svc_password) is inventory-provided.
-#
-# Removal trigger: when the custom MCP tool replaces upstream mcp-trino
-# (target: one quarter from ADR 0022 acceptance), drop this map entirely
-# and remove `PASSWORD` from `authenticationType` in values.yaml.j2.
-#
-# bcrypt hashing happens at deploy time via `htpasswd -bnBC 10` shelled
-# out from the Ansible controller (see password.db.j2). We don't use
-# Ansible's `password_hash` filter because passlib's bcrypt path breaks
-# on modern bcrypt >=4.x / Python 3.14. `htpasswd` ships on macOS
-# (built-in) and on Linux via apache2-utils / httpd-tools.
-trino_password_authenticator_users:
-  openwebui_mcp_svc: '{{ trino_openwebui_mcp_svc_password }}'
 trino_keycloak_jwks_url: '{{ keycloak_internal_url }}/realms/{{ keycloak_realm_name }}/protocol/openid-connect/certs'
 trino_keycloak_required_audience: trino
 trino_opa_endpoint: 'http://opa-trino.{{ trino_namespace }}:8181'

--- a/ansible/roles/trino/tasks/deploy.yaml
+++ b/ansible/roles/trino/tasks/deploy.yaml
@@ -69,6 +69,39 @@
         KEYSTORE_PASSWORD: '{{ trino_keystore_password }}'
         INTERNAL_SHARED_SECRET: '{{ trino_internal_shared_secret }}'
 
+# === Password authenticator (interim, ADR 0022) =============================
+# File-based PASSWORD authenticator. Service principals on
+# trino_password_authenticator_users (defined per-deployment in inventory)
+# get a bcrypted entry in password.db; clients authenticate with HTTP Basic.
+# JWT remains the primary auth mode — see values.yaml.j2 `authenticationType:
+# PASSWORD,JWT`. Trino tries each authenticator in declared order.
+#
+# Removal trigger: when the custom MCP tool replaces upstream mcp-trino
+# (target: next quarter), drop `trino_password_authenticator_users` entirely
+# and revert authenticationType to JWT-only.
+- name: Create Trino password-authenticator Secret
+  no_log: true
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: trino-password-auth
+        namespace: '{{ trino_namespace }}'
+      type: Opaque
+      stringData:
+        # Authenticator config: points at password.db, refreshes every 30s
+        # so adding/rotating an entry takes effect without a pod restart.
+        password-authenticator.properties: |
+          password-authenticator.name=file
+          file.password-file=/etc/trino/password-auth/password.db
+          file.refresh-period=30s
+        # password.db: `username:bcrypt-hash` per line. Rendered from a
+        # separate template (Jinja control flow at column 0 confuses the
+        # YAML parser when inlined here).
+        password.db: "{{ lookup('template', 'password.db.j2') }}"
+
 - name: Issue Trino TLS Certificate
   kubernetes.core.k8s:
     state: present

--- a/ansible/roles/trino/tasks/deploy.yaml
+++ b/ansible/roles/trino/tasks/deploy.yaml
@@ -70,15 +70,15 @@
         INTERNAL_SHARED_SECRET: '{{ trino_internal_shared_secret }}'
 
 # === Password authenticator (interim, ADR 0022) =============================
-# File-based PASSWORD authenticator. Service principals on
-# trino_password_authenticator_users (defined per-deployment in inventory)
-# get a bcrypted entry in password.db; clients authenticate with HTTP Basic.
-# JWT remains the primary auth mode — see values.yaml.j2 `authenticationType:
+# File-based PASSWORD authenticator. The sole entry is openwebui_mcp_svc,
+# bcrypted from trino_openwebui_mcp_svc_password at template render time
+# (see password.db.j2). Clients authenticate with HTTP Basic. JWT remains
+# the primary auth mode — see values.yaml.j2 `authenticationType:
 # PASSWORD,JWT`. Trino tries each authenticator in declared order.
 #
 # Removal trigger: when the custom MCP tool replaces upstream mcp-trino
-# (target: next quarter), drop `trino_password_authenticator_users` entirely
-# and revert authenticationType to JWT-only.
+# (target: next quarter), drop password.db.j2 + this Secret task + the
+# secretMount in values.yaml.j2 + revert authenticationType to JWT-only.
 - name: Create Trino password-authenticator Secret
   no_log: true
   kubernetes.core.k8s:

--- a/ansible/roles/trino/tasks/mcp.yaml
+++ b/ansible/roles/trino/tasks/mcp.yaml
@@ -2,12 +2,23 @@
 # Deploy Trino MCP server in the Trino namespace
 # Provides MCP interface to Trino for AI assistants
 
-- name: Clone or update mcp-trino repository
+# Always start from a clean checkout. A reused /tmp directory across runs
+# (partial fetch, .git without HEAD, root-owned files from an earlier
+# elevated run, anything) trips up ansible.builtin.git's clone-or-update
+# heuristic. The repo is small; re-cloning every install is cheaper than
+# the failure modes of trying to reuse the tree.
+- name: Remove any prior mcp-trino chart checkout
+  ansible.builtin.file:
+    path: '{{ mcp_trino_chart_path }}'
+    state: absent
+  delegate_to: localhost
+  run_once: true
+
+- name: Clone mcp-trino repository
   ansible.builtin.git:
     repo: '{{ mcp_trino_repo_url }}'
     dest: '{{ mcp_trino_chart_path }}'
     version: '{{ mcp_trino_repo_version }}'
-    update: true
   delegate_to: localhost
   run_once: true
 
@@ -24,3 +35,39 @@
     helm_chart_ref: '{{ mcp_trino_chart_path }}/charts/mcp-trino'
     helm_chart_namespace: '{{ trino_namespace }}'
     helm_chart_values: '{{ mcp_trino_helm_chart_values }}'
+
+- name: Restrict mcp-trino ingress to Open WebUI
+  # The X-Trino-User impersonation pattern trusts that the inbound OIDC token
+  # came from the chat user via Open WebUI's system_oauth tool forwarding.
+  # Without this NetworkPolicy, any in-cluster pod could forge a forwarded
+  # token (or call mcp-trino with the right ServiceAccount JWT) and have the
+  # MCP impersonate arbitrary users on the outbound Trino call. Egress is
+  # unrestricted (mcp-trino needs Keycloak JWKS + Trino HTTPS + DNS).
+  # Mirrors the chart-shipped Voila ingress NetworkPolicy.
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: mcp-trino-ingress
+        namespace: '{{ trino_namespace }}'
+        labels:
+          app.kubernetes.io/name: mcp-trino
+      spec:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: mcp-trino
+        policyTypes:
+          - Ingress
+        ingress:
+          - from:
+              - namespaceSelector:
+                  matchLabels:
+                    kubernetes.io/metadata.name: '{{ chatbot_namespace }}'
+                podSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: open-webui
+            ports:
+              - protocol: TCP
+                port: 8080

--- a/ansible/roles/trino/templates/mcp_trino_values.yaml.j2
+++ b/ansible/roles/trino/templates/mcp_trino_values.yaml.j2
@@ -1,4 +1,19 @@
 # MCP Trino Helm values
+#
+# Connection to Trino uses HTTP Basic auth as the service principal
+# `openwebui_mcp_svc` (rendered into Trino's password file at deploy time
+# via trino_password_authenticator_users — see roles/trino/tasks/deploy.yaml).
+# Per-chat-user AuthZ is enforced via X-Trino-User impersonation: mcp-trino
+# reads the inbound OIDC user's preferred_username and sets the header on
+# the outbound Trino call. OPA's impersonation allow rule permits
+# openwebui_mcp_svc to impersonate any user (ADR 0022).
+#
+# This is the interim wiring against upstream `tuannvm/mcp-trino` which
+# only supports HTTP Basic outbound. The custom MCP tool (target: one
+# quarter from ADR 0022 acceptance) will replace this with JWT outbound;
+# at that point the PASSWORD authenticator in Trino + the trino.password
+# below + this whole values template gets dropped.
+
 replicaCount: 1
 
 image:
@@ -6,10 +21,17 @@ image:
 
 trino:
   host: trino
-  port: 8080
-  scheme: http
-  ssl: false
-  user: '{{ trino_user }}'
+  port: {{ trino_https_port }}
+  scheme: https
+  ssl: true
+  # CA verification against Scout's internal CA — see SSL_CERT_FILE in
+  # extraEnvVars below. mcp-trino is Go and respects SSL_CERT_FILE for
+  # the system trust pool.
+  sslInsecure: false
+  user: openwebui_mcp_svc
+  # Plaintext is rendered into a Helm-managed Secret (TRINO_PASSWORD).
+  # Matches the bcrypt entry in Trino's password.db. Inventory-only.
+  password: '{{ trino_openwebui_mcp_svc_password }}'
   catalog: delta
   schema: default
   allowWriteQueries: false
@@ -18,6 +40,61 @@ trino:
     catalogs: [delta]
     schemas: [delta.default]
     tables: []
+
+  # Inbound OIDC: mcp-trino validates the chat user's Keycloak token and
+  # extracts their preferred_username for impersonation. Open WebUI's MCP
+  # tool integration must forward the user's token; without it the impl
+  # falls back to anonymous and impersonation can't fire.
+  #
+  # provider=okta is a label, not actual Okta-specific logic — oauth-mcp-proxy
+  # v1.0.1's `okta`/`google`/`azure` cases all route to the same generic
+  # OIDCValidator (config.go:73 + 174). There's no `oidc` / `keycloak` /
+  # generic value in v1.0.1, so we pick one of the OIDC labels arbitrarily.
+  oauth:
+    enabled: true
+    mode: native
+    provider: okta
+    oidc:
+      issuer: '{{ keycloak_realm_url }}'
+      # The chat user's access token (forwarded by OWUI via
+      # auth_type: system_oauth) gets the aud=mcp-trino claim from the
+      # `mcp-trino-audience` client scope attached to the open-webui
+      # Keycloak client. Without that explicit audience mapper, Keycloak
+      # doesn't put a deterministic aud on the token and oauth-mcp-proxy's
+      # validation fails silently — every chat query then hits Trino as
+      # the service account with no row-filter attrs (zero rows).
+      audience: mcp-trino
+      clientId: openwebui_mcp_svc
+      clientSecret: '{{ keycloak_openwebui_mcp_svc_client_secret }}'
+
+# Per-request X-Trino-User impersonation. Field=username pulls the
+# OIDC token's preferred_username claim; matches what our OPA policy
+# expects in input.context.identity.user.
+extraEnvVars:
+  - name: TRINO_ENABLE_IMPERSONATION
+    value: 'true'
+  - name: TRINO_IMPERSONATION_FIELD
+    value: username
+  # Trust Scout's internal CA so the HTTPS connection to Trino verifies.
+  # mcp-trino is Go; SSL_CERT_FILE is Go's standard way to override the
+  # system trust pool with a single PEM file.
+  - name: SSL_CERT_FILE
+    value: /etc/trino-ca/ca.crt
+
+# Mount Trino's CA from the cert-manager-issued Secret (same Secret
+# Trino itself uses for its server cert).
+extraVolumes:
+  - name: trino-ca
+    secret:
+      secretName: trino-tls
+      items:
+        - key: ca.crt
+          path: ca.crt
+
+extraVolumeMounts:
+  - name: trino-ca
+    mountPath: /etc/trino-ca
+    readOnly: true
 
 resources: {{ mcp_trino_resources_default | combine(mcp_trino_resources | default({}), recursive=true) | to_json }}
 

--- a/ansible/roles/trino/templates/mcp_trino_values.yaml.j2
+++ b/ansible/roles/trino/templates/mcp_trino_values.yaml.j2
@@ -1,8 +1,8 @@
 # MCP Trino Helm values
 #
 # Connection to Trino uses HTTP Basic auth as the service principal
-# `openwebui_mcp_svc` (rendered into Trino's password file at deploy time
-# via trino_password_authenticator_users — see roles/trino/tasks/deploy.yaml).
+# `openwebui_mcp_svc` (rendered into Trino's password.db at deploy time
+# from trino_openwebui_mcp_svc_password — see roles/trino/tasks/deploy.yaml).
 # Per-chat-user AuthZ is enforced via X-Trino-User impersonation: mcp-trino
 # reads the inbound OIDC user's preferred_username and sets the header on
 # the outbound Trino call. OPA's impersonation allow rule permits

--- a/ansible/roles/trino/templates/password.db.j2
+++ b/ansible/roles/trino/templates/password.db.j2
@@ -1,0 +1,15 @@
+{#- Password file consumed by Trino's `file` password authenticator. One
+    `username:bcrypt-hash` line per entry in trino_password_authenticator_users.
+
+    bcrypt is computed via `htpasswd -bnBC 10`, shelled out from the
+    Ansible controller. We don't use Ansible's `password_hash` filter
+    because passlib's bcrypt path breaks on modern bcrypt >=4.x / Python
+    3.14 (`error reading bcrypt version`). htpasswd ships on macOS
+    (/usr/sbin/htpasswd) and on Linux via apache2-utils / httpd-tools —
+    the only required-tools list Scout adds with this change.
+
+    `quote` filter protects against passwords containing shell metacharacters.
+-#}
+{% for user, plaintext in trino_password_authenticator_users.items() -%}
+{{ lookup('pipe', 'htpasswd -bnBC 10 ' ~ (user | quote) ~ ' ' ~ (plaintext | quote)) }}
+{% endfor %}

--- a/ansible/roles/trino/templates/password.db.j2
+++ b/ansible/roles/trino/templates/password.db.j2
@@ -1,15 +1,16 @@
-{#- Password file consumed by Trino's `file` password authenticator. One
-    `username:bcrypt-hash` line per entry in trino_password_authenticator_users.
+{#- Password file consumed by Trino's `file` password authenticator. Single
+    `username:bcrypt-hash` entry for openwebui_mcp_svc — the only HTTP-Basic-
+    outbound client today (upstream tuannvm/mcp-trino). When the bespoke MCP
+    tool ships and speaks JWT outbound, this file, the password-authenticator
+    Secret task, and `PASSWORD` in `authenticationType` all come out together.
 
-    bcrypt is computed via `htpasswd -bnBC 10`, shelled out from the
-    Ansible controller. We don't use Ansible's `password_hash` filter
-    because passlib's bcrypt path breaks on modern bcrypt >=4.x / Python
-    3.14 (`error reading bcrypt version`). htpasswd ships on macOS
+    bcrypt is computed via `htpasswd -bnBC 10`, shelled out from the Ansible
+    controller. We don't use Ansible's `password_hash` filter because
+    passlib's bcrypt path breaks on modern bcrypt >=4.x / Python 3.14
+    (`error reading bcrypt version`). htpasswd ships on macOS
     (/usr/sbin/htpasswd) and on Linux via apache2-utils / httpd-tools —
-    the only required-tools list Scout adds with this change.
+    the only required-tools list Scout adds with this feature.
 
     `quote` filter protects against passwords containing shell metacharacters.
 -#}
-{% for user, plaintext in trino_password_authenticator_users.items() -%}
-{{ lookup('pipe', 'htpasswd -bnBC 10 ' ~ (user | quote) ~ ' ' ~ (plaintext | quote)) }}
-{% endfor %}
+{{ lookup('pipe', 'htpasswd -bnBC 10 openwebui_mcp_svc ' ~ (trino_openwebui_mcp_svc_password | quote)) }}

--- a/ansible/roles/trino/templates/values.yaml.j2
+++ b/ansible/roles/trino/templates/values.yaml.j2
@@ -7,10 +7,14 @@ server:
     query:
       # Cluster-wide max memory = workers × worker_heap × per_node_fraction
       maxMemory: "{{ trino_worker_max_heap | multiply_memory(trino_worker_count * trino_per_node_query_memory_fraction) }}B"
-    # JWT over HTTPS. User JWTs flow from Jupyter; service-account JWTs
-    # from Superset/Voila. Trino validates against Keycloak's JWKS and
-    # requires `aud=trino`.
-    authenticationType: JWT
+    # Dual-mode auth. JWT is the primary path (user JWTs from Jupyter,
+    # service-account JWTs from Superset/Voila); PASSWORD is the interim
+    # accommodation for upstream `tuannvm/mcp-trino`, which only supports
+    # HTTP Basic outbound (see `trino_password_authenticator_users`
+    # below and ADR 0022). When the custom MCP tool ships and starts
+    # speaking JWT, the password authenticator and the PASSWORD entry
+    # on this line are removed.
+    authenticationType: PASSWORD,JWT
     https:
       enabled: true
       port: {{ trino_https_port }}
@@ -18,13 +22,16 @@ server:
         path: /etc/trino/tls/keystore.p12
   # Coordinator-only config. JWT settings + keystore password aren't
   # recognized by workers (they don't serve auth or HTTPS), so the chart
-  # writes them only to the coordinator's config.properties.
+  # writes them only to the coordinator's config.properties. The file-
+  # based PASSWORD authenticator is also coordinator-only — workers
+  # don't terminate client auth.
   coordinatorExtraConfig: |
     http-server.authentication.jwt.key-file={{ trino_keycloak_jwks_url }}
     http-server.authentication.jwt.required-audience={{ trino_keycloak_required_audience }}
     http-server.authentication.jwt.principal-field=preferred_username
     http-server.authentication.jwt.user-mapping.pattern=(?:service-account-)?(.+)
     http-server.https.keystore.key=${ENV:KEYSTORE_PASSWORD}
+    password-authenticator.config-files=/etc/trino/password-auth/password-authenticator.properties
 
 # Service exposes both ports per the chart's design:
 #   - 8080/http: worker→coordinator internal-communication (shared-secret-
@@ -64,10 +71,19 @@ accessControl:
 # chart mounts on every pod (coordinator + workers); workers don't read
 # keystore.p12 since internal-comm runs over HTTP, but the mount is
 # harmless and keeps the values structure simple.
+#
+# trino-password-auth: contains password-authenticator.properties +
+# password.db for the file-based PASSWORD authenticator. Coordinator
+# reads it on startup and again every `file.refresh-period` so adding
+# / rotating a service principal doesn't need a pod restart. Mount is
+# also harmless on workers (they don't terminate client auth).
 secretMounts:
   - name: trino-tls
     secretName: trino-tls
     path: /etc/trino/tls
+  - name: trino-password-auth
+    secretName: trino-password-auth
+    path: /etc/trino/password-auth
 
 {% if aws_deployment %}
 serviceAccount:

--- a/ansible/roles/trino/templates/values.yaml.j2
+++ b/ansible/roles/trino/templates/values.yaml.j2
@@ -10,10 +10,10 @@ server:
     # Dual-mode auth. JWT is the primary path (user JWTs from Jupyter,
     # service-account JWTs from Superset/Voila); PASSWORD is the interim
     # accommodation for upstream `tuannvm/mcp-trino`, which only supports
-    # HTTP Basic outbound (see `trino_password_authenticator_users`
-    # below and ADR 0022). When the custom MCP tool ships and starts
-    # speaking JWT, the password authenticator and the PASSWORD entry
-    # on this line are removed.
+    # HTTP Basic outbound (sole entry: openwebui_mcp_svc rendered from
+    # trino_openwebui_mcp_svc_password; ADR 0022). When the custom MCP
+    # tool ships and starts speaking JWT, the password authenticator and
+    # the PASSWORD entry on this line are removed.
     authenticationType: PASSWORD,JWT
     https:
       enabled: true

--- a/docs/internal/adr/0022-trino-auth-and-impersonation.md
+++ b/docs/internal/adr/0022-trino-auth-and-impersonation.md
@@ -163,7 +163,7 @@ Use `http-server.authentication.type=PASSWORD` only; every client gets a Trino p
 
 Add a NetworkPolicy in front of `mcp-trino` allowing ingress only from the Open WebUI pod, on the theory that a network-layer gate makes forge-`X-Trino-User`-from-another-pod attacks go away.
 
-**Rejected**: the MCP already validates the inbound Keycloak OIDC token before honoring `X-Trino-User`, so requests without a valid Keycloak-signed token are rejected at the MCP. Token-forgery resistance comes from Keycloak's signing key, not from network position.
+**Accepted as defense-in-depth** (revised post-review). The MCP's inbound OIDC validation is still the primary gate — token-forgery resistance comes from Keycloak's signing key, not from network position. But the NetworkPolicy is cheap and consistent with the Voila ingress policy (which has the same shape for a structurally-similar concern), and it gives an independent regression-testable second layer if an upstream `tuannvm/mcp-trino` change ever weakens the OIDC validation. The network-policy test suite asserts both directions: open-webui-labeled pods reach `mcp-trino:8080`; other in-cluster pods don't.
 
 ### Sharing one service principal across all impersonation-pattern clients
 

--- a/tests/data-authorization/authz-tests/job.yaml
+++ b/tests/data-authorization/authz-tests/job.yaml
@@ -65,6 +65,16 @@ spec:
                 secretKeyRef:
                   name: data-authz-test-creds
                   key: SUPERSET_SVC_CLIENT_SECRET
+            # PASSWORD-auth scenario (PR6): mcp-trino's HTTP-Basic outbound
+            # principal. Optional — run.sh skips scenario 10 if unset, so
+            # this Job runs unchanged against deployments without PR6's
+            # password-authenticator Secret.
+            - name: MCP_SVC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: data-authz-test-creds
+                  key: MCP_SVC_PASSWORD
+                  optional: true
             - name: OPA_URL
               value: http://opa-trino.scout-analytics:8181
             - name: TRINO_URL

--- a/tests/data-authorization/authz-tests/run.sh
+++ b/tests/data-authorization/authz-tests/run.sh
@@ -28,7 +28,7 @@
 #   stdout: a streaming log of each scenario + assertion
 #   exit:   0 if all pass, non-zero on first failure
 #
-# Test scenarios (9):
+# Test scenarios (10):
 #   1. enabled=true, allowed_facilities=["ABCHOSP1"], allowed_modalities=["*"]
 #      -> COUNT(*) FROM test_reports = 3   (only ABCHOSP1 rows)
 #   2. allowed_facilities=["*"]
@@ -46,6 +46,12 @@
 #         table-not-found but NOT on permission-denied)
 #   8. enabled=false
 #      -> any SELECT denied at /allow
+#   9. not in scout-user group
+#      -> any SELECT denied at /allow
+#   10. PASSWORD auth + X-Trino-User impersonation (PR6, optional —
+#       requires MCP_SVC_PASSWORD env)
+#      -> COUNT(*) FROM test_reports = 3   (same as scenario 1 but
+#         exercising HTTP Basic instead of Bearer JWT)
 
 set -euo pipefail
 
@@ -273,6 +279,48 @@ trino_query() {
     done
 }
 
+# Same as trino_query but authenticates via HTTP Basic against Trino's
+# PASSWORD authenticator (ADR 0022) instead of a Bearer JWT. This is
+# the path mcp-trino uses against the dual-auth listener — its outbound
+# is HTTP-Basic-only. Used by the PR6 scenario below to exercise the
+# PASSWORD path end-to-end: bcrypt match in password.db, OPA
+# impersonation allow, row filter, Delta connector — the whole chain
+# with everything else identical to the JWT scenarios above.
+trino_query_via_password() {
+    local sql=$1 user=$2
+    local next response data
+
+    response=$(curl -fsS "${CURL_CA_OPTS[@]}" -X POST "$TRINO_URL/v1/statement" \
+        -u "openwebui_mcp_svc:$MCP_SVC_PASSWORD" \
+        -H "X-Trino-User: $user" \
+        -H "X-Trino-Catalog: delta" \
+        -H "X-Trino-Schema: default" \
+        --data-binary "$sql")
+
+    data='[]'
+    while true; do
+        local page_data
+        page_data=$(echo "$response" | jq -c '.data // []')
+        if [[ "$page_data" != "[]" && "$page_data" != "null" ]]; then
+            data=$(jq -cn --argjson a "$data" --argjson b "$page_data" '$a + $b')
+        fi
+        local err
+        err=$(echo "$response" | jq -r '.error.message // empty')
+        if [[ -n "$err" ]]; then
+            echo "ERROR: $err" >&2
+            return 1
+        fi
+        next=$(echo "$response" | jq -r '.nextUri // empty')
+        if [[ -z "$next" ]]; then
+            echo "$data"
+            return 0
+        fi
+        response=$(curl -fsS "${CURL_CA_OPTS[@]}" "$next" \
+            -u "openwebui_mcp_svc:$MCP_SVC_PASSWORD" \
+            -H "X-Trino-User: $user")
+    done
+}
+
 # Variant that expects the query to fail (deny). Returns 0 if Trino
 # refused (HTTP error or error in response body), 1 if the query
 # succeeded unexpectedly.
@@ -441,6 +489,26 @@ fi
 # Restore membership so subsequent test runs against the same Keycloak
 # instance start from a clean state.
 add_user_to_group "$USER_ID" "$SCOUT_USER_GROUP_ID"
+
+# --- Scenario 10: PASSWORD auth + impersonation (PR6) -----------------------
+# Exercises the dual-auth listener's PASSWORD path that mcp-trino uses
+# (HTTP Basic + X-Trino-User), end to end: bcrypt match in password.db,
+# OPA permits openwebui_mcp_svc to impersonate, row filter applies.
+# Skipped if MCP_SVC_PASSWORD isn't injected (deploys without the
+# password-authenticator Secret task running, e.g. trino role pre-PR6).
+if [[ -n "${MCP_SVC_PASSWORD:-}" ]]; then
+    log "scenario 10: PASSWORD-auth + X-Trino-User -> 3 ABCHOSP1 rows"
+    set_user_state "$USER_ID" true '{"allowed_facilities":["ABCHOSP1"],"allowed_modalities":["*"]}'
+    wait_for_bundle '.result.allowed_facilities[0] == "ABCHOSP1"' "$PROPAGATION_TIMEOUT"
+    count=$(trino_query_via_password "SELECT COUNT(*) AS c FROM test_reports" "$TEST_USER" | jq -r '.[0][0]')
+    if [[ "$count" == "3" ]]; then
+        ok "PASSWORD+impersonation: row filter sees 3 ABCHOSP1 rows"
+    else
+        fail "PASSWORD+impersonation expected 3 rows, got $count"
+    fi
+else
+    log "scenario 10 skipped: MCP_SVC_PASSWORD not set"
+fi
 
 # ---------------------------------------------------------------------------
 # Cleanup

--- a/tests/network/network-policy-tests.sh
+++ b/tests/network/network-policy-tests.sh
@@ -45,7 +45,10 @@ VOILA_PORT=8866
 VOILA_PATH=/
 MCP_HOST=mcp-trino.scout-analytics
 MCP_PORT=8080
-MCP_PATH=/health
+# /status is the chart's own startup/liveness/readiness probe path
+# (mcp-trino chart values.yaml -> healthCheck.*Probe.httpGet.path).
+# The OWUI README's `/health` reference is stale.
+MCP_PATH=/status
 
 # Test groups can be filtered via --include for split CI runs where not
 # every target service is deployed. Empty = run all groups.

--- a/tests/network/network-policy-tests.sh
+++ b/tests/network/network-policy-tests.sh
@@ -43,15 +43,20 @@ OPA_PATH=/health
 VOILA_HOST=voila.scout-analytics
 VOILA_PORT=8866
 VOILA_PATH=/
+MCP_HOST=mcp-trino.scout-analytics
+MCP_PORT=8080
+MCP_PATH=/health
 
 # Test groups can be filtered via --include for split CI runs where not
 # every target service is deployed. Empty = run all groups.
-#   trino-rw       — works wherever the trino role has been run (deploys
-#                    trino-rw + its NetworkPolicy). Both smoke-test sides.
-#   opa-trino      — needs OPA + trino-analytics. Both smoke-test sides
-#                    (trino role deploys both).
-#   voila-ingress  — needs the voila Service to exist for the target URL
-#                    to resolve. Notebook side only.
+#   trino-rw          — works wherever the trino role has been run (deploys
+#                       trino-rw + its NetworkPolicy). Both smoke-test sides.
+#   opa-trino         — needs OPA + trino-analytics. Both smoke-test sides
+#                       (trino role deploys both).
+#   voila-ingress     — needs the voila Service to exist for the target URL
+#                       to resolve. Notebook side only.
+#   mcp-trino-ingress — needs the mcp-trino Service. Notebook side only
+#                       (chat is part of that smoke half).
 INCLUDE_GROUPS=""
 
 while [[ $# -gt 0 ]]; do
@@ -65,12 +70,13 @@ while [[ $# -gt 0 ]]; do
 Usage: $(basename "$0") [--include <groups>]
 
   --include <groups>   Comma-separated test groups to run (default: all).
-                       Available: trino-rw, opa-trino, voila-ingress.
+                       Available: trino-rw, opa-trino, voila-ingress,
+                       mcp-trino-ingress.
 
 Examples:
   $(basename "$0")
   $(basename "$0") --include trino-rw
-  $(basename "$0") --include trino-rw,opa-trino,voila-ingress
+  $(basename "$0") --include trino-rw,opa-trino,voila-ingress,mcp-trino-ingress
 EOF
       exit 0
       ;;
@@ -158,6 +164,19 @@ fi
 if include_group "voila-ingress"; then
   queue_test voila-bypass-attack    scout-analytics 000 ''                                "$VOILA_HOST" "$VOILA_PORT" "$VOILA_PATH"
   queue_test voila-traefik-allowed  kube-system     200 'app.kubernetes.io/name=traefik'  "$VOILA_HOST" "$VOILA_PORT" "$VOILA_PATH"
+fi
+
+# mcp-trino ingress (port 8080).
+# mcp-trino's per-user impersonation trust model depends on this NetworkPolicy:
+# only Open WebUI pods should reach mcp-trino directly. A random in-cluster
+# pod hitting :8080 could either forge the Bearer (if it has any valid
+# realm-issued JWT) or skip auth entirely if mcp-trino's OIDC validator is
+# bypassed; either way it could ask the MCP to impersonate arbitrary users
+# on the outbound Trino call.
+if include_group "mcp-trino-ingress"; then
+  queue_test mcp-bypass-attack       scout-analytics 000 ''                                "$MCP_HOST" "$MCP_PORT" "$MCP_PATH"
+  queue_test mcp-extractor-rando     scout-extractor 000 ''                                "$MCP_HOST" "$MCP_PORT" "$MCP_PATH"
+  queue_test mcp-owui-allowed        scout-analytics 200 'app.kubernetes.io/name=open-webui' "$MCP_HOST" "$MCP_PORT" "$MCP_PATH"
 fi
 
 if [ "${#NAMES[@]}" -eq 0 ]; then


### PR DESCRIPTION
## Description

### Product
N/A - Sixth slice of the Trino per-user AuthZ feature: **Open WebUI MCP joins the impersonation path.** Chat queries now run against Trino as the logged-in user.

### Technical
- **Trino** runs dual-auth (`PASSWORD,JWT`) on its HTTPS listener. JWT is the primary path; PASSWORD is the interim accommodation for upstream `tuannvm/mcp-trino`, which only speaks HTTP Basic outbound. File-based authenticator with a single `openwebui_mcp_svc` entry.
- **`mcp-trino`** chart values: HTTPS + Basic outbound to Trino, `TRINO_ENABLE_IMPERSONATION=true` + `TRINO_IMPERSONATION_FIELD=username` to set `X-Trino-User` from the inbound token's `preferred_username`, `SSL_CERT_FILE` + `trino-ca` mount for Trino TLS verification, OIDC inbound (`oauth.enabled=true`, `audience=mcp-trino`, `clientId=openwebui_mcp_svc`).
- **Open WebUI**: `tool_server_connections[mcp].auth_type` flips from `none` to `system_oauth`. OWUI forwards the logged-in user's Keycloak access token as `Authorization: Bearer` on every MCP call.
- **NetworkPolicy** on `mcp-trino`: ingress restricted to `app.kubernetes.io/name=open-webui` pods in `scout-analytics`. Defense-in-depth behind the OIDC validation; mirrors the Voila ingress policy shape. ADR 0022's "rejected" verdict on this NP is reframed to "accepted as defense-in-depth."

Design rationale and the broader picture are in ADRs 0020–0023, see #402.

## Type of change
- [ ] Work behind a feature flag
- [x] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [x] Test update

## Impact

### Security

##### Authorization
Adds `PASSWORD` to Trino's authenticator stack for one client only (`openwebui_mcp_svc`), used exclusively by `mcp-trino`. OPA's `ImpersonateUser` rule already permits the three service principals (`superset_svc`, `voila_svc`, `openwebui_mcp_svc`) to impersonate any user; the actual access stays governed by the impersonated user's Keycloak attributes (#406). No new OPA rules.

##### Appsec
- The `openwebui_mcp_svc` password lives in a Helm-managed Secret on `mcp-trino` and in `trino-password-auth` on Trino. Bcrypt-hashed in `password.db`; plaintext is never on disk in Trino.
- `mcp-trino`'s OIDC validation is the primary gate against forged `X-Trino-User`. NetworkPolicy is the second layer.
- `auth_type: system_oauth` only forwards the IdP token from OAuth-authenticated OWUI users. 
- `tuannvm/mcp-trino` runs as a privileged-looking service principal but has no JWT-issuance capabilities of its own. Container compromise = service-principal compromise (equivalent to anyone-can-be-anyone within the OPA-policy guardrails). This is a weak link that we plan to replace.

### Performance
N/A

### Data
N/A

### Backward compatibility
Compatible

## Testing
- Network policy tests (`tests/network/network-policy-tests.sh`) cover the new `mcp-trino-ingress` group: open-webui-labeled pods reach `mcp-trino:8080/status`; other in-cluster pods don't.
- New scenario in the data-auth `run.sh`: authenticates to Trino as `openwebui_mcp_svc` via HTTP Basic, impersonates the test user, queries `test_reports`, expects 3 rows back (the user's ABCHOSP1-only facility scope). 
- **Not asserted by CI**: the OWUI → mcp-trino arrow itself (OIDC token-forwarding by OWUI's `system_oauth`, OIDC inbound validation in mcp-trino). The Trino-side of the chain is covered end-to-end; the chat-side leg needs a synthetic OWUI session + tool-call to exercise, deferred to a follow-up.

## Note for reviewers
**Stacked on top of #412** — base is `rbac/5-jupyter` until that merges.

**Interim accommodation, removal trigger documented.** The PASSWORD authenticator, `password.db`, and the `openwebui_mcp_svc` static password exist solely because upstream `tuannvm/mcp-trino` speaks HTTP Basic outbound only. When the bespoke MCP tool ships and sends a JWT to Trino, the whole layer comes out.

**ADR 0022 amended.** "NetworkPolicy on the MCP" moves from Rejected to Accepted (defense-in-depth). The ADR's primary-gate logic (OIDC validation; token-forgery resistance via Keycloak's signing key) stays unchanged — the NP is the regression-testable second layer.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [x] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
