### PR TITLE
Fix persistent "session expired" banner in user admin panel

### DIFF
--- a/ansible/roles/keycloak/defaults/main.yaml
+++ b/ansible/roles/keycloak/defaults/main.yaml
@@ -52,9 +52,9 @@ keycloak_default_provider: github
 # available to override too, but rarely need changes.
 keycloak_terms_localizations: {}
 
-# Token lifespan (in seconds) — should match oauth2_proxy_cookie_expire
-keycloak_token_lifespan: 28800
-
+# keycloak_token_lifespan (the Scout-wide 8h SSO session) lives in
+# scout_common/defaults so the launchpad role can share the same value; these
+# client-level lifespans derive from it.
 keycloak_temporal_token_lifespan: '{{ keycloak_token_lifespan }}'
 keycloak_minio_token_lifespan: '{{ keycloak_token_lifespan }}'
 # Trino impersonation-pattern service principals (superset_svc, voila_svc,

--- a/ansible/roles/launchpad/tasks/deploy.yaml
+++ b/ansible/roles/launchpad/tasks/deploy.yaml
@@ -34,6 +34,7 @@
           issuer: '{{ keycloak_realm_url }}'
         nextAuthUrl: 'https://{{ server_hostname }}/api/auth'
         nextAuthSecret: '{{ launchpad_nextauth_secret }}'
+        sessionMaxAge: '{{ keycloak_token_lifespan }}'
         oauth2ProxySignOutUrl: '{{ oauth2_proxy_signout_url }}'
       ingress:
         enabled: true

--- a/ansible/roles/scout_common/defaults/main.yaml
+++ b/ansible/roles/scout_common/defaults/main.yaml
@@ -497,6 +497,14 @@ keycloak_wellknown_url: '{{ keycloak_realm_url }}/.well-known/openid-configurati
 # their own longer client-level lifespans (ADR 0022) and are unaffected.
 keycloak_access_token_lifespan: 300
 
+# Realm-level SSO session lifetime (seconds). Drives the realm's
+# ssoSessionIdleTimeout + ssoSessionMaxLifespan, and caps the launchpad next-auth
+# session (NEXTAUTH_SESSION_MAX_AGE) so that app cookie can't outlive the Keycloak
+# refresh token it carries. Should match oauth2_proxy_cookie_expire (the ingress
+# session) — both are the Scout-wide 8h session. Shared here (not in the keycloak
+# role) so the launchpad role can reference the same single value.
+keycloak_token_lifespan: 28800
+
 # Internal Keycloak URL for in-cluster service-to-service token minting
 # (e.g. Superset/Voila minting a *_svc client_credentials JWT for Trino).
 # Bypasses Traefik + TLS entirely — avoids self-signed-cert trust issues

--- a/helm/launchpad/templates/deployment.yaml
+++ b/helm/launchpad/templates/deployment.yaml
@@ -62,6 +62,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "launchpad.fullname" . }}-nextauth-secret
                   key: secret
+            - name: NEXTAUTH_SESSION_MAX_AGE
+              value: {{ .Values.auth.sessionMaxAge | quote }}
             {{- if .Values.auth.oauth2ProxySignOutUrl }}
             - name: OAUTH2_PROXY_SIGN_OUT_URL
               value: {{ .Values.auth.oauth2ProxySignOutUrl | quote }}

--- a/helm/launchpad/values.yaml
+++ b/helm/launchpad/values.yaml
@@ -135,6 +135,9 @@ auth:
     issuer: 'https://keycloak.example.com/auth/realms/scout'
   nextAuthUrl: 'https://launchpad.example.com'
   nextAuthSecret: 'changeme'
+  # next-auth session lifetime (seconds). Must match the Keycloak SSO session
+  # lifetime so the cookie can't outlive the refresh token it carries (8h).
+  sessionMaxAge: 28800
   oauth2ProxySignOutUrl: 'https://launchpad.example.com/oauth2/sign_out'
 
 # Additional environment variables

