### PR TITLE
ci: fix flaky smoke-test by moving k3s data-dir to /mnt scratch disk

### DIFF
--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -30,6 +30,14 @@ k3s_cluster:
     # K3s config
     k3s_token: K3S_TOKEN
     kubeconfig_group: root
+    # Relocate k3s's data-dir onto the runner's near-empty scratch disk so
+    # the embedded containerd image store + overlayfs snapshots don't run the
+    # smaller, half-full root fs into DiskPressure eviction during large image
+    # pulls (notably ollama, which bundles multi-GB CUDA runtimes). base_dir
+    # (below) moves the local-path PVs there too. K3S_DATA_DIR is templated in
+    # by the "Prepare inventory.yaml" workflow step. CI-only: production keeps
+    # the default data-dir (/var/lib/rancher/k3s).
+    k3s_extra_args: '--data-dir K3S_DATA_DIR'
 
     # CoreDNS: resolve *.scout.test to the node IP inside the cluster
     coredns_extra_server_blocks:
@@ -100,8 +108,9 @@ k3s_cluster:
     # base_dir is consumed by k3s as --default-local-storage-path for the
     # local-path provisioner; the per-service *_dir variables that used to
     # live here are dead since storage moved to dynamic provisioning
-    # (ADR 0004).
-    base_dir: /var/lib
+    # (ADR 0004). Kept under the k3s data-dir (see K3S_DATA_DIR above) so the
+    # provisioner's PVs land on the scratch disk alongside the image store.
+    base_dir: K3S_DATA_DIR/storage
     scout_repo_dir: WORK_DIR
     extractor_data_dir: '{{ scout_repo_dir }}/tests/ingest/staging_test_data'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,14 @@ env:
   JAVA_DIST: 'zulu'
   JAVA_VERSION: '21'
   REGISTRY: ghcr.io
+  # GitHub-hosted runners mount a large, near-empty scratch disk at /mnt (the
+  # Azure temp resource disk); the root fs is smaller and already half-full of
+  # preinstalled tooling. There is no built-in env var for this mount
+  # (RUNNER_TEMP / RUNNER_TOOL_CACHE both live on the root fs), so /mnt is
+  # named once here and templated into the CI inventory's k3s data-dir by the
+  # "Prepare inventory.yaml" steps — keeping k3s's image store + PVs off the
+  # root fs so large image pulls don't trigger DiskPressure eviction.
+  K3S_DATA_DIR: /mnt/k3s
 
 jobs:
   changes:
@@ -248,6 +256,7 @@ jobs:
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /usr/share/swift
           sudo rm -rf /opt/ghc
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo apt-get clean
           docker system prune -af --volumes
 
@@ -259,6 +268,7 @@ jobs:
           NODE_IP=$(hostname -I | awk '{print $1}')
           sed -e "s/HOSTNAME/$(hostname)/" -e "s/K3S_TOKEN/$(openssl rand -hex 16)/" \
             -e "s:WORK_DIR:$(pwd):" -e "s/NODE_IP/$NODE_IP/g" \
+            -e "s:K3S_DATA_DIR:$K3S_DATA_DIR:g" \
             .github/ci_resources/inventory.yaml > ansible/inventory.yaml
       - name: 'ansible-galaxy dependencies'
         shell: bash
@@ -411,6 +421,7 @@ jobs:
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /usr/share/swift
           sudo rm -rf /opt/ghc
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo apt-get clean
           docker system prune -af --volumes
           echo "Disk space after cleanup:"
@@ -444,6 +455,7 @@ jobs:
           echo "Node IP for CoreDNS: $NODE_IP"
           sed -e "s/HOSTNAME/$(hostname)/" -e "s/K3S_TOKEN/$(openssl rand -hex 16)/" \
             -e "s:WORK_DIR:$(pwd):" -e "s/NODE_IP/$NODE_IP/g" \
