### PR TITLE
Bump open-webui chart to ~14.8.0 and OWUI to 0.9.6 to enable auto-login

### DIFF
--- a/ansible/group_vars/all/versions.yaml
+++ b/ansible/group_vars/all/versions.yaml
@@ -104,18 +104,19 @@ jupyter_helm_chart_version: ~4.3.5
 # running Pod's image at deploy time (see configure_admin.yaml) so it stays
 # in lockstep with the chart's appVersion without a separate pin.
 #
-# Currently pinned to ~14.6.0 (appVersion 0.9.5): upstream refactor (OWUI
+# Currently pinned to ~14.8.0 (appVersion 0.9.6): upstream refactor (OWUI
 # commit 45e49d33e, Apr 2026) moved tool-call results from a `result="..."`
 # attribute on the <details> tag into the body, and the new body-content
 # rendering path doesn't display results in the chat UI even though they
 # reach the LLM. Worked around by the `tool_result_attr_filter` Function
-# (see ansible/roles/open-webui/defaults/main.yaml). When Renovate proposes
-# a bump that advances appVersion past 0.9.5, verify the tool-call Output
-# panel renders correctly without the filter — if upstream has fixed it,
-# delete the filter source + the role's inventory entry + the chart payload
-# + this note.
+# (see ansible/roles/open-webui/defaults/main.yaml). Confirmed still broken
+# in 0.9.6: ToolCallDisplay.svelte and MarkdownTokens.svelte are byte-
+# identical between v0.9.5 and v0.9.6. When Renovate proposes a bump that
+# advances appVersion past 0.9.6, verify the tool-call Output panel renders
+# correctly without the filter — if upstream has fixed it, delete the filter
+# source + the role's inventory entry + the chart payload + this note.
 # renovate: datasource=helm registryUrl=https://helm.openwebui.com/ depName=open-webui
-open_webui_helm_chart_version: ~14.6.0
+open_webui_helm_chart_version: ~14.8.0
 # renovate: datasource=docker depName=ollama/ollama
 ollama_image_tag: 0.24.0
 

--- a/ansible/roles/open-webui/README.md
+++ b/ansible/roles/open-webui/README.md
@@ -133,7 +133,7 @@ kubectl logs -n scout-analytics -l app.kubernetes.io/name=open-webui-bootstrap -
 **Filter Functions** — installed, configured with valves, and toggled global on every deploy:
 - **Link Sanitizer** ([ADR 0010](../../../docs/internal/adr/0010-open-webui-link-exfiltration-filter.md))
 - **Context Summarization** ([ADR 0014](../../../docs/internal/adr/0014-open-webui-context-summarization-filter.md))
-- **Tool Result Body→Attribute Migrator** — diagnostic workaround for an OWUI 0.9.5 rendering regression (upstream commit 45e49d33e, Apr 2026, moved tool-call results from a `result="..."` attribute on the `<details>` tag into the body; the new path doesn't display). When bumping `open_webui_helm_chart_version` past `~14.5.0`, test without the filter (set `enable_active: false` in inventory) — if the regression is fixed, delete the inventory entry, the filter source, and its tests.
+- **Tool Result Body→Attribute Migrator** — diagnostic workaround for an OWUI 0.9.5 rendering regression (upstream commit 45e49d33e, Apr 2026, moved tool-call results from a `result="..."` attribute on the `<details>` tag into the body; the new path doesn't display). Confirmed still broken in 0.9.6 (`ToolCallDisplay.svelte` byte-identical between v0.9.5 and v0.9.6). When bumping `open_webui_helm_chart_version` past `~14.8.0`, test without the filter (set `enable_active: false` in inventory) — if the regression is fixed, delete the inventory entry, the filter source, and its tests.
 
 **PersistentConfig** — re-POSTed on every deploy: `tool_server_connections`, `DEFAULT_MODELS` (from `open_webui_default_model_id`), `TASK_MODEL` (from `open_webui_task_model_id`).
 

--- a/ansible/roles/open-webui/templates/values.yaml.j2
+++ b/ansible/roles/open-webui/templates/values.yaml.j2
@@ -193,7 +193,7 @@ extraEnvVars:
   - name: ENABLE_OAUTH_SIGNUP
     value: 'true'
 
-  # Skip OWUI's login splash and go straight to Keycloak
+  # Auto-redirect to OAuth provider
   - name: OAUTH_AUTO_REDIRECT
     value: 'true'
 

--- a/ansible/roles/open-webui/templates/values.yaml.j2
+++ b/ansible/roles/open-webui/templates/values.yaml.j2
@@ -193,6 +193,10 @@ extraEnvVars:
   - name: ENABLE_OAUTH_SIGNUP
     value: 'true'
 
+  # Skip OWUI's login splash and go straight to Keycloak
+  - name: OAUTH_AUTO_REDIRECT
+    value: 'true'
+
   # OAuth provider configuration
   - name: OAUTH_PROVIDER_NAME
     value: '{{ oauth_provider_name }}'

--- a/helm/open-webui-bootstrap/values.yaml
+++ b/helm/open-webui-bootstrap/values.yaml
@@ -9,7 +9,7 @@
 # without needing a separate pin. Standalone chart users should override
 # `image.ref` to match their OWUI deployment.
 image:
-  ref: 'ghcr.io/open-webui/open-webui:0.9.5'
+  ref: 'ghcr.io/open-webui/open-webui:0.9.6'
   pullPolicy: IfNotPresent
 
 # In-cluster URL for OWUI. Bypasses Traefik (no oauth2-proxy gate) so the

--- a/launchpad/src/app/HomeClient.tsx
+++ b/launchpad/src/app/HomeClient.tsx
@@ -473,9 +473,7 @@ export default function HomeClient({
     setSubdomainUrls({
       jupyter: subdomainUrl('jupyter'),
       superset: subdomainUrl('superset'),
-      // Route Chat through OWUI's OIDC entrypoint so cold-session clicks
-      // silent-SSO via Keycloak instead of bouncing to OWUI's /auth page.
-      chat: subdomainUrl('chat', '/oauth/oidc/login'),
+      chat: subdomainUrl('chat'),
       playbooks: subdomainUrl('playbooks'),
       minio: subdomainUrl('minio'),
       temporal: subdomainUrl('temporal', '/auth/sso'),


### PR DESCRIPTION
## Description

### Product
Users on Chat now auto-login instead of having to click "Sign in with SSO" again. One less click for the user.

### Technical
Bumps the open-webui Helm chart from ~14.6.0 to ~14.8.0 (appVersion 0.9.5 → 0.9.6). The 0.9.6 release adds OAUTH_AUTO_REDIRECT functionality so we no longer have the double login experience.

Tool-call display regression filter (tool_result_attr_filter) stays. Confirmed the bug is still present in 0.9.6 by comparing the SHAs of ToolCallDisplay.svelte and MarkdownTokens.svelte between v0.9.5 and v0.9.6, they're identical. Updated the version anchors in versions.yaml and the role README so the next renovate bump retests at the right version.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [x] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
N/A, no changes to auth flow itself.

##### Appsec
N/A

### Performance
N/A

### Data
N/A.

### Backward compatibility
Should be.

## Testing
Deploy to dev02 with `make install-chat`, verify SSO auto-redirect works, smoke-test a tool-calling chat to confirm the workaround filter still renders tool results in the Output panel.

## Note for reviewers
Users briefly see the OWUI Sign In page but are auto redirected from there.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [x] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
