### PR TITLE
fix(playbooks): serve playbook CSV exports client-side (cohort + follow-up)

### DIFF
--- a/analytics/notebooks/cohort/cohort_builder.py
+++ b/analytics/notebooks/cohort/cohort_builder.py
@@ -63,11 +63,6 @@ DEFAULT_FACILITIES = [
     "SLCH",
 ]
 
-# Export directory (must be under /home/jovyan/notebooks for Voila file serving)
-EXPORT_DIR = "/home/jovyan/notebooks/exports"
-os.makedirs(EXPORT_DIR, exist_ok=True)
-
-
 # ============================================================================
 # UTILITY FUNCTIONS
 # ============================================================================
@@ -632,7 +627,9 @@ def export_cohort(df, annotations, include_report_text=False):
         include_report_text: Whether to include full report text
 
     Returns:
-        Path to exported file
+        (csv_string, filename) tuple. The CSV is built in memory and handed to
+        the browser as a client-side download (see cohort_ui.create_export_controls)
+        rather than written to a shared server directory.
     """
     # Build export dataframe
     export_df = df[
@@ -666,12 +663,11 @@ def export_cohort(df, annotations, include_report_text=False):
     if include_report_text:
         export_df["report_text"] = df["report_text"]
 
-    # Generate filename
+    # Generate filename and serialize to an in-memory CSV string. Passing no
+    # path to to_csv() returns the CSV as text so the caller can hand it to the
+    # browser as a Blob download; nothing is written to the server.
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     filename = f"cohort_{timestamp}.csv"
-    filepath = os.path.join(EXPORT_DIR, filename)
+    csv_string = export_df.to_csv(index=False)
 
-    # Save
-    export_df.to_csv(filepath, index=False)
-
-    return filepath
+    return csv_string, filename

--- a/analytics/notebooks/cohort/cohort_ui.py
+++ b/analytics/notebooks/cohort/cohort_ui.py
@@ -7,6 +7,7 @@ This module provides the interactive UI components for the cohort builder dashbo
 import os
 import re
 import html
+import base64
 import pandas as pd
 import ipywidgets as widgets
 from IPython.display import display, HTML
@@ -950,7 +951,7 @@ def create_export_controls(state):
             export_output.clear_output(wait=True)
 
             try:
-                filepath = export_cohort(
+                csv_string, filename = export_cohort(
                     state["df"], state["annotations"], include_report_text_check.value
                 )
 
@@ -958,9 +959,15 @@ def create_export_controls(state):
                     1 for a in state["annotations"].values() if a.get("reviewed", False)
                 )
 
-                # Get filename and create download link
-                filename = os.path.basename(filepath)
-                download_url = f"/voila/files/exports/{filename}"
+                # Hand the CSV to the browser as a client-side Blob download
+                # instead of writing it to a shared server directory (a
+                # predictable /voila/files URL previously let other users fetch
+                # someone else's export). The CSV is base64-encoded into the page
+                # and reassembled into a Blob in the browser on click; a Blob (not
+                # a data: URI) has no URL length limit, so very large cohorts are
+                # held entirely in the user's browser memory.
+                csv_b64 = base64.b64encode(csv_string.encode("utf-8")).decode("ascii")
+                dl_id = f"cohort-dl-{os.urandom(6).hex()}"
 
                 display(
                     HTML(
@@ -976,7 +983,7 @@ def create_export_controls(state):
                         <div style='font-size: 14px; opacity: 0.95; margin-bottom: 16px;'>
                             Exported {len(state['df'])} reports ({annotated_count} annotated)
                         </div>
-                        <a href="{download_url}" download="{filename}"
+                        <a href="#" id="{dl_id}"
                            class='download-link'
                            style='display: block; width: 100%; box-sizing: border-box;
                                   background: rgba(255,255,255,0.2);
@@ -987,6 +994,31 @@ def create_export_controls(state):
                             📥 Download {filename}
                         </a>
                     </div>
+                    <script>
+                    (function() {{
+                        setTimeout(function() {{
+                            var link = document.getElementById("{dl_id}");
+                            if (!link) return;
+                            link.addEventListener("click", function(e) {{
+                                e.preventDefault();
+                                var bytes = atob("{csv_b64}");
+                                var arr = new Uint8Array(bytes.length);
+                                for (var i = 0; i < bytes.length; i++) {{
+                                    arr[i] = bytes.charCodeAt(i);
+                                }}
+                                var blob = new Blob([arr], {{type: "text/csv"}});
+                                var url = URL.createObjectURL(blob);
+                                var a = document.createElement("a");
+                                a.href = url;
+                                a.download = "{filename}";
+                                document.body.appendChild(a);
+                                a.click();
+                                document.body.removeChild(a);
+                                URL.revokeObjectURL(url);
+                            }});
+                        }}, 100);
+                    }})();
+                    </script>
                 """
                     )
                 )

