### PR TITLE
Move launchpad to node:24-alpine (LTS) and refresh trivyignore for CVE-2026-45447

### DIFF
--- a/launchpad/.trivyignore.yaml
+++ b/launchpad/.trivyignore.yaml
@@ -1,5 +1,3 @@
 vulnerabilities:
-  # Fixes available in Alpine repos but alpine:3.23 base image not rebuilt since 2026-01-28 — check https://github.com/alpinelinux/docker-alpine for updates
-  - id: CVE-2026-22184 # zlib 1.3.1-r2 → 1.3.2-r0
-  - id: CVE-2026-28390 # openssl 3.5.5-r0 → 3.5.6-r0
-  - id: CVE-2026-40200 # musl 1.2.5-r21 → 1.2.5-r23
+  # Fix available in Alpine repos but node:24-alpine not rebuilt with it as of 2026-06-11 — check https://hub.docker.com/_/node for updates
+  - id: CVE-2026-45447 # openssl 3.5.6-r0 → 3.5.7-r0 (libcrypto3, libssl3)

--- a/launchpad/Dockerfile
+++ b/launchpad/Dockerfile
@@ -1,5 +1,5 @@
-# Use Node.js 25 Alpine as the base image
-FROM node:25-alpine AS base
+# Use Node.js 24 (LTS) Alpine as the base image
+FROM node:24-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/launchpad/package-lock.json
+++ b/launchpad/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
-        "@types/node": "^25",
+        "@types/node": "^24",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
         "eslint": "^9",
@@ -1661,13 +1661,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/react": {
@@ -6550,9 +6550,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/launchpad/package.json
+++ b/launchpad/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^25",
+    "@types/node": "^24",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "eslint": "^9",


### PR DESCRIPTION
## Description

### Product
N/A — CI/image hygiene only.

### Technical
The `scan-images (launchpad)` job is failing on **CVE-2026-45447** (openssl 3.5.6-r0 → 3.5.7-r0, libcrypto3 + libssl3). It failed on #430 (which merged red, so the `publish` job was skipped and `ghcr.io/washu-tag/launchpad:latest` is currently **stale** — it's missing #430's launchpad change) and again on #433. Any PR touching `launchpad/**` will keep hitting it.

The fix exists in Alpine's repos but **no node image has been rebuilt with it yet** (Claude scanned `node:24-alpine`, `25-alpine`, and `26-alpine` and all three ship the same openssl 3.5.6-r0). So:

- **Base image: `node:25-alpine` → `node:24-alpine`.** Node 25 hit EOL on 2026-06-01, meaning its image will *never* get the openssl rebuild. Node 24 is Active LTS (maintained until April 2028) and will pick up the rebuild when upstream cuts new images.
- **`.trivyignore.yaml` refreshed.** The three existing entries (zlib, openssl 3.5.6, musl) no longer match anything, so they're dropped. One new entry for CVE-2026-45447 with a dated not-yet-rebuilt comment, same pattern as before; remove it once the base rebuilds.
- **`@types/node` `^25` → `^24`** to match the runtime. With a runtime downgrade this matters: types newer than the runtime would let code reference APIs that don't exist at runtime.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
N/A

##### Appsec
This is itself a scan response. The ignored CVE is real but unfixable by us until upstream rebuilds; the entry is scoped to the single CVE and dated so it doesn't quietly become permanent.

### Performance
N/A

### Data
N/A

### Backward compatibility
Runtime goes from Node 25 to 24 (a downgrade, but onto the LTS line). Launchpad's Node API surface is essentially `process.env`, and Next.js 16 supports ≥ 20.9. No data model or API changes.

## Testing
- Built the image locally on the new base and scanned it with trivy using the ignorefile, mirroring the CI gate exactly (HIGH/CRITICAL, fail on any `FixedVersion`): **0 fixable**.
- Unsuppressed scan shows *only* the two openssl hits — confirms the three removed ignore entries were genuinely stale.
- Container smoke test: serves HTTP 200 on node v24.16.0.
- Ran locally with `npm run dev`

## Note for reviewers
- Merging this unblocks the publish pipeline: the next main run rebuilds launchpad, the scan passes, and `:latest` finally ships with #430's chat-link change. #433 just needs a re-run afterward.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (`pre-commit` run on changed files)
- [x] I have commented my code, particularly in hard-to-understand areas (dated comment on the ignore entry)
- [ ] I have added or updated user documentation, if appropriate — N/A
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate — N/A
- [ ] I have added unit tests, if appropriate — N/A
- [ ] I have added end-to-end tests, if appropriate — N/A
