### PR TITLE
test: Upgrade query-spec and remove spark workaround

### DIFF
--- a/tests/ingest/build.gradle
+++ b/tests/ingest/build.gradle
@@ -79,6 +79,10 @@ test {
 dependencies {
     testImplementation("edu.washu.tag:query-spec:${vQuerySpec}")
     testImplementation("org.apache.logging.log4j:log4j-slf4j2-impl:${vLog4j2Bridge}")
+    testImplementation("org.apache.spark:spark-sql_2.13:${vSparkSql}")
+    testImplementation("org.apache.spark:spark-hive_2.13:${vSparkSql}")
+    testImplementation("org.apache.spark:spark-hive-thriftserver_2.13:${vSparkSql}")
+    testImplementation("io.delta:delta-spark_4.1_2.13:${vDeltaSpark}")
     testImplementation("org.apache.hadoop:hadoop-aws:${vHadoop}")
     testImplementation("org.postgresql:postgresql:${vPostgres}")
     testImplementation("io.temporal:temporal-sdk:${vTemporal}")

--- a/tests/ingest/build.gradle
+++ b/tests/ingest/build.gradle
@@ -22,7 +22,7 @@ repositories {
     }
 }
 
-final String vQuerySpec = '1.2-SNAPSHOT'
+final String vQuerySpec = '1.3'
 final String vCheckstyle = '13.4.2'
 final String vLog4j2Bridge = '2.24.2'
 final String vSparkSql = '4.1.1'
@@ -77,18 +77,8 @@ test {
 }
 
 dependencies {
-    // query-spec declares spark-sql_2.12 (Spark 3.5) at runtime scope; Spark 4
-    // is Scala 2.13 only, so excluding it here keeps the 2.12 jars off the
-    // classpath and runs query-spec against the 2.13 Spark below instead.
-    // Remove after query-spec bumps to Spark 4 and Scala 2.13: washu-tag/data-generator#14
-    testImplementation("edu.washu.tag:query-spec:${vQuerySpec}") {
-        exclude group: 'org.apache.spark'
-    }
+    testImplementation("edu.washu.tag:query-spec:${vQuerySpec}")
     testImplementation("org.apache.logging.log4j:log4j-slf4j2-impl:${vLog4j2Bridge}")
-    testImplementation("org.apache.spark:spark-sql_2.13:${vSparkSql}")
-    testImplementation("org.apache.spark:spark-hive_2.13:${vSparkSql}")
-    testImplementation("org.apache.spark:spark-hive-thriftserver_2.13:${vSparkSql}")
-    testImplementation("io.delta:delta-spark_4.1_2.13:${vDeltaSpark}")
     testImplementation("org.apache.hadoop:hadoop-aws:${vHadoop}")
     testImplementation("org.postgresql:postgresql:${vPostgres}")
     testImplementation("io.temporal:temporal-sdk:${vTemporal}")


### PR DESCRIPTION
## Description

### Product
N/A

### Technical
Reverts the workaround in #453 by using newly released 1.3 of query-spec.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [X] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [X] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
Pure test update, so far untested, so I'll see how it does in CI.

## Note for reviewers
<!-- Any additional information or direction for reviewers. -->

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
