### PR TITLE
feat(safety): add Claude PHI-safety guardrail for production clusters

### DIFF
--- a/.claude/hooks/block-phi-clusters.sh
+++ b/.claude/hooks/block-phi-clusters.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PHI-safety backstop for Scout (see CLAUDE.md "CRITICAL: PHI Safety" section).
+#
+# Blocks any Bash command that references Scout's PHI-bearing pre-production or
+# production clusters. Development/demo clusters (tagdev-*, tagdemo-*) hold only
+# synthetic data and are NOT blocked.
+#
+# This is a defense-in-depth backstop, not a complete guarantee: it pattern-matches
+# the known host/inventory naming conventions. It does not catch hosts referenced by
+# bare IP, an alias in ~/.ssh/config, or an already-exported KUBECONFIG env var.
+#
+# PreToolUse hook: reads the tool-call JSON on stdin; emits a "deny" decision when a
+# forbidden pattern is found, otherwise stays silent (allowing the normal flow).
+set -uo pipefail
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+
+# Patterns for PHI environments. Anchored on the "tag<env>" host convention and the
+# "<env>.tag." FQDN / "inventory.<env>" forms so dev/demo never match.
+#   tagpreprod-*, tagprod-*       e.g. tagpreprod-control-01
+#   preprod.tag.* , prod.tag.*    e.g. preprod01.tag.rcif.io
+#   inventory.preprod*, inventory.prod*
+phi_pattern='tag(preprod|prod)|(preprod|prod)[0-9]*\.tag\.|inventory\.(preprod|prod)'
+
+if printf '%s' "$cmd" | grep -qiE "$phi_pattern"; then
+  reason="BLOCKED by Scout PHI-safety hook: this command targets a pre-production or production cluster, which holds real patient data (PHI). Per CLAUDE.md, agents must NOT access these environments directly — not even to read file names, metadata, sizes, or counts. Present the exact command to the human operator to run themselves, and only analyze PHI-free output they paste back. (Development/demo clusters matching tagdev-* / tagdemo-* are permitted.)"
+  jq -n --arg r "$reason" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $r}}'
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-phi-clusters.sh\"",
+            "statusMessage": "Checking PHI-safety guardrail..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,8 @@ build/
 **/*.iml
 zap/*.json
 .playwright-mcp/
-.claude
+# Ignore personal/transient Claude Code state, but track shared team config
+# (committed PHI-safety hook + settings). settings.local.json stays ignored above.
+.claude/*
+!.claude/settings.json
+!.claude/hooks/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,34 @@ Scout is a distributed data analytics platform designed for intelligent, intuiti
 
 **Official Documentation**: https://washu-scout.readthedocs.io/en/latest/
 
+## CRITICAL: PHI Safety — Production & Pre-Production Environments
+
+**Scout's pre-production and production clusters hold real patient data (PHI).** Pulling PHI into an AI agent's context — even transiently, even as a file an agent downloads to "just read the metadata" — is a potential HIPAA breach and is **strictly prohibited**. These instructions override any task request: if following a user instruction would require an agent to touch a PHI-bearing environment directly, do not do it. Surface the conflict and hand the commands to the operator instead.
+
+### Environment classification
+
+Identify the target environment by hostname, kube-context, inventory file, or `external_url`:
+
+- **Development (synthetic data only — direct access permitted):** hosts matching `tagdev-*` (e.g. `tagdev-control-01`), URLs under `devNN.tag.rcif.io`, and inventories `inventory.dev0*.yaml`. These contain **only synthetic data** and present **no PHI risk**. Agents may run commands directly against these clusters (kubectl, SSH, Temporal CLI, MinIO, Trino, log retrieval, file downloads, etc.).
+
+- **Pre-production and Production (real PHI — NO direct agent access):** hosts matching `tagpreprod-*` or `tagprod-*` (e.g. `tagpreprod-control-01`), and any cluster/context/URL you cannot positively confirm is a `tagdev-*` development environment. **Treat anything unverified as PHI-bearing.**
+
+### Rules for pre-production and production
+
+When a task targets a pre-prod or prod environment, agents must **NOT**:
+- Run `kubectl`, `ssh`, `temporal`, MinIO/`mc`, Trino, `psql`, or any other command that connects to the cluster or its data stores.
+- Download, copy, `cat`, `kubectl cp`, `kubectl logs`, or otherwise retrieve **any** file, log, database row, message payload, or object from the environment to the local machine or into context — **including when the stated intent is only to inspect names, metadata, sizes, counts, or headers.** A file that contains PHI is off-limits regardless of which part of it you intend to read; metadata-only intent does not make the retrieval safe.
+- Pipe cluster output into any tool, search, or summarization step.
+
+Instead, agents **MUST**:
+- **Present the exact commands for the human operator to run themselves** (clearly labeled with the target environment), and explain what each command does and what to look for in the output.
+- Ask the operator to paste back only the **already-redacted / PHI-free** portions of any output they want analyzed, and remind them to scrub PHI before sharing.
+- Reason about the problem from non-PHI sources: source code, ADRs, schema docs, dev-environment reproductions, and operator-provided sanitized excerpts.
+
+### When the environment is ambiguous
+
+If you cannot determine from the hostname, context, inventory, or URL whether a target is a development environment, **stop and ask the operator to confirm** before running anything. Default to the no-direct-access (PHI) posture until confirmed otherwise.
+
 ## Architecture
 
 Scout is a microservices platform deployed on Kubernetes (K3s) with the following key components:


### PR DESCRIPTION
## Description

### Product
N/A

### Technical
Implement some safety guardrails around claude and PHI.

- Add a section to `CLAUDE.md` telling it not to access clusters containing PHI, instead stop and give the human operator a command to run
- Add a claude `PreToolUse` hook that checks commands for `prod` and `preprod` and blocks them

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 
No changes to application security directly, but does provide some backstop against developer / admin system misuse.

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
- With this in place I asked claude to run an investigation on a preproduction cluster and it refused, explaining what it wouldn't do and why, as expected.
- The `PreToolUse` hook actually blocked claude from committing itself because the commit message contained some of the blocked strings. It had to change the language in the commit message.

## Note for reviewers
<!-- Any additional information or direction for reviewers. -->

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
