### PR TITLE
ci: suppress linux-libc-dev kernel CVEs via Trivy ignore-policy

### DIFF
--- a/.github/actions/trivy-scan-image/action.yaml
+++ b/.github/actions/trivy-scan-image/action.yaml
@@ -5,7 +5,7 @@ inputs:
     description: 'Name of the image artifact'
     required: true
   subproject:
-    description: 'Path to the subproject directory (used to find .trivyignore.yaml)'
+    description: 'Path to the subproject directory (used to find .trivyignore.yaml and .trivyignore.rego)'
     required: false
     default: ''
   severity:
@@ -36,14 +36,28 @@ runs:
       env:
         SUBPROJECT: ${{ inputs.subproject }}
       run: |
-        ignorefile="${SUBPROJECT}/.trivyignore.yaml"
-        if [ -n "${SUBPROJECT}" ] && [ -f "${ignorefile}" ]; then
-          echo "Using ignore file: ${ignorefile}"
-          echo "ignorefile: ${ignorefile}" > trivy-config.yaml
-        else
-          echo "No per-image ignore file found"
-          echo "# No ignore file" > trivy-config.yaml
+        # Build trivy-config.yaml from whichever per-image suppressions exist:
+        #   .trivyignore.yaml  -> ignorefile    (individual CVEs, by ID)
+        #   .trivyignore.rego  -> ignore-policy (whole package families, by Rego)
+        : > trivy-config.yaml
+        if [ -n "${SUBPROJECT}" ]; then
+          ignorefile="${SUBPROJECT}/.trivyignore.yaml"
+          if [ -f "${ignorefile}" ]; then
+            echo "Using ignore file: ${ignorefile}"
+            echo "ignorefile: ${ignorefile}" >> trivy-config.yaml
+          fi
+          ignorepolicy="${SUBPROJECT}/.trivyignore.rego"
+          if [ -f "${ignorepolicy}" ]; then
+            echo "Using ignore policy: ${ignorepolicy}"
+            echo "ignore-policy: ${ignorepolicy}" >> trivy-config.yaml
+          fi
         fi
+        if [ ! -s trivy-config.yaml ]; then
+          echo "No per-image ignore file or policy found"
+          echo "# none" > trivy-config.yaml
+        fi
+        echo "--- trivy-config.yaml ---"
+        cat trivy-config.yaml
 
     - name: Run Trivy (JSON — single scan)
       if: steps.download.outcome == 'success'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,6 @@ jobs:
             # into the image. The Dockerfile path is derived from
             # `subproject` (see docker-build-cache action).
             context: '.'
-            allow-failure: true
           - image-name: launchpad
             subproject: launchpad
           - image-name: superset

--- a/docs/internal/ci-security-scanning.md
+++ b/docs/internal/ci-security-scanning.md
@@ -91,7 +91,7 @@ Each matrix entry attempts to download the image tarball artifact. If the image 
 
 The composite action (`.github/actions/trivy-scan-image/action.yaml`) does a single Trivy invocation per image:
 
-1. **Configure** — checks for a per-image `.trivyignore.yaml` in the subproject directory and generates a Trivy config if found.
+1. **Configure** — checks the subproject directory for a per-image `.trivyignore.yaml` (individual CVE suppressions) and `.trivyignore.rego` (package-level ignore-policy) and generates a Trivy config referencing whichever are present.
 2. **Single JSON scan** — Trivy scans once, outputting JSON. The Trivy DB is cached automatically by the trivy-action.
 3. **SARIF conversion** — `trivy convert` produces SARIF from the JSON. The SARIF is post-processed with `jq` to tag the tool name and alert messages with the image name (e.g., "Trivy (launchpad)", "[launchpad] CVE description...") so findings are identifiable in the Security tab. The tagged SARIF is uploaded to GitHub.
 4. **Gate check** — a shell step parses the JSON for fixable vulnerabilities and fails the job if any exist at CRITICAL or HIGH severity. Images with `allow-failure: true` in the matrix still scan and report but don't block the build.
@@ -217,7 +217,8 @@ Each subproject can have its own `.trivyignore.yaml` alongside its `Dockerfile`.
 ```
 helm/scout-notebook/
 ├── Dockerfile
-└── .trivyignore.yaml    # CVE suppressions for this image only
+├── .trivyignore.yaml    # individual CVE suppressions for this image
+└── .trivyignore.rego    # package-level ignore-policy for this image
 ```
 
 Example ignore file:
