### PR TITLE
Force Superset Database Updates

### DIFF
--- a/helm/scout-dashboards/files/import.py
+++ b/helm/scout-dashboards/files/import.py
@@ -1,19 +1,25 @@
-"""Force-overwrite Superset chart and dashboard params by UUID.
+"""Force-overwrite Superset Database / dataset / chart / dashboard params by UUID.
 
-Workaround for `superset import-dashboards` not reliably overwriting the
-`params`, `query_context`, and `position_json` of existing assets — it
-preserves the existing rows and silently ignores the new YAML for any UUID
-already in the DB.
+`superset import-dashboards` silently preserves existing rows on UUID
+match, so edits to the YAML never reach the DB without this script.
 
-Run AFTER `superset import-dashboards`. The CLI handles creating new assets
-(datasets, charts, dashboards); this script handles updating existing ones.
+Invoked twice by the import Job:
 
-For dashboards we also have to remap chartId references in position_json
-and json_metadata: YAML files capture chartId values from whatever DB the
-export came from, but on import Superset auto-assigns new local IDs by
-auto-increment. UUID is the only stable identifier across instances.
+  1. `python import.py <dir> --databases-only` runs BEFORE the CLI to
+     heal a stale `Database.sqlalchemy_uri`. Required because the CLI's
+     `import_dataset` opens a Trino connection when creating a new
+     dataset, and a stale URI aborts the Job before the post-CLI pass
+     can heal it.
+  2. `python import.py <dir>` (no flag) runs AFTER the CLI. Sweeps
+     databases / datasets / charts / dashboards and force-overwrites
+     params, position_json, json_metadata, etc. on existing rows.
 
-Usage: python import.py [analytics_dir]
+For dashboards we also remap chartId references in position_json and
+json_metadata. YAML files capture chartId values from whatever DB the
+export came from, but on import Superset auto-assigns new local IDs.
+UUID is the only stable identifier across instances.
+
+Usage: python import.py [analytics_dir] [--databases-only]
 """
 
 import glob
@@ -28,6 +34,9 @@ from superset.app import create_app  # noqa: E402
 app = create_app()
 app.app_context().push()
 
+from superset.commands.database.importers.v1.utils import (  # noqa: E402
+    import_database,
+)
 from superset.connectors.sqla.models import (  # noqa: E402
     SqlaTable,
     SqlMetric,
@@ -37,7 +46,12 @@ from superset.models.core import Database  # noqa: E402
 from superset.models.dashboard import Dashboard  # noqa: E402
 from superset.models.slice import Slice  # noqa: E402
 
-ANALYTICS = sys.argv[1] if len(sys.argv) > 1 else "/app/dashboard-config/analytics"
+# `--databases-only` runs Pass 0 and exits. Used pre-CLI to heal a stale
+# `sqlalchemy_uri` before `superset import-dashboards` opens a Trino
+# connection (e.g., when creating a new dataset).
+_args = [a for a in sys.argv[1:] if not a.startswith("--")]
+ANALYTICS = _args[0] if _args else "/app/dashboard-config/analytics"
+DATABASES_ONLY = "--databases-only" in sys.argv[1:]
 
 
 def _coerce_bool(val) -> bool:
@@ -62,47 +76,30 @@ _METRIC_FIELDS = (
 )
 
 
-# Fields on `Database` we want the chart's YAML to be authoritative for. The
-# YAML lives in the chart's `_helpers.tpl` (database_name, sqlalchemy_uri,
-# allow_*, expose_in_sqllab, impersonate_user, extra). `password` is NOT here —
-# Trino auth is JWT-based and the password column should stay NULL. `uuid` is
-# the lookup key and must not be overwritten.
-_DATABASE_FIELDS = (
-    "database_name",
-    "sqlalchemy_uri",
-    "cache_timeout",
-    "expose_in_sqllab",
-    "allow_run_async",
-    "allow_ctas",
-    "allow_cvas",
-    "allow_dml",
-    "allow_file_upload",
-    "impersonate_user",
-)
-
-
 def update_database(path: str) -> bool:
     """Sync a Database row's connection fields from the YAML by UUID.
 
