### PR TITLE
fix(data-generator): Pass in number of workers in helm deploy to data generator

### DIFF
--- a/helm/data-generator/templates/deployment.yaml
+++ b/helm/data-generator/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: "JAVA_TOOL_OPTIONS"
               value: {{ .Values.javaToolOptions | quote }}
             - name: "NUM_WORKERS"
-              value: {{ .Values.replicaCount }}
+              value: {{ .Values.replicaCount | quote }}
           {{- with .Values.env.secrets }}
           envFrom:
             - secretRef:

--- a/helm/data-generator/templates/deployment.yaml
+++ b/helm/data-generator/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
               value: "/app/application.yaml"
             - name: "JAVA_TOOL_OPTIONS"
               value: {{ .Values.javaToolOptions | quote }}
+            - name: "NUM_WORKERS"
+              value: {{ .Values.replicaCount }}
           {{- with .Values.env.secrets }}
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Description

### Product
N/A

### Technical
`replicaCount` is passed into the container as `NUM_WORKERS` for some concurrency calculations.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
Working on dev01

## Note for reviewers
I'm not sure how to categorize this. It's not really a "fix" exactly, but it's not really a feature either.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
