### PR TITLE
(Minor) Bump up helm timeout for scout-dashboards

### DIFF
--- a/ansible/roles/superset/tasks/deploy.yaml
+++ b/ansible/roles/superset/tasks/deploy.yaml
@@ -137,6 +137,7 @@
     helm_chart_name: scout-dashboards
     helm_chart_ref: '{{ scout_dashboards_helm_chart_ref }}'
     helm_chart_namespace: '{{ superset_namespace }}'
+    helm_chart_timeout: '{{ superset_helm_timeout }}'
     helm_chart_values:
       image:
         repository: '{{ superset_image_repository }}'


### PR DESCRIPTION
I had a timeout failure deploying `scout-dashboards` after the patient dashboards from #423