### PR TITLE
fix: harmonize default hl7-transformer timeout

### DIFF
--- a/ansible/roles/extractor/defaults/main.yaml
+++ b/ansible/roles/extractor/defaults/main.yaml
@@ -15,7 +15,7 @@ hl7_transformer_image_tag: latest
 hl7log_extractor_timeout: 480
 hl7log_extractor_heartbeat_timeout: 30
 hl7log_extractor_concurrency: 150
-hl7_transformer_timeout: 60
+hl7_transformer_timeout: 480
 # HL7 Transformer resources
 # Memory: requests = spark_memory, limits = 4x spark_memory to account for Spark overhead
 # Memory is computed in templates using jvm_memory_to_k8s filter (not computable here in defaults)


### PR DESCRIPTION
## Description

### Product
N/A

### Technical
See #473 

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
N/A

## Note for reviewers
I'm waffling between just saying we should drop this `default` entirely since we already define it. Maybe it's defense-in-depth? I'm leaving the structure as it is for now.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
