### PR TITLE
Parameterize documentation base URL via scout_docs_url ansible var

### DIFF
--- a/ansible/roles/jupyter/tasks/deploy.yaml
+++ b/ansible/roles/jupyter/tasks/deploy.yaml
@@ -128,9 +128,11 @@
     file_type: file
   register: _jupyter_sample_files
 
+# Samples in the repo link to the latest docs; rewrite those links to
+# scout_docs_url so deployed copies can point at a pinned docs version.
 - name: Build quickstart samples data
   ansible.builtin.set_fact:
-    _jupyter_samples_data: "{{ _jupyter_samples_data | default({}) | combine({item | basename: lookup('file', item)}) }}"
+    _jupyter_samples_data: "{{ _jupyter_samples_data | default({}) | combine({item | basename: lookup('file', item) | replace('https://washu-scout.readthedocs.io/en/latest', scout_docs_url)}) }}"
   loop: "{{ _jupyter_sample_files.files | map(attribute='path') | list }}"
   no_log: true
 

--- a/ansible/roles/jupyter/tasks/deploy.yaml
+++ b/ansible/roles/jupyter/tasks/deploy.yaml
@@ -132,7 +132,7 @@
 # scout_docs_url so deployed copies can point at a pinned docs version.
 - name: Build quickstart samples data
   ansible.builtin.set_fact:
-    _jupyter_samples_data: "{{ _jupyter_samples_data | default({}) | combine({item | basename: lookup('file', item) | replace('https://washu-scout.readthedocs.io/en/latest', scout_docs_url)}) }}"
+    _jupyter_samples_data: "{{ _jupyter_samples_data | default({}) | combine({item | basename: lookup('file', item) | replace(scout_docs_latest_url, scout_docs_url)}) }}"
   loop: "{{ _jupyter_sample_files.files | map(attribute='path') | list }}"
   no_log: true
 

--- a/ansible/roles/jupyter/templates/spawn.html.j2
+++ b/ansible/roles/jupyter/templates/spawn.html.j2
@@ -8,7 +8,7 @@
 {% if jupyter_cull_max_age is defined and jupyter_cull_max_age > 0 %}
     <div style="margin-bottom: 20px; padding: 12px 16px; background-color: light-dark(#fff3cd, #4a4000); border-left: 4px solid light-dark(#ffc107, #ffd700); border-radius: 4px; font-size: 14px; color: light-dark(#856404, #ffd700);">
       <strong>⚠️</strong> All servers are automatically stopped after <strong>{{ '%d' | format((jupyter_cull_max_age / 3600) | int) }} hours</strong> regardless of activity to help manage compute resources.
-      <a href="https://washu-scout.readthedocs.io/en/latest/tips.html#notebooks" target="_blank" style="text-decoration: underline; color: inherit;">Learn more</a>
+      <a href="{{ scout_docs_url }}/tips.html#notebooks" target="_blank" style="text-decoration: underline; color: inherit;">Learn more</a>
     </div>
 {% endif %}
   </div>

--- a/ansible/roles/launchpad/tasks/deploy.yaml
+++ b/ansible/roles/launchpad/tasks/deploy.yaml
@@ -21,6 +21,7 @@
       enablePlaybooks: '{{ enable_playbooks }}'
       scoutEnv: '{{ scout_env }}'
       deployerName: '{{ deployer_name }}'
+      docsUrl: '{{ scout_docs_url }}'
       image:
         repository: '{{ launchpad_image_repository }}'
         tag: '{{ launchpad_image_tag }}'

--- a/ansible/roles/oauth2-proxy/tasks/deploy.yaml
+++ b/ansible/roles/oauth2-proxy/tasks/deploy.yaml
@@ -8,6 +8,8 @@
       register: oauth2_proxy_templates
       delegate_to: localhost
 
+    # The html files are Go templates rendered by oauth2-proxy, so they can't
+    # go through Jinja; rewrite their docs links to scout_docs_url instead.
     - name: Create ConfigMap for OAuth2 Proxy templates
       delegate_to: localhost
       no_log: true