--- a/launchpad/src/app/admin/users/UsersClient.tsx
+++ b/launchpad/src/app/admin/users/UsersClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSession, signIn } from 'next-auth/react';
 import TopBar from '@/components/TopBar';
 import Brand from '@/components/Brand';
@@ -199,16 +199,28 @@ function seedValues(user: Row, schema: AttrSchema[]): Record<string, string[]> {
   return init;
 }
 
-// A 401 from the /api/users proxy means the SSO session backing our refresh
-// token is gone (Keycloak redeploy, a logout elsewhere, idle/max timeout), so
-// the proxy couldn't mint a token — distinct from a 403, which is a genuine
-// "not scout-admin". Throw a sentinel so callers prompt re-login instead of
-// surfacing the misleading authz message.
+// The /api/users proxy signals a dead session with 440 (it avoids 401, which the
+// oauth2-proxy ingress rewrites into its sign-in page — see the proxy route). A
+// 401 here instead means the ingress itself denied us. Either way the SSO session
+// backing our refresh token is gone (Keycloak redeploy, logout elsewhere, idle/max
+// timeout) — distinct from a 403, a genuine "not scout-admin". Throw a sentinel so
+// callers trigger recovery instead of surfacing the misleading authz message.
 const SESSION_EXPIRED = 'SESSION_EXPIRED';
+
+// One-shot guard (in sessionStorage so it survives the re-auth redirect) that
+// caps the silent re-login in recoverFromExpiry to one attempt per page load.
+// Cleared the moment any request succeeds — a returned response means the proxy
+// minted a token, so the refresh token is alive again.
+const REAUTH_GUARD = 'scoutUsersReauthAttempted';
 
 async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
   const r = await fetch(path, init);
-  if (r.status === 401) throw new Error(SESSION_EXPIRED);
+  // 440: the proxy's app-level "re-authenticate" signal (refresh token dead or no
+  // session), chosen to slip past the oauth2-proxy-error middleware that rewrites
+  // 401s into the sign-in page. 401: the ingress itself denied us (oauth2-proxy
+  // session gone) — same recovery either way.
+  if (r.status === 440 || r.status === 401) throw new Error(SESSION_EXPIRED);
+  if (typeof window !== 'undefined') sessionStorage.removeItem(REAUTH_GUARD);
   return r;
 }
 
@@ -694,6 +706,34 @@ export default function UsersClient({ scoutEnv, docsUrl }: { scoutEnv?: string; 
 
   const isAdmin = !!session?.user?.isAdmin;
 
+  // True once a re-auth redirect is kicked off this page load. The panel fires
+  // several /api/users calls at once (schema + rows), so multiple can 440
+  // together; only the first should start the redirect and the rest must no-op —
+  // otherwise the second trips the cross-load guard below and flashes the
+  // "session expired" banner for the moment before signIn() navigates away.
+  const recoveringRef = useRef(false);
+
+  // The session is dead (proxy 440/401) but our next-auth cookie is still present
+  // — a stale refresh token (e.g. signed out elsewhere, killing the SSO but not
+  // this cookie) or one that briefly outlived its SSO — so the no-session
+  // auto-login below won't fire. Re-mint via signIn(): with the 8h cookie cap, the
+  // original all-expired case is handled by cookie expiry + that auto-login, so
+  // whenever THIS path is reachable the oauth2-proxy session is still alive (you
+  // loaded the SPA through it). Keycloak then re-issues silently and the fresh
+  // refresh token replaces the dead one — no manual "Sign in again" step.
+  const recoverFromExpiry = useCallback(() => {
+    if (recoveringRef.current) return;
+    // Already tried a silent re-auth in a prior load and still landed here with a
+    // dead session — surface the manual banner rather than redirecting again.
+    if (sessionStorage.getItem(REAUTH_GUARD)) {
+      setAuthExpired(true);
+      return;
+    }
+    recoveringRef.current = true;
+    sessionStorage.setItem(REAUTH_GUARD, '1');
+    signIn('keycloak');
+  }, []);
+
   useEffect(() => {
     if (status !== 'loading' && !session) signIn('keycloak');
   }, [status, session]);
@@ -711,31 +751,34 @@ export default function UsersClient({ scoutEnv, docsUrl }: { scoutEnv?: string; 
       .then((s) => setSchema(s as AttrSchema[]))
       .catch((e) =>
         (e as Error).message === SESSION_EXPIRED
-          ? setAuthExpired(true)
+          ? recoverFromExpiry()
           : setError('Could not load the attribute schema. You may not have the scout-admin role.'),
       );
-  }, [isAdmin]);
+  }, [isAdmin, recoverFromExpiry]);
 
   // Pending uses /pending (carries requestedAt for the queue sort); active and
   // admin use /users?status= (carries current attributes for the editor).
