### PR TITLE
feat(github_actions): Add issue templates and PR project board automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Report a bug
+title: ''
+type: Bug
+---
+
+## Expected behavior
+<!-- What should happen. -->
+
+## Actual behavior
+<!-- What happens instead. -->
+
+## Steps to reproduce
+1.
+2.
+
+## Environment
+<!-- e.g., browser, air-gapped, feature flags, GPUs, user roles/attributes. -->
+
+## Additional context
+<!-- Logs, screenshots, related issues/PRs. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Propose new functionality
+title: ''
+type: Feature
+---
+
+## Problem
+<!-- What problem this solves and why it matters. -->
+
+## Proposed solution
+<!-- What should happen. -->
+
+## Alternatives considered
+<!-- Other approaches and why they don't fit. -->
+
+## Additional context
+<!-- Related ADRs, issues/PRs, screenshots. -->

--- a/.github/ISSUE_TEMPLATE/qa.md
+++ b/.github/ISSUE_TEMPLATE/qa.md
@@ -1,0 +1,20 @@
+---
+name: QA
+about: QA pass on a major feature or change
+title: 'QA: '
+type: Task
+---
+
+## Scope
+<!-- What's being validated in few sentences. Link the parent feature/PRs. -->
+
+## Acceptance criteria
+<!-- Checklist of things to verify. -->
+- [ ]
+- [ ]
+
+## Environment
+<!-- e.g., air-gapped, feature flags, GPUs, user roles/attributes, data expectations. -->
+
+## Additional context
+<!-- Related ADRs, issues/PRs. -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,12 @@
+---
+name: Task
+about: A chore, refactor, doc update, dependency bump, cleanup, etc.
+title: ''
+type: Task
+---
+
+## Description
+<!-- What needs to happen and why. -->
+
+## Additional context
+<!-- Related ADRs, issues/PRs. -->

--- a/.github/workflows/assign-author.yaml
+++ b/.github/workflows/assign-author.yaml
@@ -11,4 +11,4 @@ jobs:
   assign:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v3
+      - uses: toshimaru/auto-author-assign@3e19bfc990cb1cf0589dce95e9f75289bb1e22de # v3.0.3

--- a/.github/workflows/assign-author.yaml
+++ b/.github/workflows/assign-author.yaml
@@ -1,0 +1,14 @@
+name: Assign PR Author
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v3

--- a/.github/workflows/pr-status.yaml
+++ b/.github/workflows/pr-status.yaml
@@ -6,5 +6,8 @@ on:
 
 jobs:
   status:
+    permissions: {}
     uses: washu-tag/.github/.github/workflows/pr-status.yaml@main
-    secrets: inherit
+    secrets:
+      PROJECT_APP_ID: ${{ secrets.PROJECT_APP_ID }}
+      PROJECT_APP_PRIVATE_KEY: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}

--- a/.github/workflows/pr-status.yaml
+++ b/.github/workflows/pr-status.yaml
@@ -1,0 +1,10 @@
+name: PR to In Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  status:
+    uses: washu-tag/.github/.github/workflows/pr-status.yaml@main
+    secrets: inherit

--- a/.github/workflows/pr-status.yaml
+++ b/.github/workflows/pr-status.yaml
@@ -2,7 +2,7 @@ name: PR to In Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
 
 jobs:
   status:

--- a/extractor/hl7-transformer/.trivyignore.yaml
+++ b/extractor/hl7-transformer/.trivyignore.yaml
@@ -41,6 +41,12 @@ vulnerabilities:
   - id: CVE-2026-46195 # linux-libc-dev
   - id: CVE-2026-46300 # linux-libc-dev
   - id: CVE-2026-46333 # linux-libc-dev
+  - id: CVE-2026-23216 # linux-libc-dev
+  - id: CVE-2023-53673 # linux-libc-dev
+  - id: CVE-2025-37778 # linux-libc-dev
+  - id: CVE-2025-71089 # linux-libc-dev
+  - id: CVE-2026-43494 # linux-libc-dev
+  - id: CVE-2026-43503 # linux-libc-dev
   # netty 4.2.7 family bundled by Spark (plus copies shaded into the
   # connect-repl client jars, which the worker never loads)
   - id: CVE-2026-33870 # netty-codec-http


### PR DESCRIPTION
## Description

### Product
N/A. Internal process tooling for the team, no user-facing change.

### Technical
Adds issue templates (bug, feature, task, QA) for the repo, plus two workflows to keep the TAG Team project board current without manual steps:
- Auto-assign the PR author as assignee (toshimaru/auto-author-assign)
- Move a PR to "In Review" when opened or marked ready for review, via a reusable workflow in washu-tag/.github. Drafts and bot PRs (Dependabot, Renovate) are skipped and stay wherever the built-in auto-add workflow put them.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
N/A.

##### Appsec
The project-status workflow authenticates as a dedicated GitHub App (TAG Project Automation) scoped to org-projects read/write and repo PR and issues read-only.

Also ignores 6 new linux-libc-dev CVEs in hl7-transformer, the same package is already ignored many times over for the same reason, headers only, no runtime code, containers use the host kernel.

### Performance
N/A.

### Data
N/A.

### Backward compatibility
N/A.

## Testing
Auto assign and In Review workflows both were successful for this PR.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate