### PR TITLE
ci: pin docker/setup-buildx-action and docker/build-push-action to SHAs

### DIFF
--- a/.github/actions/docker-build-cache/action.yaml
+++ b/.github/actions/docker-build-cache/action.yaml
@@ -24,7 +24,7 @@ runs:
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
     - name: 'Derive version'
       id: derive-version
@@ -33,7 +33,7 @@ runs:
         subproject: ${{ inputs.subproject }}
 
     - name: 'Build/Cache Image'
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: ${{ inputs.context != '' && inputs.context || inputs.subproject }}
         file: ${{ inputs.subproject }}/Dockerfile


### PR DESCRIPTION
## Description

### Product
N/A

### Technical
Pins the two remaining unpinned third-party CI actions (`docker/setup-buildx-action`, `docker/build-push-action`) to commit SHAs, bringing them in line with the documented policy in `docs/internal/ci-security-scanning.md`. Pinned to the latest release within the current major (v4.2.0, v7.3.0), so no behavior change. GitHub first-party actions remain on tags by policy.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
N/A

##### Appsec
Reduces supply-chain risk by pinning third-party actions to immutable SHAs instead of mutable tags. Dependabot's `github-actions` ecosystem keeps the pins current.

### Performance
N/A

### Data
N/A

### Backward compatibility
None; SHAs correspond to the latest release within the same major already in use.

## Testing
N/A — covered by existing CI.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
