### PR TITLE
fix(launchpad): admin user-management UX — access warning, new tab, clearer status

### DIFF
--- a/launchpad/src/app/HomeClient.tsx
+++ b/launchpad/src/app/HomeClient.tsx
@@ -383,7 +383,7 @@ const ContentGrid = ({
               {[
                 {
                   href: '/admin/users',
-                  external: false,
+                  external: true,
                   label: 'Users',
                   description: 'Approve requests and manage user access',
                   Icon: HiClipboardCheck,

--- a/launchpad/src/app/admin/users/UsersClient.tsx
+++ b/launchpad/src/app/admin/users/UsersClient.tsx
@@ -10,6 +10,7 @@ import {
   HiChevronLeft,
   HiChevronRight,
   HiExternalLink,
+  HiInformationCircle,
   HiSearch,
   HiShieldCheck,
   HiTrash,
@@ -418,6 +419,16 @@ function UserDrawer({
                   <HiTrash className="text-base" /> Remove access
                 </button>
               </div>
+            </div>
+          )}
+
+          {mode === 'edit' && (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-950/30 px-3 py-2.5 text-xs text-amber-700 dark:text-amber-300">
+              <HiInformationCircle className="mt-0.5 flex-shrink-0 text-sm" />
+              <span>
+                Lowering a user&apos;s access applies to future queries only. It does not remove
+                data they already saved in notebooks or chat history.
+              </span>
             </div>
           )}
         </div>

--- a/launchpad/src/app/admin/users/UsersClient.tsx
+++ b/launchpad/src/app/admin/users/UsersClient.tsx
@@ -128,18 +128,28 @@ function matchesQuery(r: Row, query: string): boolean {
   return [r.name, r.username, r.email].some((f) => f?.toLowerCase().includes(q));
 }
 
-function StatusBadge({ status, isAdmin }: { status: string; isAdmin: boolean }) {
+// Lifecycle status only — admin is a separate dimension (see AdminBadge). An
+// admin is also active, so the backend's "admin" status reads as "Active" here.
+function StatusBadge({ status }: { status: string }) {
   const [label, cls] =
-    isAdmin || status === 'admin'
-      ? ['Admin', 'bg-indigo-50 dark:bg-indigo-950/40 text-indigo-700 dark:text-indigo-300']
-      : status === 'active'
-        ? ['Active', 'bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300']
-        : status === 'pending'
-          ? ['Pending', 'bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300']
-          : ['—', 'bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400'];
+    status === 'active' || status === 'admin'
+      ? ['Active', 'bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300']
+      : status === 'pending'
+        ? ['Pending', 'bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300']
+        : ['—', 'bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400'];
   return (
     <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${cls}`}>
       {label}
+    </span>
+  );
+}
+
+// Admin role, shown alongside (not instead of) the lifecycle status.
+function AdminBadge() {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-indigo-50 dark:bg-indigo-950/40 px-2.5 py-0.5 text-xs font-medium text-indigo-700 dark:text-indigo-300">
+      <HiShieldCheck className="text-sm" />
+      Admin
     </span>
   );
 }
@@ -357,7 +367,8 @@ function UserDrawer({
           <div className="min-w-0 flex-1">
             <h2 className="text-base font-semibold text-slate-900 dark:text-white truncate flex items-center gap-2">
               {display}
-              <StatusBadge status={user.status} isAdmin={user.isAdmin} />
+              <StatusBadge status={user.status} />
+              {user.isAdmin && <AdminBadge />}
             </h2>
             <p className="text-sm text-slate-500 dark:text-slate-400 truncate">
               {[user.username, user.email].filter(Boolean).join(' · ')}
@@ -989,7 +1000,10 @@ export default function UsersClient({ scoutEnv, docsUrl }: { scoutEnv?: string; 
                             {u.email || '—'}
                           </td>
                           <td className="px-5 py-3">
-                            <StatusBadge status={u.status} isAdmin={u.isAdmin} />
+                            <div className="flex flex-wrap items-center gap-1.5">
+                              <StatusBadge status={u.status} />
+                              {u.isAdmin && <AdminBadge />}
+                            </div>
                           </td>
                           {showRequested ? (
                             <td className="px-5 py-3 text-slate-500 dark:text-slate-400 hidden md:table-cell whitespace-nowrap">

--- a/launchpad/src/app/admin/users/UsersClient.tsx
+++ b/launchpad/src/app/admin/users/UsersClient.tsx
@@ -403,6 +403,16 @@ function UserDrawer({
           </div>
 
           {mode === 'edit' && (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-950/30 px-3 py-2.5 text-xs text-amber-700 dark:text-amber-300">
+              <HiInformationCircle className="mt-0.5 flex-shrink-0 text-sm" />
+              <span>
+                Lowering a user&apos;s access applies to future queries only. It does not remove
+                data they already saved in notebooks or chat history.
+              </span>
+            </div>
+          )}
+
+          {mode === 'edit' && (
             <div className="pt-2 border-t border-slate-200 dark:border-slate-800 space-y-3">
               <span className="block text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
                 Role &amp; access
@@ -430,16 +440,6 @@ function UserDrawer({
                   <HiTrash className="text-base" /> Remove access
                 </button>
               </div>
-            </div>
-          )}
-
-          {mode === 'edit' && (
-            <div className="flex items-start gap-2 rounded-lg border border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-950/30 px-3 py-2.5 text-xs text-amber-700 dark:text-amber-300">
-              <HiInformationCircle className="mt-0.5 flex-shrink-0 text-sm" />
-              <span>
-                Lowering a user&apos;s access applies to future queries only. It does not remove
-                data they already saved in notebooks or chat history.
-              </span>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Description

### Product
Two improvements to the admin user-management page:
- On user details flyout, a note now warns that this only affects future queries and does **not** remove data the user already saved in notebooks or chats (#515). While I understand it might be preferable to detect a downgrade and only warn then, that seemed like a lot of complexity, close to a release. This is a stop-gap until we think more deeply about a purge mechanism in #517.

<img width="432" height="480" alt="Screenshot 2026-07-14 at 12 47 00 PM" src="https://github.com/user-attachments/assets/b16dd719-3028-40e7-8f00-5d2121899f65" />

- The Users admin card opens in a new tab like the other admin tools, and the user list shows a user's admin role as a **separate** badge instead of "Admin" replacing "Active", since an admin is also active (#516).

<img width="575" height="400" alt="Screenshot 2026-07-14 at 12 30 42 PM" src="https://github.com/user-attachments/assets/151fa43e-79ef-4391-9b0f-5d36cbaa77fe" />


### Technical
- **#515:** an edit-mode info note in the user drawer (`UsersClient.tsx`). UI-only, no backend change.
- **#516:** `HomeClient.tsx`: the Users card is now `external: true` (opens in a new tab). `UsersClient.tsx`: `StatusBadge` split into a lifecycle-status badge (Active / Pending) plus a separate admin badge, rendered in both the table's Status column and the drawer header.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
No authorization change, UI only. The #515 warning improves operator understanding that lowering access isn't retroactive; scrubbing already-materialized artifacts is tracked separately (#517).

##### Appsec
No new input surface.

### Performance
N/A.

### Data
N/A.

### Backward compatibility
No API or data-model changes.

## Testing
Deployed to dev04: the Users card opens in a new tab; in the user list an active admin shows both an "Active" status badge and a separate "Admin" badge; editing a user surfaces the access-change warning.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate

Closes #515
Closes #516
