### PR TITLE
open-webui: route RAG embeddings through Ollama (skip HF Hub)

### DIFF
--- a/ansible/roles/open-webui/templates/values.yaml.j2
+++ b/ansible/roles/open-webui/templates/values.yaml.j2
@@ -163,6 +163,21 @@ extraEnvFrom:
 # Note: WEBUI_SECRET_KEY and OAUTH_CLIENT_SECRET are loaded from secret above
 # REDIS_URL and WEBSOCKET_REDIS_URL are loaded from secret via valueFrom below
 extraEnvVars:
+  # Route RAG embeddings through Ollama instead of OWUI's default
+  # sentence-transformers (which fetches the model from HuggingFace
+  # Hub on first startup). Air-gapped clusters degrade silently
+  # because pod DNS to huggingface.co fails fast, but internet-
+  # connected clusters (CI) succeed slowly: ~250MB of model weights
+  # over 2-3 minutes, racing the open-webui-bootstrap Job's signin
+  # retry budget and causing atomic Helm rollback. Scout doesn't
+  # actively use RAG (Scout Explorer's function_calling: native
+  # bypasses OWUI's RAG auto-injection per the role README), so
+  # the engine choice is functionally moot — but pointing at Ollama
+  # prevents the HF lookup entirely and makes startup deterministic
+  # everywhere.
+  - name: RAG_EMBEDDING_ENGINE
+    value: 'ollama'
+
   # Disable local authentication (email/password)
   - name: ENABLE_SIGNUP
     value: 'false'


### PR DESCRIPTION
## Description

### Product
N/A — operational fix to OWUI startup. Air-gapped prod was relying on DNS-fail-fast to skip an unintended HuggingFace Hub model download; internet-connected clusters (CI, internet-reachable dev) succeed slowly, race the bootstrap Job's retry budget, and trigger atomic Helm rollback.

### Technical
- **Adds one env var** to OWUI's extraEnvVars: `RAG_EMBEDDING_ENGINE=ollama`. OWUI 0.9.5's default engine is sentence-transformers, which fetches its model from HF Hub on first startup (~250 MB over 30 files). Routing through Ollama (already running in Scout) prevents the HF lookup entirely.
- **Scout doesn't actively use RAG.** Scout Explorer's `function_calling=native` bypasses OWUI's RAG auto-injection per `roles/open-webui/README.md`. The engine choice is functionally moot today; this just makes startup deterministic.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security
N/A — no auth path changes, no new dependencies, no new network reach (Ollama is already in-cluster).

### Performance
- **Air-gapped prod**: unchanged (~1s startup, was DNS-fail-fast).
- **Internet-connected dev/CI**: ~2-3 min faster startup (skips the HF download).

### Data
N/A.

### Backward compatibility
If a future flow needs sentence-transformers RAG (or any other HF-Hub-fetched model), this env var would need to be removed or overridden. Scout doesn't use RAG today.

## Testing
- helm template renders cleanly with the new env var.
- The bug repros consistently in PR #411 / #412 CI today; the fix should land them green when merged forward into trino-rbac.

## Note for reviewers
**Targeting main, not the trino-rbac stack.** The bug exists on main too — air-gapped prod was lucky that DNS failure was fast enough — so the fix lands here and gets merged forward through trino-rbac into rbac/4-voila / rbac/5-jupyter / rbac/6-mcp.
