### PR TITLE
refactor(hl7-transformer): replace smolder HL7 data source with native PySpark reader

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,12 +144,20 @@ jobs:
       - uses: actions/setup-python@v6.3.0
         with:
           python-version: '3.12'
+      # JVM for the PySpark local-mode tests
+      - uses: actions/setup-java@v5
+        with:
+          distribution: ${{ ENV.JAVA_DIST }}
+          java-version: ${{ ENV.JAVA_VERSION }}
       - name: Install Molecule and dependencies
         run: |
-          pip install molecule ansible-core pytest pydantic tiktoken httpx pytest-asyncio trino requests
+          pip install molecule ansible-core pytest pydantic tiktoken httpx pytest-asyncio trino requests pyspark==3.5.4
       - name: 'Unit tests: filter plugins'
         shell: bash
         run: cd ansible && pytest tests/unit/filter_plugins/ -v
+      - name: 'Unit tests: hl7-transformer'
+        shell: bash
+        run: cd extractor/hl7-transformer && PYTHONPATH=src pytest tests/ -v
       - name: 'Unit tests: Open WebUI link sanitizer filter'
         shell: bash
         run: cd helm/open-webui-bootstrap && PYTHONPATH=files/payloads pytest tests/test_link_sanitizer_filter.py -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,8 +147,8 @@ jobs:
       # JVM for the PySpark local-mode tests
       - uses: actions/setup-java@v5
         with:
-          distribution: ${{ ENV.JAVA_DIST }}
-          java-version: ${{ ENV.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DIST }}
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Install Molecule and dependencies
         run: |
           pip install molecule ansible-core pytest pydantic tiktoken httpx pytest-asyncio trino requests pyspark==3.5.4

--- a/extractor/hl7-transformer/Dockerfile
+++ b/extractor/hl7-transformer/Dockerfile
@@ -21,7 +21,6 @@ ADD --chown=spark \
     https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-hdfs/3.2.2/hadoop-hdfs-3.2.2.jar \
     https://repo1.maven.org/maven2/org/antlr/antlr4-runtime/4.9.3/antlr4-runtime-4.9.3.jar \
     https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.793/aws-java-sdk-bundle-1.12.793.jar \
-    https://github.com/washu-tag/smolder/releases/download/0.1.0-20250306/smolder_2.12-0.1.0-SNAPSHOT.jar \
     ${SPARK_HOME}/jars/
 
 # Create venv

--- a/extractor/hl7-transformer/src/hl7scout/hl7extractor/deltalake.py
+++ b/extractor/hl7-transformer/src/hl7scout/hl7extractor/deltalake.py
@@ -25,6 +25,7 @@ from .schemautils import (
     struct_with_nulls,
 )
 from .dataextraction import process_derivative_data
+from .hl7reader import read_hl7
 from .sparkutils import merge_df_into_dt_on_column
 
 import os
@@ -146,7 +147,7 @@ def import_hl7_files_to_deltalake(
         )
 
         # Read the temp HL7 files
-        df = spark.read.format("hl7").load(temp_hl7_files)
+        df = read_hl7(spark, temp_hl7_files)
 
         # Join with the temp to s3 mapping df to get the S3 paths
         df = df.withColumn("temp_path", F.input_file_name())
