### PR TITLE
feat(launchpad): gate MinIO Lake card behind enableMinio flag

### DIFF
--- a/helm/launchpad/templates/deployment.yaml
+++ b/helm/launchpad/templates/deployment.yaml
@@ -73,6 +73,8 @@ spec:
               value: {{ .Values.enableChat | quote }}
             - name: ENABLE_PLAYBOOKS
               value: {{ .Values.enablePlaybooks | quote }}
+            - name: ENABLE_MINIO
+              value: {{ .Values.enableMinio | quote }}
             {{- if .Values.scoutEnv }}
             - name: SCOUT_ENV
               value: {{ .Values.scoutEnv | quote }}

--- a/helm/launchpad/values.yaml
+++ b/helm/launchpad/values.yaml
@@ -7,6 +7,10 @@ replicaCount: 1
 # Feature flags
 enableChat: false
 enablePlaybooks: false
+# Show the MinIO "Lake" card in the launchpad. Default true so deployments
+# still running an in-cluster MinIO continue to surface the console; sites
+# that have cut over to cloud object storage set this false.
+enableMinio: true
 
 # Environment label shown next to the Scout brand (e.g. "synthetic", "production").
 # Empty string falls back to "local" in the UI.

--- a/launchpad/src/app/HomeClient.tsx
+++ b/launchpad/src/app/HomeClient.tsx
@@ -256,11 +256,18 @@ const PlaybooksGrid = ({ playbooksUrl }: PlaybooksGridProps) => {
 interface ContentGridProps {
   enableChat: boolean;
   enablePlaybooks: boolean;
+  enableMinio: boolean;
   subdomainUrls: Record<string, string>;
   docsUrl: string;
 }
 
-const ContentGrid = ({ enableChat, enablePlaybooks, subdomainUrls, docsUrl }: ContentGridProps) => {
+const ContentGrid = ({
+  enableChat,
+  enablePlaybooks,
+  enableMinio,
+  subdomainUrls,
+  docsUrl,
+}: ContentGridProps) => {
   // Don't render until subdomain URLs are set on client side
   if (Object.keys(subdomainUrls).length === 0) {
     return (
@@ -386,17 +393,24 @@ const ContentGrid = ({ enableChat, enablePlaybooks, subdomainUrls, docsUrl }: Co
                   hoverBorder: 'hover:border-indigo-200 dark:hover:border-indigo-900/60',
                   hoverShadow: 'hover:shadow-indigo-200/50 dark:hover:shadow-indigo-500/15',
                 },
-                {
-                  href: subdomainUrls.minio,
-                  external: true,
-                  label: 'Lake',
-                  description: 'Medical data lake storage',
-                  Icon: SiMinio,
-                  iconBg: 'bg-red-50 border-red-100 dark:bg-red-950/40 dark:border-red-900/50',
-                  iconColor: 'text-red-600 dark:text-red-400',
-                  hoverBorder: 'hover:border-red-200 dark:hover:border-red-900/60',
-                  hoverShadow: 'hover:shadow-red-200/50 dark:hover:shadow-red-500/15',
-                },
+                // Sites that have cut over from in-cluster MinIO to cloud object
+                // storage hide the Lake card via ENABLE_MINIO=false.
+                ...(enableMinio
+                  ? [
+                      {
+                        href: subdomainUrls.minio,
+                        external: true,
+                        label: 'Lake',
+                        description: 'Medical data lake storage',
+                        Icon: SiMinio,
+                        iconBg:
+                          'bg-red-50 border-red-100 dark:bg-red-950/40 dark:border-red-900/50',
+                        iconColor: 'text-red-600 dark:text-red-400',
+                        hoverBorder: 'hover:border-red-200 dark:hover:border-red-900/60',
+                        hoverShadow: 'hover:shadow-red-200/50 dark:hover:shadow-red-500/15',
+                      },
+                    ]
+                  : []),
                 {
                   href: subdomainUrls.temporal,
                   external: true,
@@ -453,6 +467,7 @@ const ContentGrid = ({ enableChat, enablePlaybooks, subdomainUrls, docsUrl }: Co
 interface HomeClientProps {
   enableChat: boolean;
   enablePlaybooks: boolean;
+  enableMinio: boolean;
   scoutEnv?: string;
   deployerName?: string;
   docsUrl: string;
@@ -461,6 +476,7 @@ interface HomeClientProps {
 export default function HomeClient({
   enableChat,
   enablePlaybooks,
+  enableMinio,
   scoutEnv,
   deployerName,
   docsUrl,
@@ -543,6 +559,7 @@ export default function HomeClient({
         <ContentGrid
           enableChat={enableChat}
           enablePlaybooks={enablePlaybooks}
+          enableMinio={enableMinio}
           subdomainUrls={subdomainUrls}
           docsUrl={docsUrl}
         />

--- a/launchpad/src/app/page.tsx
+++ b/launchpad/src/app/page.tsx
@@ -8,6 +8,10 @@ export const dynamic = 'force-dynamic';
 export default function Home() {
   const enableChat = process.env.ENABLE_CHAT === 'true';
   const enablePlaybooks = process.env.ENABLE_PLAYBOOKS === 'true';
+  // Default true so deployments still running an in-cluster MinIO (e.g. on-prem)
+  // continue to show the Lake card without setting a new env var. Sites that
+  // have cut over to AWS S3 set ENABLE_MINIO=false to hide it.
+  const enableMinio = process.env.ENABLE_MINIO !== 'false';
   const scoutEnv = process.env.SCOUT_ENV;
   const deployerName = process.env.DEPLOYER_NAME;
 
@@ -15,6 +19,7 @@ export default function Home() {
     <HomeClient
       enableChat={enableChat}
       enablePlaybooks={enablePlaybooks}
+      enableMinio={enableMinio}
       scoutEnv={scoutEnv}
       deployerName={deployerName}
       docsUrl={getDocsUrl()}


### PR DESCRIPTION
## Description

### Product
Deployments that use cloud object storage instead of an in-cluster MinIO no longer show a "Lake" card in the launchpad's admin tools that links to a host that doesn't resolve. Deployments running MinIO see no change — the card remains by default.

### Technical
Adds an `enableMinio` chart value (default `true`) that emits `ENABLE_MINIO` into the launchpad container. The Next.js server component (`page.tsx`) reads `ENABLE_MINIO !== 'false'` into a boolean prop, and `HomeClient` conditionally includes the Lake entry in the admin-tools grid. Default `true` preserves existing behavior for any deployment that doesn't set the flag.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
No change. This gates the visibility of a navigation card only; it does not grant or restrict access to the MinIO console itself, which remains protected by the existing auth layers.

##### Appsec
No new user input. The flag is a server-side env var read at request time and passed as a boolean prop; it is not reflected into output.

### Performance
None — one additional boolean prop.

### Data
Not applicable.

### Backward compatibility
Fully backward compatible: the chart value defaults to `true`, so existing deployments (including the Ansible role, which doesn't set it) render exactly as before. No API or data-model changes.

## Testing
- `helm lint` passes; `helm template` renders `ENABLE_MINIO` exactly once — `"true"` with default values, `"false"` with `--set enableMinio=false`
- `npm run build` (Next.js production build) passes
- `pre-commit` hooks (prettier, eslint, yaml checks) pass on all changed files

## Note for reviewers
This is the last remaining change from the `demo-gitops` branch that never landed on main (the extractor S3-native work landed separately as #353). Re-applied onto the current `HomeClient.tsx` structure (subdomain URLs as props, SCOUT_ENV/docsUrl plumbing). Once merged, the `demo-gitops` branch can be deleted and downstream deployments can consume `launchpad:latest` instead of the stale `latest-demo-gitops` tag.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
