### PR TITLE
Fix netty and commons-lang3 CVEs; scope Gradle dependency graph to shipped deps

### DIFF
--- a/.github/workflows/gradle-dependency-submission.yaml
+++ b/.github/workflows/gradle-dependency-submission.yaml
@@ -28,6 +28,11 @@ jobs:
       - uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
           build-root-directory: extractor/hl7log-extractor
+          # Submit only the deps that ship in the artifact. Compile/test
+          # classpaths (e.g. the Keycloak server APIs the event-listener
+          # builds against) otherwise generate Dependabot alerts for code
+          # we never distribute.
+          dependency-graph-include-configurations: 'runtimeClasspath'
 
   keycloak-event-listener:
     runs-on: ubuntu-latest
@@ -42,3 +47,4 @@ jobs:
       - uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
           build-root-directory: keycloak/event-listener
+          dependency-graph-include-configurations: 'runtimeClasspath'

--- a/extractor/hl7log-extractor/.trivyignore.yaml
+++ b/extractor/hl7log-extractor/.trivyignore.yaml
@@ -1,12 +1,4 @@
 vulnerabilities:
-  # Alpine base image not yet rebuilt with zlib 1.3.2-r0 — check amazoncorretto:21-alpine on Docker Hub for rebuild after 2026-03-05
-  - id: CVE-2026-22184 # zlib
-  # Alpine base image not yet rebuilt with openssl 3.5.6-r0 — check amazoncorretto:21-alpine on Docker Hub for rebuild
-  - id: CVE-2026-28390 # openssl 3.5.5-r0 → 3.5.6-r0
-  - id: CVE-2026-40200 # musl 1.2.5-r21 → 1.2.5-r23
-  # GHSA-rwm7-x88c-3g2p — netty epoll DoS via RST on half-closed TCP connection.
-  # The advisory text states only the 4.2.x branch is affected (up to 4.2.12.Final),
-  # but its GHSA vulnerableVersionRange is "< 4.2.13.Final", which causes Trivy
-  # to flag our 4.1.133.Final as vulnerable. Remove this entry if/when the GHSA
-  # range is tightened upstream, or if we move onto the netty 4.2.x line.
-  - id: CVE-2026-42577 # io.netty:netty-transport-native-epoll (4.1.x not affected)
+  # Fix available in Alpine repos but amazoncorretto:21-alpine not yet rebuilt
+  # with openssl 3.5.7-r0 — check Docker Hub for a rebuild
+  - id: CVE-2026-45447 # libcrypto3/libssl3 3.5.6-r0 → 3.5.7-r0

--- a/extractor/hl7log-extractor/build.gradle
+++ b/extractor/hl7log-extractor/build.gradle
@@ -27,13 +27,13 @@ def checkstyleVersion = "13.4.2"
 // (CVE-2026-42198, HIGH: pgjdbc SCRAM PBKDF2 DoS).
 ext['postgresql.version'] = '42.7.11'
 
-// TODO: Remove once Spring Boot manages netty >= 4.2.13.Final.
+// TODO: Remove once Spring Boot manages netty >= 4.2.15.Final.
 // Overrides the Spring Boot BOM's pinned 4.2.12.Final to address
-// CVE-2026-42577 (epoll, 4.2.x only), CVE-2026-42579, CVE-2026-42583,
-// CVE-2026-42584, and CVE-2026-42587 (all HIGH) across netty-codec,
-// netty-codec-http, netty-codec-http2, netty-codec-dns, and
-// netty-transport-native-epoll.
-ext['netty.version'] = '4.2.13.Final'
+// CVE-2026-44249, CVE-2026-44892, CVE-2026-44894, CVE-2026-45416,
+// CVE-2026-45674, and CVE-2026-47691 (all HIGH) across netty-handler,
+// netty-codec-http3, netty-codec-classes-quic, and netty-resolver-dns,
+// plus the earlier 4.2.13 batch (CVE-2026-42577 through -42587).
+ext['netty.version'] = '4.2.15.Final'
 
 // TODO: Remove once Temporal ships a release that brings opentelemetry >= 1.62.0.
 // Pins the io.opentelemetry:* family (transitively from temporal-sdk) to 1.62.0

