### PR TITLE
Fix execute_sql connection-target leak across roles

### DIFF
--- a/ansible/roles/hive/tasks/create_readonly_user.yaml
+++ b/ansible/roles/hive/tasks/create_readonly_user.yaml
@@ -16,7 +16,7 @@
     name: scout_common
     tasks_from: execute_sql
   vars:
-    db_connect_name: '{{ hive_database_name }}'
+    sql_dbname: '{{ hive_database_name }}'
     sql_script: |-
       DO $do$
       BEGIN

--- a/ansible/roles/scout_common/tasks/execute_sql.yaml
+++ b/ansible/roles/scout_common/tasks/execute_sql.yaml
@@ -5,11 +5,9 @@
 # later execute_sql call. (That leak previously let open-webui's ALTER SCHEMA
 # run against the hive database.) Instead we derive everything below into
 # distinct psql_* facts, applying defaults inline so each call starts clean.
-# `sql_dbname` is the canonical parameter; `db_connect_name` is still honored
-# for backward compatibility.
 - name: Configure DB derived variables
   ansible.builtin.set_fact:
-    psql_dbname: "{{ sql_dbname | default(db_connect_name | default('postgres', true), true) }}"
+    psql_dbname: "{{ sql_dbname | default('postgres', true) }}"
     psql_user: "{{ db_connect_user | default('postgres', true) }}"
     psql_pass: '{{ db_connect_pass | default(postgres_superuser_password, true) }}'
     psql_sslmode: "{{ db_connect_sslmode | default('require', true) }}"

--- a/ansible/roles/scout_common/tasks/execute_sql.yaml
+++ b/ansible/roles/scout_common/tasks/execute_sql.yaml
@@ -1,15 +1,24 @@
-- name: Configure DB variables
-  ansible.builtin.set_fact:
-    db_connect_name: "{{ db_connect_name | default('postgres', true) }}"
-    db_connect_user: "{{ db_connect_user | default('postgres', true) }}"
-    db_connect_pass: '{{ db_connect_pass | default(postgres_superuser_password, true) }}'
-    db_connect_sslmode: "{{ db_connect_sslmode | default('require', true) }}"
-    maintenance_namespace: '{{ scout_core_namespace }}'
-
+# Resolve the target database for THIS invocation only. We deliberately do NOT
+# set_fact the caller-supplied inputs (sql_dbname / db_connect_*) back onto
+# themselves: set_fact persists as a host fact for the rest of the play, so a
+# self-referential default would leak one role's connection target into every
+# later execute_sql call. (That leak previously let open-webui's ALTER SCHEMA
+# run against the hive database.) Instead we derive everything below into
+# distinct psql_* facts, applying defaults inline so each call starts clean.
+# `sql_dbname` is the canonical parameter; `db_connect_name` is still honored
+# for backward compatibility.
 - name: Configure DB derived variables
   ansible.builtin.set_fact:
-    psql_connection: 'host={{ db_host }} port={{ db_port }} dbname={{ db_connect_name }} user={{ db_connect_user }} sslmode={{ db_connect_sslmode }}'
-    psql_job_name: "psql-{{ (db_connect_name | lower | regex_replace('[^a-z0-9-]', '-') | regex_replace('^-+', '') | regex_replace('-+$', '')) | default('db', true) }}-{{ lookup('pipe', 'date +%s') }}"
+    psql_dbname: "{{ sql_dbname | default(db_connect_name | default('postgres', true), true) }}"
+    psql_user: "{{ db_connect_user | default('postgres', true) }}"
+    psql_pass: '{{ db_connect_pass | default(postgres_superuser_password, true) }}'
+    psql_sslmode: "{{ db_connect_sslmode | default('require', true) }}"
+    maintenance_namespace: '{{ scout_core_namespace }}'
+
+- name: Configure DB connection string
+  ansible.builtin.set_fact:
+    psql_connection: 'host={{ db_host }} port={{ db_port }} dbname={{ psql_dbname }} user={{ psql_user }} sslmode={{ psql_sslmode }}'
+    psql_job_name: "psql-{{ (psql_dbname | lower | regex_replace('[^a-z0-9-]', '-') | regex_replace('^-+', '') | regex_replace('-+$', '')) | default('db', true) }}-{{ lookup('pipe', 'date +%s') }}"
 
 - name: Verify SQL script input
   ansible.builtin.assert:
@@ -51,7 +60,7 @@
                 image: postgres:16
                 env:
                   - name: PGPASSWORD
-                    value: '{{ db_connect_pass }}'
+                    value: '{{ psql_pass }}'
                 command:
                   - sh
                   - -lc


### PR DESCRIPTION
## Description

### Product
N/A

### Technical
`scout_common`'s `execute_sql` never consumed the `sql_dbname` parameter and instead self-referentially `set_fact`'d its connection variables (`db_connect_name`, etc.). Because `set_fact` persists as a host fact for the rest of the play, one role's connection target leaked into every later `execute_sql` call. In a full deploy, the hive role sets the target to the `hive` DB (in `create_readonly_user`); open-webui's later `ALTER SCHEMA public OWNER TO openwebui` then ran against the leaked `hive` DB instead of `openwebui`, reassigning hive's `public` schema to `openwebui`.

We observed this on a dev cluster: a routine hive image bump triggered a metastore rollout, and the new pod CrashLoopBackOff'd with `permission denied for schema public` (the `hive` role no longer owned its own schema). The version bump only surfaced the pre-existing corruption — the long-running old pod never re-validated its schema.

Fix: `execute_sql` now derives connection settings into fresh `psql_*` facts with inline defaults each invocation (no cross-role leakage), and consumes `sql_dbname` as the canonical target DB (`db_connect_name` still honored for back-compat). The hive caller switched to `sql_dbname`.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
N/A

##### Appsec
N/A — fix prevents DDL from running against an unintended database, which had reassigned schema ownership cross-database.

### Performance
N/A

### Data
N/A

### Backward compatibility
`sql_dbname` is now the canonical parameter; legacy `db_connect_name` is still honored, so existing callers continue to work.

## Testing
YAML validated for the changed task files. Manually verified the fix on the affected dev cluster: restored `hive` schema ownership, restarted the metastore, and confirmed the schema re-initialized (74 tables, `VERSION` 3.1.0) and the pod went Ready.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