-    The chart renders `analytics/databases/Scout_Data_Lake.yaml` with
-    `sqlalchemy_uri` baked in from Helm values (`.Values.trino.port`,
-    `.Values.trino.scheme`, ...). Superset's import-dashboards skips
-    Database rows whose UUID already exists, so a port / scheme change
-    in inventory never reaches the DB and Superset keeps dialing the old
-    Trino endpoint.
+    Delegates to Superset's `import_database` with `overwrite=True`,
+    which uses `set_sqlalchemy_uri` (password masking) and
+    `Database.import_from_dict` (extra-as-JSON, ssh_tunnel,
+    PREVENT_UNSAFE_DB_CONNECTIONS check). `ignore_permissions=True` is
+    needed because the import Job has no Flask request context.
+
+    Returns False when no row exists yet. On a clean install the
+    upstream CLI creates the row from the YAML.
     """
     with open(path) as f:
         data = yaml.safe_load(f)
-    d = db.session.query(Database).filter_by(uuid=data["uuid"]).first()
-    if d is None:
+    existing = db.session.query(Database).filter_by(uuid=data["uuid"]).first()
+    if existing is None:
         return False
-    for field in _DATABASE_FIELDS:
-        if field in data:
-            setattr(d, field, data[field])
-    extra = data.get("extra")
-    if extra is not None:
-        # Stored as a JSON string column on Database.
-        d.extra = extra if isinstance(extra, str) else json.dumps(extra)
+    # The helper does `config.pop("allow_csv_upload")` unconditionally
+    # (back-compat for pre-PR-16756 export YAMLs). Our chart uses the
+    # modern key, so translate here. Delete once Superset drops the
+    # legacy rename.
+    if "allow_file_upload" in data and "allow_csv_upload" not in data:
+        data["allow_csv_upload"] = data.pop("allow_file_upload")
+    import_database(data, overwrite=True, ignore_permissions=True)
     return True
 
 
@@ -284,6 +281,15 @@ for path in sorted(glob.glob(f"{ANALYTICS}/databases/*.yaml")):
     else:
         skipped_databases += 1
 db.session.flush()
+
+if DATABASES_ONLY:
+    # Pre-CLI invocation. Commit the URI fix and exit; the post-CLI
+    # invocation handles dataset / chart / dashboard passes.
+    db.session.commit()
+    print(
+        f"force-update: databases updated={updated_databases} skipped={skipped_databases}"
+    )
+    sys.exit(0)
 
 # Pass 1: datasets. Sync columns/metrics on existing datasets by UUID.
 updated_datasets = skipped_datasets = 0

--- a/helm/scout-dashboards/files/import.py
+++ b/helm/scout-dashboards/files/import.py
@@ -89,8 +89,7 @@ def update_database(path: str) -> bool:
     `.Values.trino.scheme`, ...). Superset's import-dashboards skips
     Database rows whose UUID already exists, so a port / scheme change
     in inventory never reaches the DB and Superset keeps dialing the old
-    Trino endpoint. Databases that don't exist yet get left to
-    import-dashboards (which happily creates them).
+    Trino endpoint.
     """
     with open(path) as f:
         data = yaml.safe_load(f)
@@ -275,10 +274,9 @@ def update_dashboard(path: str, chart_id_map: dict[int, int]) -> bool:
     return True
 
 
-# Pass 0a: databases. Force-overwrite the SQLAlchemy URI + connection
+# Pass 0: databases. Force-overwrite the SQLAlchemy URI + connection
 # flags on existing Database rows so a Helm values change (port, scheme,
-# user) propagates without a manual UI edit. The chart's
-# `Scout_Data_Lake.yaml` is the authoritative source.
+# user) propagates.
 updated_databases = skipped_databases = 0
 for path in sorted(glob.glob(f"{ANALYTICS}/databases/*.yaml")):
     if update_database(path):