@@ -154,7 +155,7 @@ def import_hl7_files_to_deltalake(
         df = df.drop("temp_path")
 
         activity.heartbeat()
-        # Extract the HL7 segments from the smolder objects
+        # Extract the HL7 segments from the parsed messages
         df = (
             df.select(
                 "source_file",

--- a/extractor/hl7-transformer/src/hl7scout/hl7extractor/hl7reader.py
+++ b/extractor/hl7-transformer/src/hl7scout/hl7extractor/hl7reader.py
@@ -1,0 +1,49 @@
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import functions as F
+
+
+def read_hl7(spark: SparkSession, paths: list[str]) -> DataFrame:
+    """Read one-message-per-file HL7 files into rows of {message, segments}.
+
+    Drop-in replacement for the smolder data source (spark.read.format("hl7")),
+    preserving its parsing semantics:
+
+    - One file produces one row.
+    - `message` is the first line of the file, verbatim (the MSH segment),
+      taken before any empty-line filtering.
+    - `segments` holds each subsequent non-empty line as a struct of `id` (the
+      text before the first pipe) and `fields` (the remaining pipe-separated
+      values, so fields[0] is HL7 field 1). Trailing empty fields are dropped
+      and interior empty fields are kept, matching the Java String.split
+      behavior smolder relied on.
+    - Segment lines may be terminated by \\r (HL7 standard), \\n, or \\r\\n.
+
+    Known divergences, both on inputs where smolder threw and failed the Spark
+    task: a zero-byte file yields no row at all (the text source skips empty
+    files, so the file is never marked ingested), and a segment line of only
+    pipes yields a segment with an empty id. Neither input is produced by
+    hl7log-extractor, which drops all-blank messages before upload.
+    """
+    raw_lines = F.split(F.col("value"), "\r\n|\r|\n")
+    # Split each segment line once into tokens, then build structs from the
+    # token arrays; repeating the split inside the struct lambda would
+    # re-evaluate it per accessed element.
+    segment_tokens = F.transform(
+        F.filter(
+            F.slice(raw_lines, 2, F.size(raw_lines) - 1),
+            lambda line: line != "",
+        ),
+        # Stripping trailing pipes before the split is what drops trailing
+        # empty fields.
+        lambda line: F.split(F.regexp_replace(line, "\\|+$", ""), "\\|"),
+    )
+    return spark.read.text(paths, wholetext=True).select(
+        F.get(raw_lines, 0).alias("message"),
+        F.transform(
+            segment_tokens,
+            lambda tokens: F.struct(
+                F.get(tokens, 0).alias("id"),
+                F.slice(tokens, 2, F.size(tokens) - 1).alias("fields"),
+            ),
+        ).alias("segments"),
+    )

--- a/extractor/hl7-transformer/tests/test_hl7reader.py
+++ b/extractor/hl7-transformer/tests/test_hl7reader.py
@@ -163,3 +163,34 @@ def test_downstream_extraction_pattern(spark, tmp_path):
     assert row.msh[9] == "2.25.705"  # MSH-10 message control id
     assert row.pid[1] == "MPI123"  # PID-2
     assert row.obx_lines[0].fields[4] == "Report text line"  # OBX-5
+
+
+def test_repeated_segments_keep_file_order(spark, tmp_path):
+    # deltalake.py posexplodes the OBX segments and assembles report_text in
+    # array order, so the reader must keep repeated segments in file order.
+    path = write_hl7(
+        tmp_path,
+        "multi_obx.hl7",
+        [MSH, "OBX|1|TX|||LINE-A", "OBX|2|TX|||LINE-B", "OBX|3|TX|||LINE-C"],
+    )
+    obx = (
+        read_hl7(spark, [path])
+        .select(F.expr("filter(segments, x -> x.id = 'OBX')").alias("obx"))
+        .collect()[0]
+        .obx
+    )
+
+    assert [segment.fields[4] for segment in obx] == ["LINE-A", "LINE-B", "LINE-C"]
+
+
+def test_segment_of_only_pipes_yields_empty_id(spark, tmp_path):
+    # Documented divergence from smolder, which threw on an empty field array
+    # and failed the whole task. A pipes-only line yields a segment with an
+    # empty id and no fields, which matches no downstream id filter and is
+    # harmless. hl7log-extractor never produces this (segment lines start with
+    # an id).
+    path = write_hl7(tmp_path, "pipes_only.hl7", [MSH, "|||"])
+    row = read_one(spark, path)
+
+    assert [segment.id for segment in row.segments] == [""]
+    assert list(row.segments[0].fields) == []

--- a/extractor/hl7-transformer/tests/test_hl7reader.py
+++ b/extractor/hl7-transformer/tests/test_hl7reader.py
@@ -1,0 +1,165 @@
+from pathlib import Path
+
+import pytest
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+
+from hl7scout.hl7extractor.hl7reader import read_hl7
+
+
+@pytest.fixture(scope="session")
+def spark():
+    spark = (
+        SparkSession.builder.master("local[1]")
+        .appName("test-hl7reader")
+        .config("spark.ui.enabled", "false")
+        .config("spark.sql.shuffle.partitions", "1")
+        .getOrCreate()
+    )
+    yield spark
+    spark.stop()
+
+
+MSH = r"MSH|^~\&|SOMERIS|ABCHOSP|SOMEAPP|ABC_HOSP_DEPT_X|20140713130856|TBD|ORU^R01|2.25.705|P|2.7"
+
+
+def write_hl7(
+    tmp_path: Path, name: str, lines: list[str], terminator: str = "\r"
+) -> str:
+    """Write segment lines the way hl7log-extractor does: UTF-8, each line
+    followed by a terminator."""
+    path = tmp_path / name
+    path.write_bytes("".join(line + terminator for line in lines).encode("utf-8"))
+    return str(path)
+
+
+def read_one(spark, path: str):
+    rows = read_hl7(spark, [path]).collect()
+    assert len(rows) == 1
+    return rows[0]
+
+
+def segments_as_dict(row) -> dict[str, list[str]]:
+    return {segment.id: list(segment.fields) for segment in row.segments}
+
+
+def test_basic_message(spark, tmp_path):
+    path = write_hl7(
+        tmp_path,
+        "basic.hl7",
+        [MSH, "PID|1||ABC451104^^^ABC^MR||PARK^SEO-HYEON", "OBR|1|placer|filler"],
+    )
+    row = read_one(spark, path)
+
+    assert row.message == MSH
+    segments = segments_as_dict(row)
+    # fields[0] is HL7 field 1: the segment id is not part of fields
+    assert segments["PID"][0] == "1"
+    assert segments["PID"][1] == ""
+    assert segments["PID"][2] == "ABC451104^^^ABC^MR"
+    assert segments["OBR"] == ["1", "placer", "filler"]
+
+
+def test_trailing_empty_fields_dropped_interior_kept(spark, tmp_path):
+    # Java's String.split drops trailing empty strings but keeps interior
+    # ones; smolder inherited that and downstream null-vs-empty checks
+    # depend on it.
+    path = write_hl7(tmp_path, "trailing.hl7", [MSH, "PID|123||", "ORC||x"])
+    segments = segments_as_dict(read_one(spark, path))
+
+    assert segments["PID"] == ["123"]
+    assert segments["ORC"] == ["", "x"]
+
+
+def test_empty_lines_skipped_in_segments(spark, tmp_path):
+    path = write_hl7(tmp_path, "blanks.hl7", [MSH, "", "PID|1", ""])
+    row = read_one(spark, path)
+
+    assert row.message == MSH
+    assert [segment.id for segment in row.segments] == ["PID"]
+
+
+@pytest.mark.parametrize("terminator", ["\r", "\n", "\r\n"])
+def test_line_terminators(spark, tmp_path, terminator):
+    path = write_hl7(
+        tmp_path,
+        f"term_{len(terminator)}_{ord(terminator[0])}.hl7",
+        [MSH, "PID|1"],
+        terminator=terminator,
+    )
+    row = read_one(spark, path)
+
+    assert row.message == MSH
+    assert segments_as_dict(row) == {"PID": ["1"]}
+
+
+def test_segment_without_pipes(spark, tmp_path):
+    path = write_hl7(tmp_path, "nopipes.hl7", [MSH, "NTE"])
+    segments = segments_as_dict(read_one(spark, path))
+
+    assert segments == {"NTE": []}
+
+
+def test_empty_file_yields_no_row(spark, tmp_path):
+    # Divergence from smolder, which threw on empty input and failed the
+    # whole Spark task: the text source skips zero-byte files entirely.
+    # hl7log-extractor never produces them (all-blank messages are dropped
+    # before upload).
+    path = tmp_path / "empty.hl7"
+    path.write_bytes(b"")
+
+    assert read_hl7(spark, [str(path)]).collect() == []
+
+
+def test_blank_first_line_is_message(spark, tmp_path):
+    # smolder took the message from the first line before filtering empty
+    # lines, so a leading blank line means the MSH line lands in segments
+    # and the file fails downstream MSH parsing. Preserve that.
+    path = write_hl7(tmp_path, "leading_blank.hl7", ["", MSH, "PID|1"])
+    row = read_one(spark, path)
+
+    assert row.message == ""
+    assert [segment.id for segment in row.segments] == ["MSH", "PID"]
+
+
+def test_non_ascii_utf8(spark, tmp_path):
+    # hl7log-extractor decodes logs as ISO-8859-1 and writes the .hl7 files
+    # as UTF-8, so non-ASCII input reaches the reader as valid UTF-8.
+    path = write_hl7(tmp_path, "utf8.hl7", [MSH, "PID|1||X||MUÑOZ^JOSÉ"])
+    segments = segments_as_dict(read_one(spark, path))
+
+    assert segments["PID"][4] == "MUÑOZ^JOSÉ"
+
+
+def test_one_row_per_file_with_input_file_name(spark, tmp_path):
+    # deltalake.py joins on input_file_name() to map rows back to S3 paths.
+    paths = [write_hl7(tmp_path, f"msg_{i}.hl7", [MSH, f"PID|{i}"]) for i in range(3)]
+    df = read_hl7(spark, paths).withColumn("file", F.input_file_name())
+    rows = df.collect()
+
+    assert len(rows) == 3
+    pid_by_file = {
+        Path(row.file.removeprefix("file://")).name: row.segments[0].fields[0]
+        for row in rows
+    }
+    assert pid_by_file == {f"msg_{i}.hl7": str(i) for i in range(3)}
+
+
+def test_downstream_extraction_pattern(spark, tmp_path):
+    # The exact expressions deltalake.py runs against the reader's output.
+    path = write_hl7(
+        tmp_path,
+        "downstream.hl7",
+        [MSH, "PID|1|MPI123|ABC451104^^^ABC^MR", "OBX|1|TX|GDT|1|Report text line"],
+    )
+    df = read_hl7(spark, [path]).select(
+        F.split("message", "\\|").alias("msh"),
+        F.expr("filter(segments, x -> x.id = 'PID')[0].fields").alias("pid"),
+        F.expr("filter(segments, x -> x.id = 'OBX')").alias("obx_lines"),
+    )
+    row = df.collect()[0]
+
+    assert row.msh[3] == "ABCHOSP"  # MSH-4 sending facility
+    assert row.msh[9] == "2.25.705"  # MSH-10 message control id
+    assert row.pid[1] == "MPI123"  # PID-2
+    assert row.obx_lines[0].fields[4] == "Report text line"  # OBX-5


### PR DESCRIPTION
## Description

### Product
N/A — no user-facing change.

### Technical
Replaces the [smolder](https://github.com/washu-tag/smolder) Spark data source (`spark.read.format("hl7")`) with a native PySpark reader (`hl7reader.read_hl7`) — ~30 lines of Catalyst expressions, no UDFs — and drops the Scala 2.12 smolder jar from the transformer image.

Two reasons:
- **Unblocks the Spark 4 upgrade** (next PR in the stack): Spark 4 is Scala 2.13-only, and the smolder jar is `_2.12`.
- **Retires a dormant dependency**: the `washu-tag/smolder` fork's only local patch was already merged upstream, and upstream has no Spark 4 / Scala 2.13 work.

The reader preserves smolder's parsing semantics the pipeline depends on: trailing empty fields dropped / interior kept (Java `String.split` behavior), `message` taken from the first line before empty-line filtering, and `\r` / `\n` / `\r\n` terminators.

## Type of change
- [x] Refactor (code improvement with no functional changes)

## Impact

### Security

##### Authorization
N/A.

##### Appsec
Removes an unmaintained third-party Scala jar from the image (smaller dependency surface).

### Performance
Parity-timed over the staging corpus: native reader within noise of smolder on a full scan; no UDFs, so no Python serialization cost.

### Data
Edge cases verified: trailing vs interior empty fields, blank lines, `\r`/`\n`/`\r\n` terminators, non-ASCII (the extractor writes UTF-8). The only behavioral divergences are on inputs `hl7log-extractor` never produces (zero-byte files, pipes-only segment lines), where smolder previously failed the whole task.

### Backward compatibility
Output parity verified against the smolder jar over all 910 messages from `tests/ingest/staging_test_data` (replicating the extractor's log-split): identical rows, values, and downstream-propagated schema.

## Testing
- New unit tests (`tests/test_hl7reader.py`, 12 cases) covering the parity edge cases above.
- Parity diff old-vs-new over the 910-message corpus: 0 differences.
- CI deploy-and-test exercises the full ingest pipeline end-to-end.

## Note for reviewers
Stacked on #451 (`pr/cve-refresh`) so CI inherits the jackson fix and keycloak ignorefile; the diff against that base is just this one commit. GitHub will auto-retarget the base to `main` once #451 merges. This is the first of the smolder → Spark 4 stack; the Spark 4.1.1 / Delta 4.3.0 upgrade follows in the next PR.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (ran `pre-commit` on the changed files)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] User documentation — N/A
- [ ] Technical documentation / ADR — N/A
- [x] I have added unit tests
- [ ] End-to-end tests — N/A (existing CI ingest tests cover the path)