--- a/keycloak/event-listener/build.gradle
+++ b/keycloak/event-listener/build.gradle
@@ -22,8 +22,8 @@ def kcVersion = "26.6.3"
 def jbossLoggingVersion = "3.6.1.Final"
 def checkstyleVersion = "13.4.2"
 // ADR 0021: OPA bundle publisher uses tar.gz as OPA's standard bundle
-// format. Commons Compress is ~700KB with no transitive deps; smaller
-// surface than adding an S3 client SDK on top. Not present on
+// format. Commons Compress (plus its commons-codec/io/lang3 deps) is a
+// smaller surface than adding an S3 client SDK on top. Not present on
 // Keycloak's classpath by default, so it ships into providers/ via
 // the copyRuntimeDeps task below.
 def commonsCompressVersion = "1.27.1"
@@ -37,6 +37,12 @@ def junitVersion = "5.11.4"
 def mockitoVersion = "5.14.2"
 
 dependencies {
+    constraints {
+        // commons-compress 1.27.1 pulls commons-lang3 3.16.0, which ships into
+        // providers/ — hold it at the CVE-2025-48924 fix.
+        implementation("org.apache.commons:commons-lang3:3.18.0")
+    }
+
     // Provided by Keycloak at runtime — compileOnly so they don't ship into
     // providers/ alongside our jar and risk classloader skew.
     compileOnly("org.keycloak:keycloak-core:${kcVersion}")


### PR DESCRIPTION
## Description

### Technical

Two related security chores: the netty bump that unblocks the Trivy gate, and a triage of the open Gradle-manifest Dependabot alerts that came out of the same review.

#### hl7log-extractor: netty bump + trivyignore refresh

Bumps `netty.version` (the Spring Boot version-property override in `extractor/hl7log-extractor/build.gradle`) from **4.2.13.Final** to **4.2.15.Final** and refreshes `.trivyignore.yaml`. No application code changes. Unblocks the post-commit Trivy gate, which began failing on 8 fixable HIGH findings against an unchanged image (fresh CVE database, not a code change — [run 27421411196](https://github.com/washu-tag/scout/actions/runs/27421411196/job/81048566699)).

| Dependency | From | To |
|---|---|---|
| `io.netty:*` ([releases](https://github.com/netty/netty/releases)) | 4.2.13.Final | 4.2.15.Final |
| `org.apache.commons:commons-lang3` (keycloak event-listener, via commons-compress) | 3.16.0 | 3.18.0 |

Fixes, all HIGH:
- [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86) — IPv6 subnet filter bypass via incorrect comparison (netty-handler)
- [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh) — SNI handler pre-allocates up to 16 MiB per connection (netty-handler)
- [CVE-2026-44892](https://github.com/advisories/GHSA-c2rx-5r8w-8xr2) — vulnerable default configuration (netty-codec-http3)
- [CVE-2026-44894](https://github.com/advisories/GHSA-cmm3-54f8-px4j) — default QUIC token handler accepts any client-supplied token (netty-codec-classes-quic)
- [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc) — DNS cache poisoning via missing bailiwick validation (netty-resolver-dns)
- [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85) — insufficient bailiwick validation for NS records (netty-resolver-dns)

**Not fixable by us yet — new ignore entry** (same CVE and same not-yet-rebuilt treatment as launchpad in #435):
- [CVE-2026-45447](https://github.com/advisories/GHSA-f684-cpcq-j565) (HIGH, alpine `libcrypto3`/`libssl3` 3.5.6-r0 → 3.5.7-r0): the fix is in the Alpine repos, but `amazoncorretto:21-alpine` hasn't been rebuilt with it — verified on a fresh pull.

**Stale ignore entries dropped** (no longer match the built image):
- CVE-2026-22184 (zlib) — fresh base ships fixed 1.3.2-r0
- CVE-2026-28390 (openssl 3.5.5) — fresh base ships fixed 3.5.6-r0
- CVE-2026-40200 (musl) — fresh base ships fixed 1.2.6-r2
- CVE-2026-42577 (netty epoll GHSA-range workaround) — its comment's stated removal condition ("if we move onto the netty 4.2.x line") is now met; a no-ignorefile scan of the rebuilt image confirms it matches nothing

#### Dependabot triage: one real fix, then scope the graph to what ships

Triage of the open Dependabot alerts on the two Gradle manifests found exactly **one** in code we distribute:

- [CVE-2025-48924](https://github.com/advisories/GHSA-j288-q9x7-2f5v) (MEDIUM, `commons-lang3` < 3.18.0): commons-compress 1.27.1 pulls commons-lang3 3.16.0 onto the keycloak event-listener's `runtimeClasspath`, which `copyRuntimeDeps` ships into Keycloak's `providers/`. Fixed with a Gradle dependency constraint to 3.18.0 (verified `3.16.0 -> 3.18.0` by constraint via `dependencyInsight`). Also corrects the stale "no transitive deps" comment on commons-compress.

Everything else flagged on `keycloak/event-listener` (netty 4.1.x, protobuf-java, opentelemetry-api, plexus-utils) is the compile/test classpath of building against `keycloak-services` — declared `compileOnly` and never distributed (traced netty-handler: `keycloak-services → quarkus-vertx → quarkus-netty`). The runtime copies of those libraries live inside the Keycloak server image, which Renovate (`keycloak_version`) and Trivy already cover. Chasing those versions in our build would change nothing that runs.

Instead, both jobs in `gradle-dependency-submission.yaml` now pass `dependency-graph-include-configurations: 'runtimeClasspath'`, so the submitted dependency graph — and every future Dependabot alert on these manifests — reflects only dependencies that ship in our artifacts. Trade-off: we stop getting alerts for test/build tooling, which matches ADR 0015's intent (CVE monitoring of application dependencies).

## Type of change
- [x] Improvement (security dependency bump)

## Impact

### Security
Removes six fixable HIGH vulnerabilities from the hl7log-extractor image and one MEDIUM from the Keycloak `providers/` payload; no authorization or API surface changes. Dependabot alerts on the Gradle manifests become meaningful ("this ships") rather than echoing Keycloak's own dependency tree.

### Performance / Data / Backward compatibility
None expected — patch-line bump of a transitive runtime dependency and a minor-line constraint on another; no data model, API, or behavior changes.

## Testing
- hl7log-extractor: `./gradlew test` passes on netty 4.2.15.Final
- keycloak event-listener: `./gradlew test` passes with the commons-lang3 constraint; `dependencyInsight --configuration runtimeClasspath` confirms 3.18.0 is what ships
- Local image build + `trivy image` on the saved tar, mirroring the CI gate (CRITICAL,HIGH, fixable count): **0 fixable with the ignorefile**; only CVE-2026-45447 without it. Local build is arm64 vs CI's amd64 — package versions are arch-independent, CI scan is the confirming word.

## Note for reviewers
Expected Dependabot behavior after merge: the dependency-submission workflow runs on push to main, and the compile-only alerts on the Gradle manifests should auto-resolve once the scoped graph replaces the old one. Two alerts won't auto-resolve and should be dismissed manually:
- **#112 `uuid` < 11.1.1** (launchpad, MEDIUM) — dismiss as *vulnerable code is not in the execute path*: it's next-auth's pin (`^8.3.2`), the advisory only affects `v3()/v5()/v6()` called with a caller-supplied output buffer, and next-auth calls only `v4()` (`jwt/index.ts`). Forcing a uuid 8→11 override under the auth library is not worth an unreachable medium.
- **#113 `spring-framework-bom` < 4.3.29** (hl7log-extractor) — dismiss as *inaccurate*: the resolved Spring Framework is 7.0.7 (Boot 4.0.6); the alert is a stray BOM node in the old unscoped graph submission.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (pre-commit run on changed files)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] User documentation — n/a
- [ ] Technical documentation / ADR — n/a
- [ ] Unit tests — n/a (existing suites pass on both bumps)
- [ ] End-to-end tests — n/a