@@ -287,7 +285,7 @@ for path in sorted(glob.glob(f"{ANALYTICS}/databases/*.yaml")):
         skipped_databases += 1
 db.session.flush()
 
-# Pass 0b: datasets. Sync columns/metrics on existing datasets by UUID.
+# Pass 1: datasets. Sync columns/metrics on existing datasets by UUID.
 updated_datasets = skipped_datasets = 0
 for path in sorted(glob.glob(f"{ANALYTICS}/datasets/**/*.yaml", recursive=True)):
     if update_dataset(path):
@@ -296,7 +294,7 @@ for path in sorted(glob.glob(f"{ANALYTICS}/datasets/**/*.yaml", recursive=True))
         skipped_datasets += 1
 db.session.flush()
 
-# Pass 1: charts. Build chart_id_map for the dashboard pass.
+# Pass 2: charts. Build chart_id_map for the dashboard pass.
 chart_id_map: dict[int, int] = {}
 updated_charts = skipped_charts = 0
 for path in sorted(glob.glob(f"{ANALYTICS}/charts/*.yaml")):
@@ -306,7 +304,7 @@ for path in sorted(glob.glob(f"{ANALYTICS}/charts/*.yaml")):
         skipped_charts += 1
 db.session.flush()
 
-# Pass 2: dashboards (uses chart_id_map).
+# Pass 3: dashboards (uses chart_id_map).
 updated_dashboards = skipped_dashboards = 0
 for path in sorted(glob.glob(f"{ANALYTICS}/dashboards/*.yaml")):
     if update_dashboard(path, chart_id_map):

--- a/helm/scout-dashboards/files/import.py
+++ b/helm/scout-dashboards/files/import.py
@@ -33,6 +33,7 @@ from superset.connectors.sqla.models import (  # noqa: E402
     SqlMetric,
     TableColumn,
 )
+from superset.models.core import Database  # noqa: E402
 from superset.models.dashboard import Dashboard  # noqa: E402
 from superset.models.slice import Slice  # noqa: E402
 
@@ -59,6 +60,51 @@ _METRIC_FIELDS = (
     "currency",
     "warning_text",
 )
+
+
+# Fields on `Database` we want the chart's YAML to be authoritative for. The
+# YAML lives in the chart's `_helpers.tpl` (database_name, sqlalchemy_uri,
+# allow_*, expose_in_sqllab, impersonate_user, extra). `password` is NOT here —
+# Trino auth is JWT-based and the password column should stay NULL. `uuid` is
+# the lookup key and must not be overwritten.
+_DATABASE_FIELDS = (
+    "database_name",
+    "sqlalchemy_uri",
+    "cache_timeout",
+    "expose_in_sqllab",
+    "allow_run_async",
+    "allow_ctas",
+    "allow_cvas",
+    "allow_dml",
+    "allow_file_upload",
+    "impersonate_user",
+)
+
+
+def update_database(path: str) -> bool:
+    """Sync a Database row's connection fields from the YAML by UUID.
+
+    The chart renders `analytics/databases/Scout_Data_Lake.yaml` with
+    `sqlalchemy_uri` baked in from Helm values (`.Values.trino.port`,
+    `.Values.trino.scheme`, ...). Superset's import-dashboards skips
+    Database rows whose UUID already exists, so a port / scheme change
+    in inventory never reaches the DB and Superset keeps dialing the old
+    Trino endpoint. Databases that don't exist yet get left to
+    import-dashboards (which happily creates them).
+    """
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    d = db.session.query(Database).filter_by(uuid=data["uuid"]).first()
+    if d is None:
+        return False
+    for field in _DATABASE_FIELDS:
+        if field in data:
+            setattr(d, field, data[field])
+    extra = data.get("extra")
+    if extra is not None:
+        # Stored as a JSON string column on Database.
+        d.extra = extra if isinstance(extra, str) else json.dumps(extra)
+    return True
 
 
 def update_dataset(path: str) -> bool:
@@ -229,7 +275,19 @@ def update_dashboard(path: str, chart_id_map: dict[int, int]) -> bool:
     return True
 
 