@@ -21,7 +23,7 @@
             namespace: {{ oauth2_proxy_namespace }}
           data:
             '{{ item.path | basename }}': |-
-              {{ lookup("file", item.path) | indent(4) }}
+              {{ lookup("file", item.path) | replace("https://washu-scout.readthedocs.io/en/latest", scout_docs_url) | indent(4) }}
         kubeconfig: '{{ local_kubeconfig_yaml }}'
       loop: '{{ oauth2_proxy_templates.files }}'
       loop_control:

--- a/ansible/roles/oauth2-proxy/tasks/deploy.yaml
+++ b/ansible/roles/oauth2-proxy/tasks/deploy.yaml
@@ -23,7 +23,7 @@
             namespace: {{ oauth2_proxy_namespace }}
           data:
             '{{ item.path | basename }}': |-
-              {{ lookup("file", item.path) | replace("https://washu-scout.readthedocs.io/en/latest", scout_docs_url) | indent(4) }}
+              {{ lookup("file", item.path) | replace(scout_docs_latest_url, scout_docs_url) | indent(4) }}
         kubeconfig: '{{ local_kubeconfig_yaml }}'
       loop: '{{ oauth2_proxy_templates.files }}'
       loop_control:

--- a/ansible/roles/scout_common/defaults/main.yaml
+++ b/ansible/roles/scout_common/defaults/main.yaml
@@ -26,12 +26,17 @@ helm_chart_values_files: []
 scout_notebook_image_name: ghcr.io/washu-tag/scout-notebook
 scout_notebook_image_tag: latest
 
+# Docs base URL as hardcoded in repo files (quickstart samples, OAuth2 Proxy
+# html); deploy tasks rewrite it to scout_docs_url. Not a knob — change only
+# if the links in those files change.
+scout_docs_latest_url: https://washu-scout.readthedocs.io/en/latest
+
 # Base URL for Scout user documentation links surfaced in deployed services
 # (Launchpad, OAuth2 Proxy error page, JupyterHub spawn page, quickstart
 # notebooks). No trailing slash. Override in inventory to pin users to the
 # docs for a released version, e.g.
 #   scout_docs_url: https://washu-scout.readthedocs.io/en/v4.0.0
-scout_docs_url: https://washu-scout.readthedocs.io/en/latest
+scout_docs_url: '{{ scout_docs_latest_url }}'
 
 # Kubernetes configuration
 kubeconfig_yaml: /etc/rancher/k3s/k3s.yaml

--- a/ansible/roles/scout_common/defaults/main.yaml
+++ b/ansible/roles/scout_common/defaults/main.yaml
@@ -26,6 +26,13 @@ helm_chart_values_files: []
 scout_notebook_image_name: ghcr.io/washu-tag/scout-notebook
 scout_notebook_image_tag: latest
 
+# Base URL for Scout user documentation links surfaced in deployed services
+# (Launchpad, OAuth2 Proxy error page, JupyterHub spawn page, quickstart
+# notebooks). No trailing slash. Override in inventory to pin users to the
+# docs for a released version, e.g.
+#   scout_docs_url: https://washu-scout.readthedocs.io/en/v4.0.0
+scout_docs_url: https://washu-scout.readthedocs.io/en/latest
+
 # Kubernetes configuration
 kubeconfig_yaml: /etc/rancher/k3s/k3s.yaml
 air_gapped: false

--- a/docs/internal/versions-and-releases.md
+++ b/docs/internal/versions-and-releases.md
@@ -112,6 +112,13 @@ Developer                    GitHub                        CI
 - Tag `v2.1.0` points to the commit that was actually built and released
 - Branch is back to dev versions (unless `skip_dev_reset` was checked)
 