-  const loadRows = useCallback(async (t: Tab) => {
-    setRows(null);
-    setError(null);
-    try {
-      if (t === 'pending') {
-        const r = await apiFetch('/api/users/pending');
-        if (!r.ok) throw new Error();
-        setRows(((await r.json()) as PendingUser[]).map(pendingToRow));
-      } else {
-        const r = await apiFetch(`/api/users/users?status=${t}`);
-        if (!r.ok) throw new Error();
-        setRows(((await r.json()) as ScoutUser[]).map(scoutToRow));
+  const loadRows = useCallback(
+    async (t: Tab) => {
+      setRows(null);
+      setError(null);
+      try {
+        if (t === 'pending') {
+          const r = await apiFetch('/api/users/pending');
+          if (!r.ok) throw new Error();
+          setRows(((await r.json()) as PendingUser[]).map(pendingToRow));
+        } else {
+          const r = await apiFetch(`/api/users/users?status=${t}`);
+          if (!r.ok) throw new Error();
+          setRows(((await r.json()) as ScoutUser[]).map(scoutToRow));
+        }
+      } catch (e) {
+        if ((e as Error).message === SESSION_EXPIRED) recoverFromExpiry();
+        else setError('Could not load users. You may not have the scout-admin role.');
       }
-    } catch (e) {
-      if ((e as Error).message === SESSION_EXPIRED) setAuthExpired(true);
-      else setError('Could not load users. You may not have the scout-admin role.');
-    }
-  }, []);
+    },
+    [recoverFromExpiry],
+  );
 
   useEffect(() => {
     if (isAdmin) loadRows(tab);
@@ -975,7 +1018,7 @@ export default function UsersClient({ scoutEnv, docsUrl }: { scoutEnv?: string; 
           onDone={onDone}
           onAuthExpired={() => {
             setSelected(null);
-            setAuthExpired(true);
+            recoverFromExpiry();
           }}
         />
       )}

--- a/launchpad/src/app/api/auth/signout/route.ts
+++ b/launchpad/src/app/api/auth/signout/route.ts
@@ -1,5 +1,0 @@
-import { NextResponse } from 'next/server';
-
-export async function POST() {
-  return NextResponse.json({ redirectUrl: process.env.OAUTH2_PROXY_SIGN_OUT_URL || null });
-}

--- a/launchpad/src/app/api/signout/route.ts
+++ b/launchpad/src/app/api/signout/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+
+// Hands the client the oauth2-proxy (ingress) sign-out URL so the dropdown can
+// redirect there after next-auth has cleared its own session.
+//
+// Deliberately NOT under /api/auth: a route there shadows next-auth's own
+// /api/auth/signout (App Router static segments beat the [...nextauth] catch-all),
+// so signOut() never reaches next-auth's handler — and since the session cookie
+// is httpOnly, only that handler can expire it. Living here keeps next-auth's
+// signout intact, so the launchpad logout actually clears the next-auth cookie.
+export async function POST() {
+  return NextResponse.json({ redirectUrl: process.env.OAUTH2_PROXY_SIGN_OUT_URL || null });
+}

--- a/launchpad/src/app/api/users/[...path]/route.ts
+++ b/launchpad/src/app/api/users/[...path]/route.ts
@@ -11,6 +11,15 @@ import { NextRequest, NextResponse } from 'next/server';
 // users/{id}/membership) match alongside the flat ones (schema, pending, users,
 // approve). Each method's allowlist of path shapes is checked before forwarding.
 
+// Both auth-failure responses below use 440 (Login Time-out), NOT 401. The shared
+// `oauth2-proxy-error` Traefik middleware rewrites every upstream 401 into the
+// oauth2-proxy sign-in page (status: ["401"] -> /oauth2/sign_in), which would
+// swallow these app-level "re-authenticate me" signals before the launchpad UI
+// ever sees them. 440 is caught by no middleware, so it reaches the browser
+// intact. (Still never 403 — a genuine authz denial is the SPI's 403, forwarded
+// as-is below.)
+const REAUTH_REQUIRED = 440;
+
 const ALLOWED: Record<string, readonly RegExp[]> = {
   GET: [/^schema$/, /^pending$/, /^users$/],
   POST: [/^approve$/, /^users\/[^/]+\/attributes$/, /^users\/[^/]+\/admin$/],
@@ -81,17 +90,17 @@ async function forward(req: NextRequest, segments: string[], method: 'GET' | 'PO
   }
   const jwt = await getToken({ req });
   if (!jwt) {
-    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    return NextResponse.json({ error: 'Not authenticated' }, { status: REAUTH_REQUIRED });
   }
 
   const body = method === 'POST' ? await req.text() : undefined;
   const accessToken = await freshAccessToken(jwt);
   if (!accessToken) {
     // Couldn't mint a token from the stored refresh token: the SSO session is
-    // gone. 401 (not 403) so the console prompts re-login rather than showing a
-    // misleading "not scout-admin" — a genuine authz denial is the SPI's 403,
-    // forwarded as-is below.
-    return NextResponse.json({ error: 'session_expired' }, { status: 401 });
+    // gone. Return REAUTH_REQUIRED (440, see above) so the console can prompt
+    // re-login — a bare 401 would be rewritten into the oauth2-proxy sign-in page
+    // by the ingress before the UI sees it.
+    return NextResponse.json({ error: 'session_expired' }, { status: REAUTH_REQUIRED });
   }
 
   const upstream = await callKeycloak(issuer, target, method, accessToken, body);

--- a/launchpad/src/components/UserDropdown.tsx
+++ b/launchpad/src/components/UserDropdown.tsx
@@ -60,9 +60,11 @@ export default function UserDropdown() {
               // First sign out from NextAuth
               await signOut({ redirect: false });
 
-              // Get the OAuth2 sign out URL from the API
+              // Then get the oauth2-proxy sign-out URL (a non-/api/auth route so it
+              // doesn't shadow next-auth's /api/auth/signout, which the signOut()
+              // above needs in order to clear the httpOnly session cookie).
               try {
-                const response = await fetch('/api/auth/signout', {
+                const response = await fetch('/api/signout', {
                   method: 'POST',
                 });
                 const data = await response.json();

--- a/launchpad/src/lib/auth.ts
+++ b/launchpad/src/lib/auth.ts
@@ -10,6 +10,19 @@ export const authOptions: NextAuthOptions = {
       authorization: { params: { scope: 'openid email profile microprofile-jwt' } },
     }),
   ],
+  // Cap our next-auth session at the Keycloak SSO session lifetime (8h, set from
+  // keycloak_token_lifespan via NEXTAUTH_SESSION_MAX_AGE). The default is 30 days,
+  // which lets the cookie — and the refresh token it carries — far outlive the SSO
+  // session it was minted from: the /api/users proxy can no longer refresh that
+  // token, so every call 401s until cookies are cleared. Matching the lifetimes
+  // also bounds how long the login-time isAdmin flag can stay stale after a
+  // Keycloak change. (JWT strategy, since there is no database adapter; sessions
+  // killed early — Keycloak redeploy, logout elsewhere — are recovered client-side
+  // on the proxy 401, so this is the floor, not the only safeguard.)
+  session: {
+    strategy: 'jwt',
+    maxAge: Number(process.env.NEXTAUTH_SESSION_MAX_AGE) || 28800,
+  },
   callbacks: {
     async jwt({ token, account, profile }) {
       // Only the refresh token goes in the session cookie — NOT the access token.


### PR DESCRIPTION
## Description

### Product

The user-administration console (Launchpad → Users) would get stuck on "Your session expired. Sign in again to continue — your access is unchanged" after the daily 8-hour session timeout (or KC session change by other means like logout or upgrade). Signing in again didn't fix the issue, the only workaround was manually clearing browser cookies. 

After this change, admins are re-authenticated transparently when SSO still active, or logged out cleanly to match the rest of the app.

### Technical

The root cause was a mismatch between Launchpad's two session layers, plus an ingress interaction:

- Launchpad runs its own next-auth session (a JWT cookie holding the Keycloak refresh token; the `/api/users` proxy mints an access token from it per request) in addition to the platform oauth2-proxy/Keycloak SSO. next-auth's cookie defaulted to 30 days, far outliving the 8h Keycloak SSO session. Once the SSO session expired, the cookie kept presenting a dead refresh token and every `/api/users` call failed, but `useSession()` still reported the user authenticated, so the SPA rendered as logged-in.
- The shared `oauth2-proxy-error` Traefik middleware rewrites every upstream HTTP 401 into the oauth2-proxy sign-in page, so the proxy's app-level "re-authenticate" 401 was swallowed before the UI could act on it.
- Launchpad sign-out never cleared the next-auth cookie: a custom `/api/auth/signout` route shadowed next-auth's signout endpoint, meaning logout killed the KC SSO but left a stale next-auth cookie, and re-login reused it.

Changes:

- Cap next-auth `session.maxAge` at the Keycloak SSO lifetime via a new `NEXTAUTH_SESSION_MAX_AGE` env var, sourced from `keycloak_token_lifespan`. 
- The `/api/users` proxy returns HTTP 440 (Login Time-out), not 401, for dead-session cases, so the `oauth2-proxy-error` middleware leaves the response intact; the client treats 440 (and 401) as "session expired".
- On 440/401 the console silently re-authenticates via next-auth `signIn('keycloak')`, falling back to the manual banner only if re-auth fails. Whenever this path is reachable, the oauth2-proxy session is still alive, so Keycloak re-issues silently and the dead refresh token is replaced.
- Moved the oauth2-proxy sign-out-URL helper from `/api/auth/signout` to `/api/signout` so it no longer shadows next-auth's signout; logout now clears the next-auth cookie and re-login mints a fresh session.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization

N/A, no role/perms change

##### Appsec

N/A, improved slightly by more thorough logout.

### Performance

N/A

### Data

N/A

### Backward compatibility

No issues with upgrade

## Testing

Verified on the dev04 cluster:

- Built and deployed the image; confirmed the new digest rolled out and that an unauthenticated `/api/users/schema` now returns 440 (was 401).
- Logout/login cycle: signing out through Launchpad then back in lands on a working Users console with no banner (the next-auth cookie is now cleared on logout).
- Mid-session recovery: revoking the admin's Keycloak session (admin console → Users → Sessions → Sign out) kills the token while oauth2-proxy stays alive; reopening Users auto-re-authenticates via `signIn` with no manual "Sign in again" click
- Logout from other service, confirm logged out from Launchpad Users console, logging back in works.

## Note for reviewers

- 440 status reasoning: `oauth2-proxy-error` middleware catches HTTP 401 and rewrites it to the oauth2-proxy sign-in page; returning 401 here for the internal call means ingress supersedes the next auth cookie refresh. 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`) — pre-commit passed on the changed files; run `--all-files` before merge
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate (N/A — no user doc covers the admin-console session lifecycle)
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate (Launchpad has no unit-test harness)
- [ ] I have added end-to-end tests, if appropriate