-# Pass 0: datasets. Sync columns/metrics on existing datasets by UUID.
+# Pass 0a: databases. Force-overwrite the SQLAlchemy URI + connection
+# flags on existing Database rows so a Helm values change (port, scheme,
+# user) propagates without a manual UI edit. The chart's
+# `Scout_Data_Lake.yaml` is the authoritative source.
+updated_databases = skipped_databases = 0
+for path in sorted(glob.glob(f"{ANALYTICS}/databases/*.yaml")):
+    if update_database(path):
+        updated_databases += 1
+    else:
+        skipped_databases += 1
+db.session.flush()
+
+# Pass 0b: datasets. Sync columns/metrics on existing datasets by UUID.
 updated_datasets = skipped_datasets = 0
 for path in sorted(glob.glob(f"{ANALYTICS}/datasets/**/*.yaml", recursive=True)):
     if update_dataset(path):
@@ -259,7 +317,8 @@ for path in sorted(glob.glob(f"{ANALYTICS}/dashboards/*.yaml")):
 db.session.commit()
 
 print(
-    f"force-update: datasets updated={updated_datasets} skipped={skipped_datasets}, "
+    f"force-update: databases updated={updated_databases} skipped={skipped_databases}, "
+    f"datasets updated={updated_datasets} skipped={skipped_datasets}, "
     f"charts updated={updated_charts} skipped={skipped_charts}, "
     f"dashboards updated={updated_dashboards} skipped={skipped_dashboards}, "
     f"chart_id_map_size={len(chart_id_map)}"

--- a/helm/scout-dashboards/templates/import-job.yaml
+++ b/helm/scout-dashboards/templates/import-job.yaml
@@ -45,12 +45,19 @@ spec:
               set -eu
               cd /app/dashboard-config
               zip -rq /tmp/dashboard.zip analytics
-              # Creates new assets; v1 importer skips any UUID that already
-              # exists, so this alone won't update edited charts/dashboards.
+              # Pre-CLI: heal Database.sqlalchemy_uri so the CLI hits the
+              # right Trino endpoint when creating a new dataset. Skipping
+              # this risks the CLI aborting on a stale URI before the
+              # post-CLI pass can heal it.
+              cd /app
+              python /app/dashboard-config/import.py /app/dashboard-config/analytics --databases-only
+              # Creates new assets only. The v1 importer skips any UUID
+              # that already exists, so edited charts/dashboards need the
+              # post-CLI pass below.
+              cd /app/dashboard-config
               superset import-dashboards -p /tmp/dashboard.zip -u {{ .Values.importUser }}
-              # Force-overwrite params/position/etc. on existing assets by
-              # UUID. Required because import-dashboards has no --overwrite
-              # flag in 5.0 (only the API does).
+              # Post-CLI: force-overwrite existing assets by UUID.
+              # import-dashboards in 5.0 has no --overwrite flag.
               cd /app
               python /app/dashboard-config/import.py /app/dashboard-config/analytics
           resources:


### PR DESCRIPTION
## Description

### Product
No user facing changes

### Technical
Add `update_database` to `scout-dashboards/import.py` alongside the existing dataset/chart/dashboard updaters. Port or scheme changes in`.Values.trino` never reached Superset's `dbs` row after the initial install.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
N/A.

##### Appsec
N/A.

### Performance
N/A. Runs once per deploy inside the existing Bootstrap Job.

### Data
N/A.

### Backward compatibility
Additive: returns early if the Database row does not exist, so clean installs are untouched. On upgrades it overwrites with the chart YAML.

## Testing
Deployed on dev02. Import Job logs `databases updated=1`; Superset's stored `sqlalchemy_uri` matches the rendered YAML (port now 8443/https, was stuck at 8080). I was then able to view data in Superset.

## Note for reviewers
This came up when deploying Trino RBAC to dev02. The Trino port change to 8443 was not being picked up by Superset on update.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project
- [x] I have commented my code, particularly in hard-to-understand areas