### PR TITLE
Disable Alloy stats reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/
 **/*.iml
 zap/*.json
 .playwright-mcp/
+.claude

--- a/ansible/roles/alloy/templates/alloy.values.yaml.j2
+++ b/ansible/roles/alloy/templates/alloy.values.yaml.j2
@@ -10,6 +10,11 @@ controller:
   tolerations: {{ alloy_tolerations | to_json }}
 
 alloy:
+  # Disable the anonymous usage report to stats.grafana.org (fails on
+  # air-gapped systems and wastes resources), mirroring how the grafana and
+  # loki roles disable analytics.reporting_enabled.
+  enableReporting: false
+
   configMap:
     content: |
       discovery.kubernetes "pods" {


### PR DESCRIPTION
## Description

When we switched to alloy in #368, we neglected to configure it to _not_ report stats a la #280 and #295. This fixes that gap.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
Minuscule unnoticeable performance improvement from not issuing stats updates requests, and not having to discard them on air-gapped nodes.

### Data
N/A

### Backward compatibility
Yes

## Testing
Noticed log lines reporting failures to connect to `stats.grafana.org/alloy-usage-report` from alloy in loki on dev03. Deployed with this modification and the lines disappeared.

## Note for reviewers
I threw in a `.gitignore` line for the `.claude` directory, which had been annoying me sitting untracked in my local repo. It's unrelated but I didn't want to open a separate PR just for that.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
