### PR TITLE
Pin sphinxawesome-theme to exclude broken 6.0.3 (unblock RTD builds)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx
 sphinx-rtd-theme
-sphinxawesome-theme
+sphinxawesome-theme!=6.0.3  # 6.0.3 wheel is broken: ships no sphinxawesome_theme module
 myst_parser[sphinx]
 sphinxcontrib-openapi


### PR DESCRIPTION
## Description

### Product
N/A

### Technical
Read the Docs builds are failing on every PR because `sphinxawesome-theme` **6.0.3** (released 2026-06-10) ships a **broken wheel** — it contains only `.dist-info` metadata and no actual module (3 KB vs ~377 KB for prior versions). `pip install` succeeds but Sphinx then dies at startup:

```
sphinx.errors.ExtensionError: Could not import extension sphinxawesome_theme
(exception: No module named 'sphinxawesome_theme')
```

Since `readthedocs.yaml` sets `fail_on_warning: true`, the build fails. Our `docs/requirements.txt` left the theme unpinned, so RTD pulled the broken latest.

Upstream cause: a `src/` layout migration with a stale Hatch wheel-packages path (kai687/sphinxawesome-theme#2421, fix in #2422). The fix is **merged but not yet released**, and 6.0.3 is **not yanked**, so unpinned installs still break.

Fix: pin `sphinxawesome-theme!=6.0.3`. Resolves to 6.0.2 today and auto-adopts the fixed 6.0.4 when published.

## Type of change
- [x] Bug fix

## Impact

### Security
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
None — docs-only build dependency.

## Testing
Reproduced the failure (build 33075763 / PR #427) and confirmed a clean `sphinx-build -T -W --keep-going` (matching RTD flags) succeeds with the pin applied, using a fresh `--refresh` install.

## Note for reviewers
Low-impact, mildly urgent — unblocks docs builds. Once upstream releases the fix, the `!=6.0.3` pin can stay (harmless) or be dropped.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)