### PR TITLE
fix(open-webui): disable per-chat sharing

### DIFF
--- a/ansible/roles/open-webui/README.md
+++ b/ansible/roles/open-webui/README.md
@@ -174,6 +174,8 @@ Query instructions, schema reference, and charting-output rules all live in `hel
 
 OWUI stores tool servers, default/task model IDs, etc. in its Postgres `config` table as PersistentConfig — env-var changes after first launch are silent no-ops. The bootstrap Job side-steps this by re-POSTing the declarative fields via REST on every deploy. `RAG_TEMPLATE` is intentionally not pushed (Scout Explorer's `function_calling: native` bypasses OWUI's RAG auto-injection — schema docs are inlined into the system prompt instead).
 
+The Job likewise re-asserts `chat.share=false` in the default user permissions on every deploy, keeping per-chat sharing disabled platform-wide (issue #506 — a shared chat's report-viewer iframe re-runs its saved search under the recipient's identity, but searches are owner-scoped). Unlike the fields above this is a fixed safety policy, not an inventory knob. It only gates non-admins: OWUI exempts admins from the `chat.share` check, so an admin can still create a share link.
+
 Genuinely seed-only knobs (`WEBUI_URL`, `ENABLE_SIGNUP`, `ENABLE_LOGIN_FORM`, `ENABLE_COMMUNITY_SHARING`) are set via Helm extraEnvVars and only take effect at first launch. To flip one post-launch: `DELETE FROM config WHERE key = '<KEY>'`, restart the OWUI pod, env re-seeds. OAuth fields (`OAUTH_*`, `OPENID_*`) are env-only because `ENABLE_OAUTH_PERSISTENT_CONFIG=false` skips loading them from the config table.
 
 ### Example queries

--- a/ansible/roles/open-webui/defaults/main.yaml
+++ b/ansible/roles/open-webui/defaults/main.yaml
@@ -163,6 +163,10 @@ open_webui_csp_enabled: true
 # So these ARE fully declarative — change inventory, re-run make install-chat,
 # done. No SQL surgery on the `config` table needed.
 #
+# The Job also force-disables chat sharing (user.permissions.chat.share) on
+# every deploy — a fixed safety policy, not an inventory knob; see the role
+# README and issue #506.
+#
 # RAG_TEMPLATE is intentionally NOT pushed: Scout Explorer models run with
 # function_calling: native, which bypasses OWUI's RAG auto-injection path.
 # The schema/charting instructions that RAG would otherwise carry are inlined

--- a/ansible/roles/open-webui/templates/values.yaml.j2
+++ b/ansible/roles/open-webui/templates/values.yaml.j2
@@ -189,6 +189,13 @@ extraEnvVars:
   - name: ENABLE_COMMUNITY_SHARING
     value: 'false'
 
+  # Disable per-chat sharing: a shared chat's report-viewer iframe 401s for the
+  # recipient because searches are owner-scoped (issue #506). This is seed-only
+  # PersistentConfig, so the open-webui-bootstrap Job re-asserts it on every
+  # deploy for clusters whose config table was already seeded with sharing on.
+  - name: USER_PERMISSIONS_CHAT_SHARE
+    value: 'false'
+
   # Enable OAuth signup and authentication
   - name: ENABLE_OAUTH_SIGNUP
     value: 'true'

--- a/helm/open-webui-bootstrap/files/bootstrap.py
+++ b/helm/open-webui-bootstrap/files/bootstrap.py
@@ -14,7 +14,8 @@ Phases:
 3. PersistentConfig re-push. Tool servers (full overwrite); DEFAULT_MODELS
    + TASK_MODEL (GET-merge-POST to preserve siblings). RAG template is not
    pushed — Scout Explorer models use function_calling: native, which
-   bypasses OWUI's RAG auto-injection path entirely.
+   bypasses OWUI's RAG auto-injection path entirely. Also force-disables
+   chat sharing (chat.share) platform-wide — see issue #506.
 4. Filter functions, then 5. event functions. Both seed via
    /api/v1/functions: idempotent GET-create-or-update, set valves, toggle.
 6. Prune functions not in the seeded set (config-authoritative).
@@ -225,6 +226,23 @@ def push_persistent_config(token):
             token,
         )
         print(f'  task_model_id: {cfg["task_model_id"]}')
+
+    # Force chat sharing off (issue #506). An OWUI shared chat re-runs its
+    # report-viewer search live under the *recipient's* identity, but searches
+    # are owner-scoped, so a shared chat's viewer 401s for anyone but the
+    # author. user.permissions is seed-only PersistentConfig, so re-assert it
+    # every deploy. The GET returns a complete UserPermissions object; flip the
+    # one nested field and POST it back, preserving all sibling permissions.
+    # (Only gates non-admins — OWUI exempts admins from the chat.share check.)
+    perms = json.loads(
+        http_or_raise("GET", "/api/v1/users/default/permissions", token=token)
+    )
+    if perms.get("chat", {}).get("share") is False:
+        print("  chat.share: already disabled")
+    else:
+        perms.setdefault("chat", {})["share"] = False
+        http_or_raise("POST", "/api/v1/users/default/permissions", perms, token)
+        print("  chat.share: disabled (chat sharing off)")
 
 
 def push_functions(token, config_file):


### PR DESCRIPTION
## Description

Interim mitigation for #506.

### Product
Turns off the **Share** feature in Scout Chat (Open WebUI), so users can no longer create a share link for a chat conversation.

Before:
<img width="434" height="322" alt="Screenshot 2026-07-20 at 1 06 34 PM" src="https://github.com/user-attachments/assets/37abf2ee-03e4-4bc5-8fce-1220aa7eb69e" />


After:
<img width="442" height="277" alt="Screenshot 2026-07-20 at 1 06 23 PM" src="https://github.com/user-attachments/assets/8dd94b01-9b06-4a44-b71a-5874882d266d" />


A shared chat embeds a live report-viewer, and the recipient sees an empty/unauthorized viewer (#506). More importantly, a chat transcript is a frozen snapshot of the assistant's replies, which can contain report content the author was authorized to see but the recipient is not; sharing re-shows that transcript without re-checking the recipient's access. Disabling sharing removes both exposures until an access-aware sharing model exists.

### Technical
Disables the OWUI `chat.share` user permission, which gates `POST /api/v1/chats/{id}/share` (the prerequisite for both public share links and per-chat access grants) and the Share menu items in the UI.

`user.permissions` is seed-only `PersistentConfig` in OWUI, so it is handled two ways:
- **`values.yaml.j2`** — seed `USER_PERMISSIONS_CHAT_SHARE=false` via Helm `extraEnvVars`: correct default on a fresh DB and in the no-bootstrap mode, and closes the window before the post-install Job runs.
- **`bootstrap.py`** — the open-webui-bootstrap Job re-asserts `chat.share=false` in the default user permissions on every deploy (GET-merge-POST, preserving sibling permissions), because a bare env var is a no-op on clusters whose config table was already seeded with sharing enabled (i.e. any already-running deployment).

Verified against OWUI v0.10.2.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
Tightens authorization: removes a path by which report content could cross a user's Trino authorization boundary (row filters / column masks per ADR 0020/0021) via a shared chat transcript.

**Only gates non-admins**: OWUI exempts `admin` users from the `chat.share` check at the endpoint, so a `scout-admin` can still create a share link. 

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
- Does **not** retroactively revoke chats that were *already* shared before this change. On an existing cluster, use OWUI's unshare-all (`DELETE /api/v1/chats/share/all`) or manual cleanup if prior shares must be revoked.

## Testing
- `pre-commit run --files` on all four changed files: passed, nothing reformatted.
- `ruff check` and `py_compile` on `bootstrap.py`: clean.
- Deployed to `dev04`, confirmed Share link is gone. 

## Note for reviewers
- This is the interim mitigation called for on #506 ("disable chat sharing in OWUI until we have a better solution"). Suggest keeping #506 open (but out of `4.1.0` milestone) to track the real fix: access-aware **search-level** sharing in report-viewer (share the re-runnable search, evaluated as the recipient) so the owner's "frozen", permission-unaware transcript never travels.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (ran `pre-commit run --files` on the changed files)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate (N/A — not surfaced in user docs)
- [x] I have added or updated technical documentation (role README + inline comments; no ADR — interim toggle)
- [ ] I have added unit tests, if appropriate (see note for reviewers)
- [ ] I have added end-to-end tests, if appropriate
