### PR TITLE
fix(cves): jackson bump, scout-notebook base, keycloak scan enforcing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,6 @@ jobs:
             allow-failure: true
           - image-name: keycloak
             subproject: keycloak
-            allow-failure: true
           - image-name: xnat-plugin-installer
             subproject: docker/xnat-plugin-installer
             allow-failure: true

--- a/extractor/hl7log-extractor/build.gradle
+++ b/extractor/hl7log-extractor/build.gradle
@@ -35,6 +35,14 @@ ext['postgresql.version'] = '42.7.11'
 // plus the earlier 4.2.13 batch (CVE-2026-42577 through -42587).
 ext['netty.version'] = '4.2.15.Final'
 
+// TODO: Remove once Spring Boot manages jackson-databind >= 2.21.4 / 3.1.4.
+// Overrides the Spring Boot BOM's pinned Jackson lines to address
+// CVE-2026-54512 and CVE-2026-54513 (HIGH) in jackson-databind. Spring Boot 4
+// carries both Jackson 2 (com.fasterxml, jackson-2-bom) and Jackson 3
+// (tools.jackson, jackson-bom).
+ext['jackson-2-bom.version'] = '2.21.4'
+ext['jackson-bom.version'] = '3.1.4'
+
 // TODO: Remove once Temporal ships a release that brings opentelemetry >= 1.62.0.
 // Pins the io.opentelemetry:* family (transitively from temporal-sdk) to 1.62.0
 // to address the opentelemetry-api vulnerability CVE-2026-45292. Imported via

--- a/helm/scout-notebook/Dockerfile
+++ b/helm/scout-notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jupyter/scipy-notebook:python-3.13.13
+FROM quay.io/jupyter/scipy-notebook:python-3.13.14
 
 # Platform packages + Jupyter extensions via mamba. Everything else
 # (torch, transformers, scikit-learn, etc.) is user-installed via the

--- a/keycloak/.trivyignore.yaml
+++ b/keycloak/.trivyignore.yaml
@@ -1,0 +1,22 @@
+# Everything below ships inside the upstream quay.io/keycloak/keycloak:26.6.3
+# server distribution (its bundled netty / jackson / JDBC-driver jars), not in
+# our event-listener provider jar (whose Keycloak deps are compileOnly and
+# don't ship). We're already on the latest Keycloak release, and these CVEs
+# were disclosed too recently for any Keycloak build to carry the fixed deps —
+# so there's nothing to bump in our layer and no fixed base image to adopt.
+# Revisit when a newer Keycloak release bundles the fixed versions.
+vulnerabilities:
+  # mssql-jdbc (Keycloak bundles JDBC drivers for all supported DBs; Scout
+  # uses postgres, so the SQL Server driver is never loaded)
+  - id: CVE-2025-59250 # com.microsoft.sqlserver:mssql-jdbc 13.2.1
+  # netty 4.1.133 family bundled by Keycloak/Quarkus (fixed in 4.1.135)
+  - id: CVE-2026-44249 # netty-handler
+  - id: CVE-2026-44893 # netty-codec-haproxy
+  - id: CVE-2026-45416 # netty-handler
+  - id: CVE-2026-45674 # netty-resolver-dns
+  - id: CVE-2026-47691 # netty-resolver-dns
+  - id: CVE-2026-48059 # netty-codec-haproxy
+  - id: CVE-2026-50010 # netty-handler
+  # jackson-databind 2.21.2 bundled by Keycloak (fixed in 2.21.4)
+  - id: CVE-2026-54512 # jackson-databind
+  - id: CVE-2026-54513 # jackson-databind


### PR DESCRIPTION
## Description

### Product
N/A — no user-facing change.

### Technical
Security-only refresh; three independent pieces, no functional change:

- **hl7log-extractor**: override Spring Boot 4's Jackson pins to `jackson-databind` 2.21.4 (`com.fasterxml`, via `jackson-2-bom`) / 3.1.4 (`tools.jackson`, via `jackson-bom`), clearing HIGH **CVE-2026-54512** and **CVE-2026-54513**. Both lines ship in our fat jar, so this is a real fix — verified the runtimeClasspath resolves to the fixed versions.
- **scout-notebook**: bump the scipy-notebook base image to the latest `python-3.13.14`.
- **keycloak**: make its Trivy scan enforcing (drop `allow-failure`). The remaining findings are all in the upstream `keycloak:26.6.3` server distribution (netty, jackson-databind, mssql-jdbc); we're on the latest Keycloak release and the event-listener's Keycloak deps are `compileOnly`, so they can't be patched in our layer — a reasoned `keycloak/.trivyignore.yaml` covers them while the gate stays live for new CVEs.

## Type of change
- [x] Improvement

## Impact

### Security

##### Authorization
N/A — no roles, permissions, or data-access changes.

##### Appsec
Removes two HIGH `jackson-databind` CVEs from the hl7log-extractor image and turns the keycloak scan into a blocking gate. Net reduction in shipped vulnerabilities.

### Performance
N/A.

### Data
N/A.

### Backward compatibility
N/A — patch-level dependency bumps and base-image refresh; no API or data-model changes.

## Testing
- hl7log-extractor `./gradlew test` passes on the Jackson bump; `dependencyInsight` confirms the runtimeClasspath resolves to 2.21.4 / 3.1.4.
- CI image scans verify 0 fixable CRITICAL/HIGH after the ignores.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (ran `pre-commit` on the changed files)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] User documentation — N/A
- [ ] Technical documentation / ADR — N/A
- [ ] Unit tests — N/A (dependency/base bumps; existing suites pass)
- [ ] End-to-end tests — N/A