+### Post-Release Steps
+
+- When upgrading a site to the new release, bump its pinned docs URL to
+  match: `scout_docs_url: https://washu-scout.readthedocs.io/en/v2.1.0` in
+  that site's inventory (preprod/production in scout-inventory). Sites left
+  unpinned follow `/en/latest`, which can show docs for unreleased features.
+
 ## Dry Run Mode
 
 Before releasing, you can preview what the changelog will look like:

--- a/docs/source/technical/inventory.md
+++ b/docs/source/technical/inventory.md
@@ -757,6 +757,18 @@ grafana_smtp_skip_verify: false
 grafana_email_recipients: ['admin@example.com']
 ```
 
+#### Documentation Links
+
+Services that link to the Scout documentation (Launchpad, the sign-in error
+page, the JupyterHub spawn page, and the quickstart notebooks) default to the
+latest published docs. Pin them to the docs for your deployed release so users
+aren't shown features they don't have yet:
+
+```yaml
+# Base URL for documentation links (no trailing slash)
+scout_docs_url: https://washu-scout.readthedocs.io/en/v4.0.0
+```
+
 #### Superset Dashboards
 
 Scout ships its Superset dashboards via a separate Helm chart

--- a/helm/launchpad/templates/deployment.yaml
+++ b/helm/launchpad/templates/deployment.yaml
@@ -79,6 +79,10 @@ spec:
             - name: DEPLOYER_NAME
               value: {{ .Values.deployerName | quote }}
             {{- end }}
+            {{- if .Values.docsUrl }}
+            - name: SCOUT_DOCS_URL
+              value: {{ .Values.docsUrl | quote }}
+            {{- end }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm/launchpad/values.yaml
+++ b/helm/launchpad/values.yaml
@@ -16,6 +16,10 @@ scoutEnv: ''
 # footer copyright line. Empty string hides the copyright line.
 deployerName: ''
 
+# Base URL for Scout documentation links (no trailing slash). Empty string
+# falls back to the latest published docs.
+docsUrl: ''
+
 image:
   repository: ghcr.io/washu-tag/launchpad
   tag: latest

--- a/launchpad/src/app/HomeClient.tsx
+++ b/launchpad/src/app/HomeClient.tsx
@@ -257,9 +257,10 @@ interface ContentGridProps {
   enableChat: boolean;
   enablePlaybooks: boolean;
   subdomainUrls: Record<string, string>;
+  docsUrl: string;
 }
 
-const ContentGrid = ({ enableChat, enablePlaybooks, subdomainUrls }: ContentGridProps) => {
+const ContentGrid = ({ enableChat, enablePlaybooks, subdomainUrls, docsUrl }: ContentGridProps) => {
   // Don't render until subdomain URLs are set on client side
   if (Object.keys(subdomainUrls).length === 0) {
     return (
@@ -297,7 +298,7 @@ const ContentGrid = ({ enableChat, enablePlaybooks, subdomainUrls }: ContentGrid
         {/* Documentation Link */}
         <div className="mt-6 text-center">
           <a
-            href="https://washu-scout.readthedocs.io/en/latest/"
+            href={docsUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 px-4 py-2 text-sm text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors duration-200 no-underline"
@@ -454,6 +455,7 @@ interface HomeClientProps {
   enablePlaybooks: boolean;
   scoutEnv?: string;
   deployerName?: string;
+  docsUrl: string;
 }
 
 export default function HomeClient({
@@ -461,6 +463,7 @@ export default function HomeClient({
   enablePlaybooks,
   scoutEnv,
   deployerName,
+  docsUrl,
 }: HomeClientProps) {
   const [mounted, setMounted] = useState(false);
   const { data: session, status } = useSession();
@@ -531,7 +534,7 @@ export default function HomeClient({
         <div className="max-w-content mx-auto px-6 py-6 flex items-center justify-between">
           {/* Brand strip */}
           <Brand crumbs={[environment]} />
-          <TopBar />
+          <TopBar docsUrl={docsUrl} />
         </div>
       </div>
 
@@ -543,6 +546,7 @@ export default function HomeClient({
           enableChat={enableChat}
           enablePlaybooks={enablePlaybooks}
           subdomainUrls={subdomainUrls}
+          docsUrl={docsUrl}
         />
 
         {/* Footer */}

--- a/launchpad/src/app/admin/users/UsersClient.tsx
+++ b/launchpad/src/app/admin/users/UsersClient.tsx
@@ -667,7 +667,7 @@ const TABS: { key: Tab; label: string }[] = [
   { key: 'admin', label: 'Admins' },
 ];
 
-export default function UsersClient({ scoutEnv }: { scoutEnv?: string }) {
+export default function UsersClient({ scoutEnv, docsUrl }: { scoutEnv?: string; docsUrl: string }) {
   const { data: session, status } = useSession();
   const environment = scoutEnv ?? 'local';
   const [schema, setSchema] = useState<AttrSchema[]>([]);
@@ -794,7 +794,7 @@ export default function UsersClient({ scoutEnv }: { scoutEnv?: string }) {
                 Open in Keycloak
               </a>
             )}
-            <TopBar />
+            <TopBar docsUrl={docsUrl} />
           </div>
         </div>
       </div>

--- a/launchpad/src/app/admin/users/page.tsx
+++ b/launchpad/src/app/admin/users/page.tsx
@@ -1,4 +1,5 @@
 import UsersClient from './UsersClient';
+import { getDocsUrl } from '@/lib/docsUrl';
 
 // Read auth/session per request; never statically prerender this admin view.
 export const dynamic = 'force-dynamic';
@@ -10,5 +11,5 @@ export const metadata = {
 export default function ApprovalsPage() {
   // Mirror the home page so the console breadcrumb shows the same environment.
   const scoutEnv = process.env.SCOUT_ENV;
-  return <UsersClient scoutEnv={scoutEnv} />;
+  return <UsersClient scoutEnv={scoutEnv} docsUrl={getDocsUrl()} />;
 }

--- a/launchpad/src/app/page.tsx
+++ b/launchpad/src/app/page.tsx
@@ -1,4 +1,5 @@
 import HomeClient from './HomeClient';
+import { getDocsUrl } from '@/lib/docsUrl';
 
 // Force dynamic rendering so env vars are read at request time, not build time
 export const dynamic = 'force-dynamic';
@@ -16,6 +17,7 @@ export default function Home() {
       enablePlaybooks={enablePlaybooks}
       scoutEnv={scoutEnv}
       deployerName={deployerName}
+      docsUrl={getDocsUrl()}
     />
   );
 }

--- a/launchpad/src/components/TopBar.tsx
+++ b/launchpad/src/components/TopBar.tsx
@@ -5,7 +5,7 @@ import { useSession, signIn } from 'next-auth/react';
 import { FaUser, FaGithub, FaMoon, FaSun, FaBook } from 'react-icons/fa';
 import UserDropdown from './UserDropdown';
 
-export default function TopBar() {
+export default function TopBar({ docsUrl }: { docsUrl: string }) {
   const { data: session, status } = useSession();
   const [isDark, setIsDark] = useState(false);
 
@@ -40,7 +40,7 @@ export default function TopBar() {
     <div className="flex items-center gap-2">
       {/* Documentation Link */}
       <a
-        href="https://washu-scout.readthedocs.io/en/latest/"
+        href={docsUrl}
         target="_blank"
         rel="noopener noreferrer"
         className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors duration-200 cursor-pointer"

--- a/launchpad/src/lib/docsUrl.ts
+++ b/launchpad/src/lib/docsUrl.ts
@@ -1,0 +1,5 @@
+// Resolved at request time in server components; falls back to the latest
+// published docs when SCOUT_DOCS_URL is not set (e.g. local dev).
+export function getDocsUrl(): string {
+  return process.env.SCOUT_DOCS_URL || 'https://washu-scout.readthedocs.io/en/latest';
+}


### PR DESCRIPTION
## Description

### Product
Deployed Scout services (Launchpad, the sign-in error page, the JupyterHub spawn page, the Quickstart notebook) all link to the docs at `/en/latest/`. If a site is running a pinned release, users get shown docs for whatever has landed on `main` since — features they don't have, schema columns that don't exist yet. This adds a single inventory variable to pin those links to the deployed release:

```yaml
scout_docs_url: https://washu-scout.readthedocs.io/en/v4.0.0
```

Default is unchanged (`/en/latest`), so existing inventories need no edits. Documented in the inventory reference.

### Technical
A new `scout_docs_url` default in `scout_common` (no trailing slash; jupyter, oauth2-proxy, and launchpad already depend on it), defaulting from `scout_docs_latest_url` — the canonical `/en/latest` base as hardcoded in repo files, which the rewrite tasks below also reference so the literal lives in one place. The delivery mechanism differs per artifact, since — as the issue notes — most of these aren't templates:

- **Launchpad**: follows the existing `scoutEnv`/`deployerName` pattern. Ansible → `docsUrl` Helm value → `SCOUT_DOCS_URL` env var → read at request time by the server pages (`getDocsUrl()` helper, falls back to `/en/latest` for local dev) → threaded as a prop to `TopBar` and the home-page docs link.
- **JupyterHub spawn page**: `spawn.html.j2` is already rendered by Ansible, so it just uses `{{ scout_docs_url }}/tips.html#notebooks`.
- **Quickstart samples + OAuth2 Proxy error page**: these can't go through Jinja — the oauth2-proxy html files are Go templates (`{{.ProxyPrefix}}` etc.) that oauth2-proxy renders itself. Instead the deploy tasks rewrite the hardcoded `/en/latest` base with a `replace()` filter when building the ConfigMaps. The repo copies keep real, clickable links.