--- a/analytics/notebooks/cohort/cohort_ui.py
+++ b/analytics/notebooks/cohort/cohort_ui.py
@@ -947,6 +947,12 @@ def create_export_controls(state):
     export_output = widgets.Output()
 
     def on_export(b):
+        # Preparing a large cohort with report text serializes a big CSV in the
+        # kernel and can take a minute or more; disable the button and show a
+        # working state so it's clear something is happening (mirrors the
+        # follow-up dashboard's "⏳ Loading..." button pattern).
+        export_button.disabled = True
+        export_button.description = "⏳ Preparing CSV…"
         with export_output:
             export_output.clear_output(wait=True)
 
@@ -1034,6 +1040,9 @@ def create_export_controls(state):
                 """
                     )
                 )
+            finally:
+                export_button.disabled = False
+                export_button.description = "📝 Prepare Cohort CSV"
 
     export_button.on_click(on_export)
 

--- a/analytics/notebooks/cohort/cohort_ui.py
+++ b/analytics/notebooks/cohort/cohort_ui.py
@@ -720,7 +720,7 @@ def create_annotation_controls(
                     """
                 <div style='background: #fef3c7; color: #92400e; padding: 8px; border-radius: 4px;
                             font-size: 12px; text-align: center; border: 1px solid #f59e0b;'>
-                    🚧 XNAT integration is a planned feature. For now, use <strong>Export Cohort CSV</strong> to download your cohort.
+                    🚧 XNAT integration is a planned feature. For now, use <strong>Prepare Cohort CSV</strong> to download your cohort.
                 </div>
             """
                 )
@@ -939,7 +939,7 @@ def create_export_controls(state):
     )
 
     export_button = widgets.Button(
-        description="📥 Export Cohort CSV",
+        description="📝 Prepare Cohort CSV",
         button_style="info",
         layout=widgets.Layout(width="auto"),
     )
@@ -979,9 +979,9 @@ def create_export_controls(state):
                     </style>
                     <div style='background: {SUCCESS_GRADIENT}; padding: 16px; border-radius: 8px;
                                 color: white; margin-top: 12px; width: 100%; box-sizing: border-box;'>
-                        <div style='font-weight: 600; margin-bottom: 8px;'>✓ Export Successful</div>
+                        <div style='font-weight: 600; margin-bottom: 8px;'>✓ CSV ready — click below to download</div>
                         <div style='font-size: 14px; opacity: 0.95; margin-bottom: 16px;'>
-                            Exported {len(state['df'])} reports ({annotated_count} annotated)
+                            Prepared {len(state['df'])} reports ({annotated_count} annotated)
                         </div>
                         <a href="#" id="{dl_id}"
                            class='download-link'
@@ -1028,7 +1028,7 @@ def create_export_controls(state):
                         f"""
                     <div style='background: {RED_ERROR}; padding: 16px; border-radius: 8px;
                                 color: white; margin-top: 12px;'>