@@ -229,6 +230,32 @@ vulnerabilities:
 ```
 
 Images without a `.trivyignore.yaml` in their subproject directory run with no suppressions.
+
+### Suppressing a whole package family (Rego ignore-policy)
+
+Some packages produce recurring, non-actionable findings that can't be pinned to a short list of CVE IDs — most notably `linux-libc-dev`, onto which Trivy maps the entire upstream Linux **kernel** CVE stream. That package ships only C headers (no runtime code) and containers run on the host kernel, so those CVEs aren't exploitable in the image, but new batches publish constantly and each re-appears as a fresh alert. Enumerating them by ID in `.trivyignore.yaml` is endless churn.
+
+For these, add a `.trivyignore.rego` next to the `Dockerfile`. It's a Trivy [Rego ignore policy](https://trivy.dev/latest/docs/configuration/filtering/): the composite action wires it in as `ignore-policy` (alongside `ignorefile`) whenever the file is present, so one rule suppresses **every** finding for that package, current and future:
+
+```rego
+package trivy
+
+default ignore = false
+
+ignore {
+	input.PkgName == "linux-libc-dev"
+}
+```
+
+`input` is one Trivy `DetectedVulnerability` (`PkgName`, `VulnerabilityID`, `Severity`, `InstalledVersion`, …); returning `true` from `ignore` drops it. Keep `.trivyignore.yaml` for individual CVEs that have per-item rationale (bundled jars, base-OS packages awaiting a rebuild); reach for `.trivyignore.rego` only when suppressing by package name is justified for every CVE that package will ever carry.
+
+Reproduce a scan locally with both suppressions applied:
+
+```bash
+trivy image --ignorefile helm/scout-notebook/.trivyignore.yaml \
+  --ignore-policy helm/scout-notebook/.trivyignore.rego \
+  <image>
+```
 
 ### Changing Trivy severity thresholds
 

--- a/extractor/hl7-transformer/.trivyignore.rego
+++ b/extractor/hl7-transformer/.trivyignore.rego
@@ -1,0 +1,19 @@
+# Trivy Rego ignore-policy — companion to .trivyignore.yaml. This file
+# suppresses whole package families whose findings are recurring and
+# non-actionable; individual CVEs with per-item rationale stay in
+# .trivyignore.yaml. The scan action (.github/actions/trivy-scan-image) wires
+# this in as `ignore-policy` when the file is present, alongside `ignorefile`.
+#
+# linux-libc-dev ships only the Linux kernel's C headers, no runtime code.
+# Containers run on the host kernel, so the upstream *kernel* CVEs that Trivy
+# maps onto this package are not exploitable here, and nothing in this image
+# compiles against these headers. Fixes only ever land in the base image, and
+# new kernel-CVE batches publish constantly, so enumerating each ID by hand
+# was recurring churn (see issue #478).
+package trivy
+
+default ignore = false
+
+ignore {
+	input.PkgName == "linux-libc-dev"
+}

--- a/extractor/hl7-transformer/.trivyignore.yaml
+++ b/extractor/hl7-transformer/.trivyignore.yaml
@@ -5,48 +5,8 @@
 vulnerabilities:
   # Ubuntu base not yet rebuilt with openssl 3.0.2-0ubuntu1.25
   - id: CVE-2026-45447 # openssl/libssl3 3.0.2-0ubuntu1.23 → 3.0.2-0ubuntu1.25
-  # linux-libc-dev: Trivy maps upstream Linux *kernel* CVEs onto this binary
-  # package, but it ships only C headers (no runtime code) and containers use
-  # the host kernel, so none are exploitable here. Nothing in this image
-  # compiles native code either. The base ubuntu is pinned to 5.15.0-179.189;
-  # fixes land in the base, not our layers. Full current CRITICAL/HIGH set:
-  - id: CVE-2025-37924 # linux-libc-dev
-  - id: CVE-2025-68263 # linux-libc-dev
-  - id: CVE-2026-23428 # linux-libc-dev
-  - id: CVE-2026-23450 # linux-libc-dev
-  - id: CVE-2026-23455 # linux-libc-dev
-  - id: CVE-2026-31402 # linux-libc-dev
-  - id: CVE-2026-31478 # linux-libc-dev
-  - id: CVE-2026-31607 # linux-libc-dev
-  - id: CVE-2026-31637 # linux-libc-dev
-  - id: CVE-2026-31657 # linux-libc-dev
-  - id: CVE-2026-31659 # linux-libc-dev
-  - id: CVE-2026-31669 # linux-libc-dev
-  - id: CVE-2026-43011 # linux-libc-dev
-  - id: CVE-2026-43037 # linux-libc-dev
-  - id: CVE-2026-43038 # linux-libc-dev
-  - id: CVE-2026-43186 # linux-libc-dev
-  - id: CVE-2026-43284 # linux-libc-dev
-  - id: CVE-2026-43304 # linux-libc-dev
-  - id: CVE-2026-43341 # linux-libc-dev
-  - id: CVE-2026-43406 # linux-libc-dev
-  - id: CVE-2026-43407 # linux-libc-dev
-  - id: CVE-2026-43493 # linux-libc-dev
-  - id: CVE-2026-43500 # linux-libc-dev
-  - id: CVE-2026-43501 # linux-libc-dev
-  - id: CVE-2026-45988 # linux-libc-dev
-  - id: CVE-2026-46043 # linux-libc-dev
-  - id: CVE-2026-46119 # linux-libc-dev
-  - id: CVE-2026-46135 # linux-libc-dev
-  - id: CVE-2026-46195 # linux-libc-dev
-  - id: CVE-2026-46300 # linux-libc-dev
-  - id: CVE-2026-46333 # linux-libc-dev
-  - id: CVE-2026-23216 # linux-libc-dev
-  - id: CVE-2023-53673 # linux-libc-dev
-  - id: CVE-2025-37778 # linux-libc-dev
-  - id: CVE-2025-71089 # linux-libc-dev
-  - id: CVE-2026-43494 # linux-libc-dev
-  - id: CVE-2026-43503 # linux-libc-dev
+  # linux-libc-dev kernel-header CVEs are suppressed by package name in
+  # .trivyignore.rego (Trivy ignore-policy), not enumerated here — see #478.
   # netty 4.2.7 family bundled by Spark (plus copies shaded into the
   # connect-repl client jars, which the worker never loads)
   - id: CVE-2026-33870 # netty-codec-http

--- a/helm/scout-notebook/.trivyignore.rego
+++ b/helm/scout-notebook/.trivyignore.rego
@@ -1,0 +1,19 @@
+# Trivy Rego ignore-policy — companion to .trivyignore.yaml. This file
+# suppresses whole package families whose findings are recurring and
+# non-actionable; individual CVEs with per-item rationale stay in
+# .trivyignore.yaml. The scan action (.github/actions/trivy-scan-image) wires
+# this in as `ignore-policy` when the file is present, alongside `ignorefile`.
+#
+# linux-libc-dev ships only the Linux kernel's C headers, no runtime code.
+# Containers run on the host kernel, so the upstream *kernel* CVEs that Trivy
+# maps onto this package are not exploitable here, and nothing in this image
+# compiles against these headers. Fixes only ever land in the base image, and
+# new kernel-CVE batches publish constantly, so enumerating each ID by hand
+# was recurring churn (see issue #478).
+package trivy
+
+default ignore = false
+
+ignore {
+	input.PkgName == "linux-libc-dev"
+}

--- a/helm/scout-notebook/.trivyignore.yaml
+++ b/helm/scout-notebook/.trivyignore.yaml
@@ -1,0 +1,25 @@
+# Everything below is bundled inside the upstream
+# quay.io/jupyter/scipy-notebook base image (or vendored inside its
+# dependencies' assets), not in the layers we add. There is nothing to bump in
+# our layer and no rebuilt base adopting the fixes yet. Recurring
+# linux-libc-dev kernel-header CVEs are handled separately, by package, in
+# .trivyignore.rego — not enumerated here. Revisit when a newer
+# scipy-notebook base ships these fixes.
+vulnerabilities:
+  # MathJax 2.7.9 ReDoS — vendored static asset inside the nbclassic package
+  # (nbclassic/static/components/MathJax/). MathJax 2.x is end-of-life with no
+  # 2.x fix (the fix is MathJax 3, which nbclassic does not ship), and the
+  # classic-notebook UI it serves is not Scout's interface (JupyterLab is).
+  - id: CVE-2023-39663 # mathjax 2.7.9 (vendored in nbclassic)
+  # underscore.js ReDoS — vendored static asset inside the nbclassic package
+  # (nbclassic/static/components/underscore/). The fix (1.13.8) exists upstream
+  # in underscore.js but cannot be delivered into this vendored JS copy from
+  # our layer without patching base contents; bumping nbclassic does not
+  # re-vendor it.
+  - id: CVE-2026-27601 # underscore 1.13.7 -> 1.13.8 (vendored in nbclassic)
+  # PyO3 out-of-bounds read — compiled into rattler's Rust extension
+  # (rattler.abi3.so), part of the base image's conda tooling. The fix
+  # (pyo3 0.29.0) is a Rust build-time dependency we cannot bump independently;
+  # it needs a newer rattler build, and rattler is not exercised at notebook
+  # runtime (package resolution only).
+  - id: GHSA-36hh-v3qg-5jq4 # pyo3 0.25.1 -> 0.29.0 (compiled into rattler)


### PR DESCRIPTION
## Description

### Product
No user-facing change. This is an internal CI security-scanning improvement.

### Technical
Trivy maps the entire upstream Linux *kernel* CVE stream onto the `linux-libc-dev` package, which ships only kernel C headers (no runtime code). Containers run on the host kernel, so these aren't exploitable in-image, but new CVE batches publish constantly and each re-appears as a fresh open alert. Suppressing them one CVE-ID at a time in `.trivyignore.yaml` was recurring churn (#478): **166 of 167** open `hl7-transformer` alerts and **171 of 174** open `scout-notebook` alerts were `linux-libc-dev`.

This adds a package-level Trivy **Rego `ignore-policy`** (`.trivyignore.rego`) as a companion to the per-CVE `.trivyignore.yaml`, wired into the `trivy-scan-image` composite action (applied as `ignore-policy` alongside `ignorefile` whenever the file is present). A single rule suppresses every `linux-libc-dev` finding, current and future (implementing Option A from #478).

- Add `.trivyignore.rego` to `helm/scout-notebook` and `extractor/hl7-transformer`
- Remove the 37 hand-listed `linux-libc-dev` CVEs from the transformer's `.trivyignore.yaml` (now covered by the policy)
- Suppress the 3 remaining `scout-notebook` findings with per-item rationale — `mathjax` & `underscore` (vendored JS inside the `nbclassic` package) and `pyo3` (compiled into `rattler`'s extension) — all bundled in the `quay.io/jupyter/scipy-notebook` base image, none fixable from our layer
- Drop `allow-failure` on the `scout-notebook` scan so it gates like the other first-party images now that its findings are clean
- Document the mechanism in `docs/internal/ci-security-scanning.md`

Net once merged: **scout-notebook 174 → 0** open alerts, **hl7-transformer 167 → 1** (a stale `lz4-java` alert already covered by its own yaml entry).

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [x] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
No changes to roles, data visibility, or API surface.

##### Appsec
This narrows scanner noise; it does not weaken the gate.
- The Rego rule is scoped to exactly one package (`linux-libc-dev`) whose CVEs are kernel-header mappings not reachable in a container. `pyo3` (which *does* have a fix) correctly falls **through** the policy, it is not wildcarded and is suppressed only by an explicit, documented `.trivyignore.yaml` entry.
- The two *fixable* suppressions (`underscore` → 1.13.8, `pyo3` → 0.29.0) are justified in-file: the vulnerable copies are vendored/compiled into the upstream base image and can't be bumped from our layer without patching base contents.
- Net posture is stronger: the `scout-notebook` scan changes from `allow-failure` (report-only) to gating, so a future *fixable* base CVE will now block the build.

### Performance
N/A — CI-only change.

### Data
N/A.

### Backward compatibility
Compatible

## Testing
- **Rego**: `opa check --v0-compatible` compiles clean; `opa eval` confirms `linux-libc-dev` → suppressed and `pyo3`/empty-input → not suppressed (so the per-CVE entries still apply).
- `pre-commit run --files <changed>` passed with no reformatting.
- CI on this PR exercises the real Trivy scan end-to-end.

## Note for reviewers
- Rego uses v0 syntax (`ignore { … }`) to match Trivy's ignore-policy evaluator and the current Trivy docs example; verified locally with `opa --v0-compatible`.
- The `.rego` is per-subproject (mirroring the `.trivyignore.yaml` convention and #478's Option A); the file is identical in both images by design.
- `allow-failure` was removed for `scout-notebook` only, `superset` and `xnat-plugin-installer` keep theirs (heavier third-party bases).

Closes #478

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (ran `pre-commit` on the changed files)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [x] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