+            -e "s:K3S_DATA_DIR:$K3S_DATA_DIR:g" \
             .github/ci_resources/inventory.yaml > ansible/inventory.yaml
       - name: 'ansible-galaxy dependencies'
         shell: bash


### PR DESCRIPTION
## Problem

`smoke-test-analytics` fails flakily during the `chatbot` playbook — the `open-webui` Helm release times out (`--atomic --wait --timeout 10m` → `context deadline exceeded`) and rolls back. It "passes on a re-run" often enough that it's been getting restarted manually.

Example: [run 28602071214](https://github.com/washu-tag/scout/actions/runs/28602071214/job/84821801941?pr=453).

## Root cause — disk, not CPU/memory

The debug output shows the real failure:

```
pod/ollama-...  Failed to pull image "ollama/ollama:0.24.0":
  failed to extract layer .../mlx_cuda_v13/libnvrtc.so.13.0.88: no space left on device
node/...  Insufficient free disk space on the node's image filesystem (85% of 71.6 GiB used)
node/...  Attempting to reclaim ephemeral-storage
```

k3s runs its **own embedded containerd**, rooted under `<data-dir>/agent/containerd` — which defaults to `/var/lib/rancher/k3s` on the runner's **root fs** (`/dev/root`, ~72G, already ~half full of preinstalled tooling). The Ollama image bundles multi-GB CUDA runtimes; extracting it runs the root fs into **DiskPressure eviction**, so the ollama pod never goes Ready and the atomic Helm install rolls back and fails the job.

It's *flaky* because runs sit right at the disk margin (~85%) — a fresh runner sometimes lands just under it. That's the "restart a few times and it eventually passes" behavior, and it's the analytics side every time (the only side that deploys the chat stack).

Meanwhile the runner mounts a second disk at **`/mnt`** (the Azure temp resource disk, ~74G, **<10% used**) that k3s never touches:

| Filesystem | Mount | Size | Used | Avail |
|---|---|---|---|---|
| `/dev/root` | `/` | 72G | 33G (post-cleanup) | 40G |
| `/dev/sdb1` | `/mnt` | 74G | 4.1G | **66G (idle)** |

## Fix

- **Relocate k3s's data-dir onto `/mnt`** via `--data-dir` (`k3s_extra_args`), and move the local-path provisioner's PVs (`base_dir`) under the same tree — so both the containerd image store and the PVs land on the idle scratch disk instead of the crowded root fs.
- There's **no built-in env var** pointing at `/mnt` (`RUNNER_TEMP` / `RUNNER_TOOL_CACHE` / `AGENT_TOOLSDIRECTORY` all live on the root fs — the disk we're fleeing). So `/mnt` is named **once** in the workflow's top-level `env:` (`K3S_DATA_DIR`) and templated into the CI inventory via the existing `sed` placeholder mechanism (same as `WORK_DIR` / `NODE_IP`). No magic path scattered around.
- **Align the four `Free up disk space` steps**: `deploy-and-test` and `smoke-test` now also remove `$AGENT_TOOLSDIRECTORY`, matching `publish` / `publish-demo`, so every k3s-hosting job reclaims the same space.

Production is unaffected — it keeps the default data-dir (`/var/lib/rancher/k3s`); the change is entirely in `.github/ci_resources/inventory.yaml` and `.github/workflows/ci.yaml`.

## Verification

- Confirmed via the failing run's own logs that k3s's containerd snapshot path is under the data-dir (`/var/lib/rancher/k3s/agent/containerd/...`), so `--data-dir` moves the image store.
- Grepped for hardcoded `/var/lib/rancher/k3s` paths: the only data-dir-relative one is the GPU-operator containerd config, which CI never deploys and production leaves at the default. `storage_classes.yaml` reads the live local-path config, so moving `base_dir` doesn't break it.
- Simulated the `sed` render → `--data-dir /mnt/k3s`, `base_dir: /mnt/k3s/storage`, no leftover placeholder tokens; both YAML files parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)