Repo docs (README, CLAUDE.md, role READMEs, architecture diagram) intentionally keep `/en/latest` — they aren't deployment artifacts.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
N/A — no roles, data access, or API surface changes.

##### Appsec
The value lands in `href`s across several pages, but it's operator-set inventory config (same trust level as every other URL we template), not user input.

### Performance
N/A

### Data
N/A

### Backward compatibility
Default behavior is identical. The launchpad chart gains an optional `docsUrl` value (empty = current behavior); `TopBar`/`HomeClient`/`UsersClient` props changed, but launchpad has no external consumers.

## Testing
- `npm run build` in `launchpad/` passes (includes the TypeScript check).
- `helm template` with `docsUrl` set renders `SCOUT_DOCS_URL`; unset omits it.
- Ran the exact Jinja expressions from both edited deploy tasks against the real files with a pinned URL: deep links rewrite cleanly (e.g. `…/en/v4.0.0/dataschema.html#longitudinal-patient-id-resolution`), Go template syntax in the oauth2-proxy html comes through untouched, and the rendered ConfigMap is valid YAML.
- `pre-commit` on all changed files.

Manual testing by me (Kate) on `dev04` - launchpad, jupyter (startup page + Quickstart nb), OA2P (Flavin requested a new account)

## Note for reviewers
- Convention call: `scout_docs_url` has **no trailing slash** (use sites append `/tips.html` etc.). Flagging in case you'd prefer the opposite.
- The `replace()` approach means **the jupyter samples/error page must keep linking to the canonical `/en/latest` base for the rewrite to match. If someone later edits those links, the substitution silently stops applying**

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (`pre-commit` run on all changed files)
- [x] I have commented my code, particularly in hard-to-understand areas (why the oauth2-proxy files can't be Jinja-templated, what the rewrite is for)
- [x] I have added or updated user documentation, if appropriate (inventory reference: new "Documentation Links" section)
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate — N/A at this size
- [ ] I have added unit tests, if appropriate — N/A
- [ ] I have added end-to-end tests, if appropriate — N/A

Closes #416 