-                        <div style='font-weight: 600; margin-bottom: 8px;'>✗ Export Failed</div>
+                        <div style='font-weight: 600; margin-bottom: 8px;'>✗ CSV Preparation Failed</div>
                         <div style='font-size: 14px; opacity: 0.95;'>Error: {str(e)}</div>
                     </div>
                 """

--- a/analytics/notebooks/followup-detection/followup_review_dashboard.py
+++ b/analytics/notebooks/followup-detection/followup_review_dashboard.py
@@ -36,6 +36,7 @@ import ipywidgets as widgets
 from IPython.display import display, HTML
 import html as html_lib
 import os
+import base64
 
 # Global state
 annotations = {}
@@ -1496,33 +1497,20 @@ def create_review_dashboard(
                 if a.get("reviewed") and a.get("ground_truth") is None
             )
 
-            # Export to CSV with timestamp.
-            # Voilà mounts each notebook directory read-only, so we cannot write
-            # CSV next to the notebook. Use the canonical writable exports dir
-            # (sibling mount). Fall back to CWD for environments without it.
+            # Serialize the annotations to an in-memory CSV string and hand it to
+            # the browser as a Blob download (see the download link below) rather
+            # than writing a file on the shared server, so no other user can fetch
+            # this export from a predictable /voila/files URL.
             from datetime import datetime
 
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            export_dir = "/home/jovyan/notebooks/exports"
-            if not os.path.isdir(export_dir) or not os.access(export_dir, os.W_OK):
-                export_dir = os.getcwd()
-            output_path = os.path.join(
-                export_dir, f"followup_annotations_{timestamp}.csv"
-            )
+            csv_filename = f"followup_annotations_{timestamp}.csv"
 
             with annotation_status:
                 annotation_status.clear_output(wait=True)
-                print(f"📦 Preparing annotations for export...")
-                print(f"💾 Saving to CSV: {output_path}...")
+                print("📦 Preparing annotations for export...")
 
-            try:
-                ann_df.to_csv(output_path, index=False)
-            except OSError as e:
-                with annotation_status:
-                    annotation_status.clear_output(wait=True)
-                    print(f"❌ CSV write failed: {e}")
-                    print(f"   (target: {output_path})")
-                return
+            csv_string = ann_df.to_csv(index=False)
 
             # Write reviewer annotations back to the Delta table via trino-rw
             # (ADR 0019). Trino's Delta connector supports row-level UPDATE; the
@@ -1532,8 +1520,7 @@ def create_review_dashboard(
 
             with annotation_status:
                 annotation_status.clear_output(wait=True)
-                print(f"💾 Saved to CSV: {output_path}")
-                print(f"🔄 Updating Delta Lake table...")
+                print("🔄 Updating Delta Lake table...")
 
             try:
                 from playbook_helpers import connect_writeback
@@ -1613,24 +1600,66 @@ def create_review_dashboard(
             except Exception as e:
                 delta_error = str(e)
 
+            # Build a client-side Blob download for the CSV. The CSV is
+            # base64-encoded into the page and reassembled into a Blob in the
+            # browser on click; a Blob (not a data: URI) has no URL length limit,
+            # so very large annotation sets are held entirely in browser memory.
+            csv_b64 = base64.b64encode(csv_string.encode("utf-8")).decode("ascii")
+            dl_id = f"followup-dl-{os.urandom(6).hex()}"
+            download_html = f"""
+                <a href="#" id="{dl_id}"
+                   style='display: inline-block; margin-top: 8px; background: #10b981;
+                          padding: 8px 14px; border-radius: 6px; color: white;
+                          text-decoration: none; font-weight: bold; font-size: 13px;'>
+                    📥 Download {csv_filename}
+                </a>
+                <script>
+                (function() {{
+                    setTimeout(function() {{
+                        var link = document.getElementById("{dl_id}");
+                        if (!link) return;
+                        link.addEventListener("click", function(e) {{
+                            e.preventDefault();
+                            var bytes = atob("{csv_b64}");
+                            var arr = new Uint8Array(bytes.length);
+                            for (var i = 0; i < bytes.length; i++) {{
+                                arr[i] = bytes.charCodeAt(i);
+                            }}
+                            var blob = new Blob([arr], {{type: "text/csv"}});
+                            var url = URL.createObjectURL(blob);
+                            var a = document.createElement("a");
+                            a.href = url;
+                            a.download = "{csv_filename}";
+                            document.body.appendChild(a);
+                            a.click();
+                            document.body.removeChild(a);
+                            URL.revokeObjectURL(url);
+                        }});
+                    }}, 100);
+                }})();
+                </script>
+            """
+
             # Final success message
             with annotation_status:
                 annotation_status.clear_output(wait=True)
                 print(f"✅ Successfully exported {len(ann_data)} annotations")
-                print(f"   📄 CSV file: {output_path}")
                 if delta_success:
                     print(
                         f"   💾 Updated Delta Lake table: "
                         f"{table_name or 'default.reports_followup'}"
                     )
                 else:
-                    print("   ⚠️  Delta Lake update failed (CSV export still saved)")
+                    print(
+                        "   ⚠️  Delta Lake update failed (CSV download still available)"
+                    )
                     if delta_error:
                         print(f"       Error: {delta_error}")
                 print(f"\n📊 Annotation Summary:")
                 print(f"   ✓ {yes_count} Follow-up Needed")
                 print(f"   ✗ {no_count} No Follow-up")
                 print(f"   ? {uncertain_count} Uncertain")
+                display(HTML(download_html))
 
         finally:
             # Always re-enable button

--- a/helm/voila/templates/deployment.yaml
+++ b/helm/voila/templates/deployment.yaml
@@ -101,8 +101,6 @@ spec:
             - name: trino-ca
               mountPath: /etc/trino-ca
               readOnly: true
-            - name: exports
-              mountPath: /home/jovyan/notebooks/exports
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -144,8 +142,6 @@ spec:
             items:
               - key: ca.crt
                 path: ca.crt
-        - name: exports
-          emptyDir: {}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
## Description

### Product
Playbook CSV exports (cohort builder + follow-up dashboard) were written to a shared directory served by Voila under a predictable URL, so any signed-in user could download another user's export by guessing the URL. Exports now download directly in the browser, so nothing is served from a shared path (#508). Along the way, two cohort-export UX tweaks: the button reads "Prepare Cohort CSV" and then offers a Download link (so the two steps read clearly), and it shows a working state while a large CSV is being prepared.

<img width="336" height="354" alt="Screenshot 2026-07-14 at 12 50 31 PM" src="https://github.com/user-attachments/assets/83b22080-ca3d-480f-8ee9-d0e5e8c693e2" />

### Technical
- **#508:** The cohort builder (`cohort_ui.py` / `cohort_builder.py`) and the follow-up dashboard now build the CSV in memory and hand it to the browser as a `Blob` via `URL.createObjectURL()` (base64-shipped from the kernel, decoded client-side), triggered from a temporary anchor. Nothing is written to `/home/jovyan/notebooks/exports`, and the now-unused `exports` `emptyDir` is removed from the Voila deployment. RADS is unchanged.
- **Cohort UX:** the export button is relabeled "Prepare Cohort CSV" and switches to "⏳ Preparing CSV…" (disabled) while the CSV serializes in the kernel — which can take a minute+ for a large cohort with report text — mirroring the follow-up dashboard's button pattern.

<img width="310" height="95" alt="Screenshot 2026-07-14 at 12 50 23 PM" src="https://github.com/user-attachments/assets/71278b3e-7745-45d2-8b4a-56d9daa2d01a" />

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
Closes a cross-user data exposure: exports were readable by any authenticated user via a guessable `/voila/files/exports/<name>` URL, regardless of their data access. Delivering the file client-side removes the served artifact entirely — there is no URL to enumerate.

##### Appsec
The CSV is base64-embedded in the page and reassembled into a Blob in the browser via an inline script (matching the dashboard's existing script-output pattern). No server-side file, no shared path.

### Performance
A Blob has no URL-length limit (unlike a `data:` URI), so large cohorts export fine, but the CSV is held in browser memory while downloading; noted in the code. Typical exports are small. Tested a 30MB download (20k reports + full text), which took a while to "prepare," but downloaded fine.

### Data
No change to ingested data or schema.

### Backward compatibility
Compatible

## Testing
Deployed to dev04. Confirmed `/home/jovyan/notebooks/exports` no longer exists and the `exports` volume is gone from the deployment. Smoke test to run in the deployed Voila: prepare + download a cohort CSV in cohort builder, export and download follow-up annotations in FUD playbook, and confirm nothing is served under `/voila/files/exports/`.

No network traffic for download (no URL to pirate):
<img width="1492" height="682" alt="Screenshot 2026-07-14 at 12 50 41 PM" src="https://github.com/user-attachments/assets/8b98c786-0183-4440-bea8-87cf9713d660" />

No shared directory:
<img width="485" height="78" alt="Screenshot 2026-07-14 at 9 53 38 AM" src="https://github.com/user-attachments/assets/2e2fda29-e5e3-4b3b-b254-e8d95ffbf8ba" />

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate

Closes #508
