### PR TITLE
fix(extractor): Dedupe incoming update/inserts on curated table

### DIFF
--- a/extractor/hl7-transformer/src/hl7scout/hl7extractor/curatedtable.py
+++ b/extractor/hl7-transformer/src/hl7scout/hl7extractor/curatedtable.py
@@ -71,7 +71,7 @@ def curate_silver_table(batch_df, spark, table_name):
       more complex workflow to implement.
     """
 
-    filtered_df = filter_df_for_update_inserts(batch_df)
+    filtered_df = filter_df_for_update_inserts(batch_df, "source_file")
     if filtered_df is None:
         return
 

--- a/extractor/hl7-transformer/src/hl7scout/hl7extractor/mappingtableextractor.py
+++ b/extractor/hl7-transformer/src/hl7scout/hl7extractor/mappingtableextractor.py
@@ -67,7 +67,9 @@ class MappingTableExtractor:
         self.dataframes_to_unpersist: List[DataFrame] = []
 
     def extract(self, batch_df: DataFrame):
-        filtered_df = filter_df_for_update_inserts(batch_df, "primary_report_identifier")
+        filtered_df = filter_df_for_update_inserts(
+            batch_df, "primary_report_identifier"
+        )
         if filtered_df is None:
             return
         processed_df = self.preprocess(filtered_df)

--- a/extractor/hl7-transformer/src/hl7scout/hl7extractor/mappingtableextractor.py
+++ b/extractor/hl7-transformer/src/hl7scout/hl7extractor/mappingtableextractor.py
@@ -67,7 +67,7 @@ class MappingTableExtractor:
         self.dataframes_to_unpersist: List[DataFrame] = []
 
     def extract(self, batch_df: DataFrame):
-        filtered_df = filter_df_for_update_inserts(batch_df)
+        filtered_df = filter_df_for_update_inserts(batch_df, "primary_report_identifier")
         if filtered_df is None:
             return
         processed_df = self.preprocess(filtered_df)

--- a/extractor/hl7-transformer/src/hl7scout/hl7extractor/sparkutils.py
+++ b/extractor/hl7-transformer/src/hl7scout/hl7extractor/sparkutils.py
@@ -20,22 +20,28 @@ def merge_df_into_dt_on_column(
     )
 
 
-def filter_df_for_update_inserts(batch_df: DataFrame) -> Optional[DataFrame]:
+def filter_df_for_update_inserts(batch_df: DataFrame, dedupe_col: str) -> Optional[DataFrame]:
     if batch_df.isEmpty():
         return None
 
     updates_insert_df = batch_df.filter(
         F.col("_change_type").isin(["insert", "update_postimage"])
-    ).drop("_change_type", "_commit_version", "_commit_timestamp")
+    )
 
     if updates_insert_df.isEmpty():
         return None
 
-    return updates_insert_df
+    dedupe_window = Window.partitionBy(dedupe_col).orderBy(F.desc("_commit_version"))
+
+    return (
+        updates_insert_df.withColumn("dedupe_index", F.row_number().over(dedupe_window))
+        .filter(F.col("dedupe_index") == 1)
+        .drop("_change_type", "_commit_version", "_commit_timestamp", "dedupe_index")
+    )
 
 
 def dedupe_df_on_accession_number(batch_df: DataFrame) -> Optional[DataFrame]:
-    updates_insert_df = filter_df_for_update_inserts(batch_df)
+    updates_insert_df = filter_df_for_update_inserts(batch_df, "primary_report_identifier")
 
     if updates_insert_df is None:
         return None

--- a/extractor/hl7-transformer/src/hl7scout/hl7extractor/sparkutils.py
+++ b/extractor/hl7-transformer/src/hl7scout/hl7extractor/sparkutils.py
@@ -20,7 +20,9 @@ def merge_df_into_dt_on_column(
     )
 
 
-def filter_df_for_update_inserts(batch_df: DataFrame, dedupe_col: str) -> Optional[DataFrame]:
+def filter_df_for_update_inserts(
+    batch_df: DataFrame, dedupe_col: str
+) -> Optional[DataFrame]:
     if batch_df.isEmpty():
         return None
 
@@ -41,7 +43,9 @@ def filter_df_for_update_inserts(batch_df: DataFrame, dedupe_col: str) -> Option
 
 
 def dedupe_df_on_accession_number(batch_df: DataFrame) -> Optional[DataFrame]:
-    updates_insert_df = filter_df_for_update_inserts(batch_df, "primary_report_identifier")
+    updates_insert_df = filter_df_for_update_inserts(
+        batch_df, "primary_report_identifier"
+    )
 
     if updates_insert_df is None:
         return None


### PR DESCRIPTION
To handle the scenario where multiple changes are processed at once

## Description

### Product
N/A

### Technical
We deduplicate multiple updates and/or insert rows when processing the delta CDF to keep only the latest (from `_commit_version`) row per report.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
N/A

##### Appsec
<!-- Did you review your changes with application security in mind? See the [OWASP list](https://github.com/0xRadi/OWASP-Web-Checklist). -->

### Performance
If anything, would hopefully improve performance.

### Data
Allowed "stuck" state of preprod to continue.

### Backward compatibility
N/A

## Testing
Allowed "stuck" state of preprod to continue. I also tried it on one of the failed days and now it passed. I had some odd behavior where I ran into a failure + #458 , although I think that was from the scheduled ingest starting at around the same time and backing up. The automatic retry did succeed eventually.

## Note for reviewers
<!-- Any additional information or direction for reviewers. -->

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
