### PR TITLE
fix(report-viewer): CSV Export Fix and Dark Mode

### DIFF
--- a/report-viewer/frontend/src/App.tsx
+++ b/report-viewer/frontend/src/App.tsx
@@ -7,8 +7,8 @@ function App() {
       <div
         style={{
           fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
-          color: '#222',
-          background: '#fff',
+          color: 'var(--rv-fg)',
+          background: 'var(--rv-surface)',
           padding: '0.5rem',
           height: '100vh',
           boxSizing: 'border-box',
@@ -25,9 +25,9 @@ function App() {
     <div
       style={{
         fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
-        color: '#222',
+        color: 'var(--rv-fg)',
         height: '100vh',
-        background: '#fafafa',
+        background: 'var(--rv-bg)',
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
@@ -36,8 +36,8 @@ function App() {
       <header
         style={{
           padding: '0.75rem 1.5rem',
-          background: '#fff',
-          borderBottom: '1px solid #e2e2e2',
+          background: 'var(--rv-surface)',
+          borderBottom: '1px solid var(--rv-border)',
           flex: '0 0 auto',
         }}
       >

--- a/report-viewer/frontend/src/Modal.tsx
+++ b/report-viewer/frontend/src/Modal.tsx
@@ -44,7 +44,8 @@ export function Modal(props: {
         onClick={(e) => e.stopPropagation()}
         style={{
           position: 'relative',
-          background: '#fff',
+          background: 'var(--rv-surface)',
+          color: 'var(--rv-fg)',
           padding: '1.25rem 1.5rem',
           borderRadius: 6,
           minWidth: props.minWidth,

--- a/report-viewer/frontend/src/api/client.ts
+++ b/report-viewer/frontend/src/api/client.ts
@@ -183,14 +183,17 @@ export async function getReport(reportId: string, idColumn: string): Promise<Rep
   return row as unknown as ReportDetail;
 }
 
-export function getSearchRows(searchId: string, params: RowsParams): Promise<RowsResponse> {
+// Serializes the sort + filter view state shared by the /rows and /csv
+// endpoints into query params. Callers add their own page/limit/columns.
+export function buildViewQuery(view: {
+  sort?: { col: string; dir: 'asc' | 'desc' } | null;
+  filters?: FilterState;
+}): URLSearchParams {
   const qs = new URLSearchParams();
-  qs.set('page', String(params.page));
-  qs.set('limit', String(params.limit));
-  if (params.sort) {
-    qs.set('sort', `${params.sort.col}:${params.sort.dir}`);
+  if (view.sort) {
+    qs.set('sort', `${view.sort.col}:${view.sort.dir}`);
   }
-  const f = params.filters;
+  const f = view.filters;
   if (f) {
     if (f.patient_age?.min) qs.set('filter.patient_age.min', f.patient_age.min);
     if (f.patient_age?.max) qs.set('filter.patient_age.max', f.patient_age.max);
@@ -203,5 +206,31 @@ export function getSearchRows(searchId: string, params: RowsParams): Promise<Row
     if (f.accession_number) qs.set('filter.accession_number', f.accession_number);
     if (f.sending_facility) qs.set('filter.sending_facility', f.sending_facility);
   }
+  return qs;
+}
+
+export function getSearchRows(searchId: string, params: RowsParams): Promise<RowsResponse> {
+  const qs = buildViewQuery({ sort: params.sort, filters: params.filters });
+  qs.set('page', String(params.page));
+  qs.set('limit', String(params.limit));
   return api<RowsResponse>(`/api/searches/${encodeURIComponent(searchId)}/rows?${qs.toString()}`);
+}
+
+// Download URL for the CSV export. Mirrors the current view: same sort/filters
+// as the table, and `columns` restricts the export to the visible columns
+// (primary_report_identifier is always appended server-side).
+export function csvUrl(
+  searchId: string,
+  view: {
+    sort?: { col: string; dir: 'asc' | 'desc' } | null;
+    filters?: FilterState;
+    columns?: string[];
+  },
+): string {
+  const qs = buildViewQuery({ sort: view.sort, filters: view.filters });
+  if (view.columns && view.columns.length > 0) {
+    qs.set('columns', view.columns.join(','));
+  }
+  const suffix = qs.toString();
+  return `/api/searches/${encodeURIComponent(searchId)}/csv${suffix ? `?${suffix}` : ''}`;
 }

--- a/report-viewer/frontend/src/main.tsx
+++ b/report-viewer/frontend/src/main.tsx
@@ -9,6 +9,7 @@ import SearchDetailPage from './pages/SearchDetailPage';
 import { ApiError, getConfig } from './api/client';
 import { setChatOrigin } from './chat';
 import { postHeight } from './iframeHeight';
+import './theme.css';
 
 // basename must match the FastAPI StaticFiles mount (/spa/); Vite's `base`
 // only handles asset URLs, not React Router's internal routes.
@@ -37,14 +38,6 @@ const queryClient = new QueryClient({
     },
   },
 });
-
-const pulseStyle = document.createElement('style');
-pulseStyle.textContent =
-  '@keyframes scoutSpin{to{transform:rotate(360deg)}}' +
-  '.scout-col-resize{border-right:1px solid #d0d0d0}' +
-  '.scout-col-resize:hover{border-right-color:#888}' +
-  'tr.scout-row:hover{background:#f5f7f9 !important}';
-document.head.appendChild(pulseStyle);
 
 // Fetch chat origin from the backend before mounting; a failure leaves
 // _chatOrigin empty and cross-frame postMessages no-op silently.

--- a/report-viewer/frontend/src/pages/SearchDetailPage.tsx
+++ b/report-viewer/frontend/src/pages/SearchDetailPage.tsx
@@ -173,7 +173,7 @@ export default function SearchDetailPage() {
           <span
             title="Search ID"
             style={{
-              color: '#999',
+              color: 'var(--rv-muted)',
               fontSize: '0.7rem',
               fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
               userSelect: 'all',
@@ -183,9 +183,11 @@ export default function SearchDetailPage() {
           </span>
         )}
       </div>
-      {rowsQ.error && <p style={{ color: '#b00' }}>{friendlyError(rowsQ.error, 'these rows')}</p>}
+      {rowsQ.error && (
+        <p style={{ color: 'var(--rv-danger)' }}>{friendlyError(rowsQ.error, 'these rows')}</p>
+      )}
       {!rowsQ.data && rowsQ.isLoading ? (
-        <p style={{ color: '#666' }}>Loading reports…</p>
+        <p style={{ color: 'var(--rv-muted)' }}>Loading reports…</p>
       ) : (
         rowsQ.data && (
           <div
@@ -202,8 +204,8 @@ export default function SearchDetailPage() {
                 overflowY: 'auto',
                 flex: '1 1 auto',
                 minHeight: 0,
-                background: '#fff',
-                border: '1px solid #e2e2e2',
+                background: 'var(--rv-surface)',
+                border: '1px solid var(--rv-border)',
                 borderRadius: 4,
               }}
             >
@@ -234,11 +236,11 @@ export default function SearchDetailPage() {
                               padding: '0.35rem 0.45rem',
                               fontSize: '0.78rem',
                               fontWeight: 600,
-                              color: '#555',
-                              background: '#f5f5f5',
+                              color: 'var(--rv-muted)',
+                              background: 'var(--rv-surface-2)',
                               // border-collapse: collapse + sticky drops
                               // border-bottom on scroll; box-shadow survives.
-                              boxShadow: 'inset 0 -1px 0 #c8ccd0',
+                              boxShadow: 'inset 0 -1px 0 var(--rv-border)',
                               whiteSpace: 'nowrap',
                               width: header.getSize(),
                               cursor: 'pointer',
@@ -264,7 +266,9 @@ export default function SearchDetailPage() {
                                 cursor: 'col-resize',
                                 userSelect: 'none',
                                 touchAction: 'none',
-                                ...(isResizing ? { borderRight: '2px solid #4477AA' } : {}),
+                                ...(isResizing
+                                  ? { borderRight: '2px solid var(--rv-accent)' }
+                                  : {}),
                               }}
                             />
                           </th>
@@ -282,7 +286,7 @@ export default function SearchDetailPage() {
                           className={isExpanded ? undefined : 'scout-row'}
                           onClick={() => row.toggleExpanded()}
                           style={{
-                            borderBottom: '1px solid #f0f0f0',
+                            borderBottom: '1px solid var(--rv-border)',
                             cursor: 'pointer',
                             background: isExpanded ? ROW_ACTIVE_BG : 'transparent',
                           }}
@@ -337,7 +341,7 @@ export default function SearchDetailPage() {
                     <tr>
                       <td
                         colSpan={table.getVisibleFlatColumns().length}
-                        style={{ padding: '1rem', textAlign: 'center', color: '#888' }}
+                        style={{ padding: '1rem', textAlign: 'center', color: 'var(--rv-muted)' }}
                       >
                         {activeFilterCount(appliedFilters) > 0
                           ? 'No rows match your filters.'
@@ -378,7 +382,9 @@ export default function SearchDetailPage() {
               >
                 Next
               </button>
-              <span style={{ marginLeft: '0.4rem', color: '#888', whiteSpace: 'nowrap' }}>
+              <span
+                style={{ marginLeft: '0.4rem', color: 'var(--rv-muted)', whiteSpace: 'nowrap' }}
+              >
                 Per page:
               </span>
               <select
@@ -396,7 +402,7 @@ export default function SearchDetailPage() {
               </select>
               <span
                 style={{
-                  color: '#666',
+                  color: 'var(--rv-muted)',
                   fontSize: '0.75rem',
                   whiteSpace: 'nowrap',
                 }}
@@ -431,9 +437,9 @@ export default function SearchDetailPage() {
                   activeFilterCount(appliedFilters) > 0
                     ? {
                         ...paginationBtn,
-                        background: '#4477AA',
+                        background: 'var(--rv-accent)',
                         color: '#fff',
-                        borderColor: '#4477AA',
+                        borderColor: 'var(--rv-accent)',
                       }
                     : paginationBtn
                 }
@@ -459,8 +465,8 @@ export default function SearchDetailPage() {
                       bottom: '100%',
                       right: 0,
                       marginBottom: 4,
-                      background: '#fff',
-                      border: '1px solid #d0d7e0',
+                      background: 'var(--rv-surface)',
+                      border: '1px solid var(--rv-border)',
                       borderRadius: 4,
                       boxShadow: '0 4px 12px rgba(0,0,0,0.12)',
                       padding: '0.4rem 0.6rem',
@@ -505,9 +511,7 @@ export default function SearchDetailPage() {
                 href={`/api/searches/${encodeURIComponent(searchId)}/csv`}
                 style={{
                   ...paginationBtn,
-                  color: '#222',
                   textDecoration: 'none',
-                  background: '#fff',
                 }}
               >
                 Download CSV

--- a/report-viewer/frontend/src/pages/SearchDetailPage.tsx
+++ b/report-viewer/frontend/src/pages/SearchDetailPage.tsx
@@ -424,7 +424,7 @@ export default function SearchDetailPage() {
                   width: 13,
                   height: 13,
                   borderRadius: '50%',
-                  border: '2px solid #fde6c2',
+                  border: '2px solid var(--rv-border)',
                   borderTopColor: '#ea580c',
                   animation: 'scoutSpin 0.8s linear infinite',
                   display: 'inline-block',

--- a/report-viewer/frontend/src/pages/SearchDetailPage.tsx
+++ b/report-viewer/frontend/src/pages/SearchDetailPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '@tanstack/react-table';
 import {
   activeFilterCount,
+  csvUrl,
   friendlyError,
   getSearch,
   getSearchRows,
@@ -508,7 +509,11 @@ export default function SearchDetailPage() {
                 </button>
               )}
               <a
-                href={`/api/searches/${encodeURIComponent(searchId)}/csv`}
+                href={csvUrl(searchId, {
+                  sort: sortParam,
+                  filters: appliedFilters,
+                  columns: table.getVisibleLeafColumns().map((c) => c.id),
+                })}
                 style={{
                   ...paginationBtn,
                   textDecoration: 'none',

--- a/report-viewer/frontend/src/pages/SearchesListPage.tsx
+++ b/report-viewer/frontend/src/pages/SearchesListPage.tsx
@@ -10,7 +10,7 @@ function fmtTime(iso: string): string {
 }
 
 const rowStyle: React.CSSProperties = {
-  borderBottom: '1px solid #eee',
+  borderBottom: '1px solid var(--rv-border)',
   padding: '0.55rem 0.75rem',
 };
 
@@ -38,15 +38,15 @@ export default function SearchesListPage() {
   });
 
   if (isLoading) {
-    return <p style={{ color: '#666' }}>Loading searches…</p>;
+    return <p style={{ color: 'var(--rv-muted)' }}>Loading searches…</p>;
   }
   if (error) {
-    return <p style={{ color: '#b00' }}>{friendlyError(error, 'your searches')}</p>;
+    return <p style={{ color: 'var(--rv-danger)' }}>{friendlyError(error, 'your searches')}</p>;
   }
   const searches = data ?? [];
   if (searches.length === 0) {
     return (
-      <p style={{ color: '#666' }}>
+      <p style={{ color: 'var(--rv-muted)' }}>
         No searches yet. Searches you run in Scout Chat will show up here.
       </p>
     );
@@ -64,7 +64,7 @@ export default function SearchesListPage() {
         }}
       >
         <h2 style={{ margin: 0, fontSize: '1rem', fontWeight: 600 }}>Your searches</h2>
-        <span style={{ color: '#888', fontSize: '0.85rem' }}>
+        <span style={{ color: 'var(--rv-muted)', fontSize: '0.85rem' }}>
           {searches.length} {searches.length === 1 ? 'search' : 'searches'}
           {groups.length > 1 ? ` across ${groups.length} chats` : ''}
         </span>
@@ -90,22 +90,26 @@ function ChatGroup(props: { group: { chatId: string; items: SearchMeta[] } }) {
           marginBottom: '0.4rem',
         }}
       >
-        <h3 style={{ margin: 0, fontSize: '0.9rem', fontWeight: 600, color: '#222' }}>
+        <h3 style={{ margin: 0, fontSize: '0.9rem', fontWeight: 600, color: 'var(--rv-fg)' }}>
           {displayTitle}
         </h3>
-        <span style={{ color: '#888', fontSize: '0.75rem' }}>
+        <span style={{ color: 'var(--rv-muted)', fontSize: '0.75rem' }}>
           {items.length} {items.length === 1 ? 'search' : 'searches'}
         </span>
         {!isUngrouped && chatOrigin() && (
-          <a href={chatUrl(chatId)} target="_top" style={{ fontSize: '0.75rem', color: '#4477AA' }}>
+          <a
+            href={chatUrl(chatId)}
+            target="_top"
+            style={{ fontSize: '0.75rem', color: 'var(--rv-accent)' }}
+          >
             open chat ↗
           </a>
         )}
       </div>
       <div
         style={{
-          background: '#fff',
-          border: '1px solid #e2e2e2',
+          background: 'var(--rv-surface)',
+          border: '1px solid var(--rv-border)',
           borderRadius: 4,
           overflow: 'hidden',
         }}
@@ -114,9 +118,9 @@ function ChatGroup(props: { group: { chatId: string; items: SearchMeta[] } }) {
           style={{
             display: 'grid',
             gridTemplateColumns: '1fr 0.6fr 1fr',
-            background: '#f5f5f5',
+            background: 'var(--rv-surface-2)',
             fontSize: '0.8rem',
-            color: '#555',
+            color: 'var(--rv-muted)',
             fontWeight: 600,
             ...rowStyle,
           }}
@@ -133,7 +137,7 @@ function ChatGroup(props: { group: { chatId: string; items: SearchMeta[] } }) {
               display: 'grid',
               gridTemplateColumns: '1fr 0.6fr 1fr',
               fontSize: '0.88rem',
-              color: '#222',
+              color: 'var(--rv-fg)',
               textDecoration: 'none',
               ...rowStyle,
             }}
@@ -146,7 +150,7 @@ function ChatGroup(props: { group: { chatId: string; items: SearchMeta[] } }) {
               {d.id}
             </span>
             <span>{d.count === null ? '—' : d.count.toLocaleString()}</span>
-            <span style={{ color: '#555' }}>{fmtTime(d.created_at)}</span>
+            <span style={{ color: 'var(--rv-muted)' }}>{fmtTime(d.created_at)}</span>
           </Link>
         ))}
       </div>

--- a/report-viewer/frontend/src/pages/searchDetail/ExplainSqlModal.tsx
+++ b/report-viewer/frontend/src/pages/searchDetail/ExplainSqlModal.tsx
@@ -51,11 +51,11 @@ export function ExplainSqlModal(props: {
             background: 'transparent',
             borderRadius: 3,
             cursor: 'pointer',
-            color: '#5a6b80',
+            color: 'var(--rv-muted)',
           }}
           onMouseEnter={(e) => {
-            e.currentTarget.style.background = '#e6edf6';
-            e.currentTarget.style.borderColor = '#d0dceb';
+            e.currentTarget.style.background = 'var(--rv-surface-2)';
+            e.currentTarget.style.borderColor = 'var(--rv-border)';
           }}
           onMouseLeave={(e) => {
             e.currentTarget.style.background = 'transparent';
@@ -68,7 +68,7 @@ export function ExplainSqlModal(props: {
         {props.explanation ? (
           <p style={{ margin: '0 0 1rem', lineHeight: 1.5 }}>{props.explanation}</p>
         ) : (
-          <p style={{ margin: '0 0 1rem', color: '#888', fontStyle: 'italic' }}>
+          <p style={{ margin: '0 0 1rem', color: 'var(--rv-muted)', fontStyle: 'italic' }}>
             No plain-language explanation was attached to this search.
           </p>
         )}
@@ -76,8 +76,8 @@ export function ExplainSqlModal(props: {
         <div style={{ position: 'relative' }}>
           <pre
             style={{
-              background: '#f4f7fb',
-              border: '1px solid #d0dceb',
+              background: 'var(--rv-surface-2)',
+              border: '1px solid var(--rv-border)',
               borderRadius: 3,
               padding: '0.6rem 0.75rem',
               paddingRight: '2.25rem',
@@ -110,13 +110,13 @@ export function ExplainSqlModal(props: {
               background: 'transparent',
               borderRadius: 3,
               cursor: props.sql ? 'pointer' : 'not-allowed',
-              color: copied ? '#1a7a3a' : '#5a6b80',
+              color: copied ? 'var(--rv-success)' : 'var(--rv-muted)',
               opacity: props.sql ? 1 : 0.4,
             }}
             onMouseEnter={(e) => {
               if (!props.sql) return;
-              e.currentTarget.style.background = '#e6edf6';
-              e.currentTarget.style.borderColor = '#d0dceb';
+              e.currentTarget.style.background = 'var(--rv-surface-2)';
+              e.currentTarget.style.borderColor = 'var(--rv-border)';
             }}
             onMouseLeave={(e) => {
               e.currentTarget.style.background = 'transparent';
@@ -132,7 +132,12 @@ export function ExplainSqlModal(props: {
               Match criteria
             </div>
             <p
-              style={{ margin: '0 0 0.5rem', color: '#666', fontSize: '0.78rem', lineHeight: 1.4 }}
+              style={{
+                margin: '0 0 0.5rem',
+                color: 'var(--rv-muted)',
+                fontSize: '0.78rem',
+                lineHeight: 1.4,
+              }}
             >
               Words and diagnosis codes the LLM flagged as positive signals. They are highlighted in
               the report text and diagnosis chips when you expand a row, so you can spot-check why
@@ -141,7 +146,9 @@ export function ExplainSqlModal(props: {
             </p>
             {terms.length > 0 && (
               <div style={{ marginBottom: codes.length > 0 ? '0.4rem' : 0 }}>
-                <span style={{ color: '#666', fontSize: '0.78rem', marginRight: '0.4rem' }}>
+                <span
+                  style={{ color: 'var(--rv-muted)', fontSize: '0.78rem', marginRight: '0.4rem' }}
+                >
                   Match terms:
                 </span>
                 {terms.map((t, i) => (
@@ -149,6 +156,7 @@ export function ExplainSqlModal(props: {
                     key={i}
                     style={{
                       background: '#fff3a3',
+                      color: '#222',
                       padding: '0 4px',
                       marginRight: 4,
                       borderRadius: 2,
@@ -162,7 +170,9 @@ export function ExplainSqlModal(props: {
             )}
             {codes.length > 0 && (
               <div>
-                <span style={{ color: '#666', fontSize: '0.78rem', marginRight: '0.4rem' }}>
+                <span
+                  style={{ color: 'var(--rv-muted)', fontSize: '0.78rem', marginRight: '0.4rem' }}
+                >
                   Match diagnoses:
                 </span>
                 {codes.map((d, i) => (
@@ -170,6 +180,7 @@ export function ExplainSqlModal(props: {
                     key={i}
                     style={{
                       background: '#fff3a3',
+                      color: '#222',
                       padding: '0 4px',
                       marginRight: 4,
                       borderRadius: 2,

--- a/report-viewer/frontend/src/pages/searchDetail/FiltersModal.tsx
+++ b/report-viewer/frontend/src/pages/searchDetail/FiltersModal.tsx
@@ -150,7 +150,7 @@ export function FiltersModal(props: {
           style={{
             marginTop: '1rem',
             paddingTop: '0.75rem',
-            borderTop: '1px solid #eee',
+            borderTop: '1px solid var(--rv-border)',
             display: 'flex',
             gap: '0.5rem',
             alignItems: 'center',
@@ -171,9 +171,9 @@ export function FiltersModal(props: {
             onClick={() => props.onApply(staged)}
             style={{
               ...paginationBtn,
-              background: '#4477AA',
+              background: 'var(--rv-accent)',
               color: '#fff',
-              borderColor: '#4477AA',
+              borderColor: 'var(--rv-accent)',
             }}
           >
             Apply
@@ -194,7 +194,7 @@ function FieldRow(props: { label: string; children: ReactNode }) {
         padding: '0.4rem 0',
       }}
     >
-      <div style={{ width: 80, color: '#555', fontWeight: 600, paddingTop: '0.25rem' }}>
+      <div style={{ width: 80, color: 'var(--rv-muted)', fontWeight: 600, paddingTop: '0.25rem' }}>
         {props.label}
       </div>
       <div style={{ flex: 1, minWidth: 0 }}>{props.children}</div>
@@ -214,7 +214,7 @@ function RangeInputs(props: {
     minWidth: 0,
     fontSize: '0.85rem',
     padding: '0.3rem 0.45rem',
-    border: '1px solid #ccc',
+    border: '1px solid var(--rv-border)',
     borderRadius: 3,
     boxSizing: 'border-box',
   };
@@ -227,7 +227,7 @@ function RangeInputs(props: {
         placeholder={props.placeholder.min}
         style={style}
       />
-      <span style={{ color: '#888' }}>-</span>
+      <span style={{ color: 'var(--rv-muted)' }}>-</span>
       <input
         type={props.inputType}
         value={props.max}
@@ -250,7 +250,7 @@ function TextInput(props: { value: string; onChange: (value: string) => void }) 
         width: '100%',
         fontSize: '0.85rem',
         padding: '0.3rem 0.45rem',
-        border: '1px solid #ccc',
+        border: '1px solid var(--rv-border)',
         borderRadius: 3,
         boxSizing: 'border-box',
       }}

--- a/report-viewer/frontend/src/pages/searchDetail/RowDetail.tsx
+++ b/report-viewer/frontend/src/pages/searchDetail/RowDetail.tsx
@@ -39,7 +39,7 @@ export function RowDetail(props: {
     const parts = text.split(highlightRe);
     return parts.map((p, i) =>
       i % 2 === 1 ? (
-        <mark key={i} style={{ background: '#fff3a3', padding: '0 1px' }}>
+        <mark key={i} style={{ background: '#fff3a3', color: '#222', padding: '0 1px' }}>
           {p}
         </mark>
       ) : (
@@ -96,13 +96,13 @@ export function RowDetail(props: {
     Record<string, unknown>;
 
   return (
-    <div style={{ fontSize: '0.78rem', lineHeight: 1.4, color: '#222' }}>
+    <div style={{ fontSize: '0.78rem', lineHeight: 1.4, color: 'var(--rv-fg)' }}>
       <div
         style={{
           padding: '0.5rem 0.7rem',
           marginBottom: '0.5rem',
-          background: '#fff',
-          border: '1px solid #d8dde3',
+          background: 'var(--rv-surface)',
+          border: '1px solid var(--rv-border)',
           borderRadius: 4,
           fontSize: '0.74rem',
           boxShadow: '0 1px 4px rgba(31, 95, 168, 0.10)',
@@ -145,7 +145,7 @@ export function RowDetail(props: {
               fontSize: '0.7rem',
               textTransform: 'uppercase',
               letterSpacing: '0.04em',
-              color: '#5a6a7f',
+              color: 'var(--rv-muted)',
               marginBottom: '0.2rem',
             }}
           >
@@ -163,17 +163,17 @@ export function RowDetail(props: {
                     gap: '0.35rem',
                     padding: '0.15rem 0.4rem',
                     borderRadius: 3,
-                    background: positive ? '#fff3a3' : '#f4f4f6',
-                    border: positive ? '1px solid #d6b500' : '1px solid #e2e2e2',
+                    background: positive ? '#fff3a3' : 'var(--rv-surface-2)',
+                    border: positive ? '1px solid #d6b500' : '1px solid var(--rv-border)',
                     fontSize: '0.72rem',
-                    color: '#222',
+                    color: positive ? '#222' : 'var(--rv-fg)',
                     fontWeight: positive ? 600 : 400,
                   }}
                 >
                   <code
                     style={{
                       fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
-                      color: positive ? '#7a5a00' : '#4477AA',
+                      color: positive ? '#7a5a00' : 'var(--rv-accent)',
                     }}
                   >
                     {String(d.diagnosis_code ?? '')}
@@ -188,17 +188,19 @@ export function RowDetail(props: {
         </div>
       )}
 
-      {reportQ.isLoading && <div style={{ color: '#888' }}>Loading report…</div>}
+      {reportQ.isLoading && <div style={{ color: 'var(--rv-muted)' }}>Loading report…</div>}
       {reportQ.error && (
-        <div style={{ color: '#b00' }}>{friendlyError(reportQ.error, 'this report')}</div>
+        <div style={{ color: 'var(--rv-danger)' }}>
+          {friendlyError(reportQ.error, 'this report')}
+        </div>
       )}
       {reportQ.data && (
         <div
           style={{
             whiteSpace: 'pre-wrap',
-            color: '#333',
-            background: '#fff',
-            border: '1px solid #e2e2e2',
+            color: 'var(--rv-fg)',
+            background: 'var(--rv-surface)',
+            border: '1px solid var(--rv-border)',
             borderRadius: 3,
             padding: '0.4rem 0.6rem',
             fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
@@ -210,7 +212,7 @@ export function RowDetail(props: {
               (reportQ.data.report_section_impression as string | null) ??
               (reportQ.data.report_section_findings as string | null) ??
               '',
-          ) || <em style={{ color: '#888' }}>(empty)</em>}
+          ) || <em style={{ color: 'var(--rv-muted)' }}>(empty)</em>}
         </div>
       )}
 
@@ -233,7 +235,7 @@ export function RowDetail(props: {
               style={{
                 flex: 1,
                 minWidth: 0,
-                color: '#888',
+                color: 'var(--rv-muted)',
                 fontSize: '0.7rem',
                 display: 'flex',
                 alignItems: 'baseline',
@@ -291,10 +293,10 @@ function CardField(props: { label: string; value: string; mono?: boolean }) {
         alignItems: 'baseline',
       }}
     >
-      <span style={{ color: '#888', fontWeight: 600 }}>{props.label}</span>
+      <span style={{ color: 'var(--rv-muted)', fontWeight: 600 }}>{props.label}</span>
       <span
         style={{
-          color: '#222',
+          color: 'var(--rv-fg)',
           fontFamily: props.mono ? 'ui-monospace, SFMono-Regular, Menlo, monospace' : 'inherit',
           wordBreak: 'break-word',
         }}

--- a/report-viewer/frontend/src/pages/searchDetail/styles.ts
+++ b/report-viewer/frontend/src/pages/searchDetail/styles.ts
@@ -1,13 +1,14 @@
 import type { CSSProperties } from 'react';
 
-export const ROW_ACTIVE_BG = '#e8f0fa';
-export const DETAIL_ZONE_BG = '#f0f6fc';
+export const ROW_ACTIVE_BG = 'var(--rv-accent-soft)';
+export const DETAIL_ZONE_BG = 'var(--rv-bg)';
 
 export const paginationBtn: CSSProperties = {
   fontSize: '0.72rem',
   padding: '0.2rem 0.45rem',
-  border: '1px solid #aaa',
-  background: '#fff',
+  border: '1px solid var(--rv-border)',
+  background: 'var(--rv-surface)',
+  color: 'var(--rv-fg)',
   borderRadius: 3,
   cursor: 'pointer',
   whiteSpace: 'nowrap',

--- a/report-viewer/frontend/src/theme.css
+++ b/report-viewer/frontend/src/theme.css
@@ -1,0 +1,44 @@
+/* Dark mode follows the browser; no in-app toggle. */
+:root {
+  color-scheme: light dark;
+  --rv-bg: #fafafa;
+  --rv-surface: #fff;
+  --rv-surface-2: #f5f5f5;
+  --rv-accent-soft: #e8f0fa;
+  --rv-fg: #222;
+  --rv-muted: #666;
+  --rv-border: #e2e2e2;
+  --rv-accent: #4477aa;
+  --rv-danger: #b00;
+  --rv-success: #1a7a3a;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --rv-bg: #1a1a1a;
+    --rv-surface: #242424;
+    --rv-surface-2: #2e2e2e;
+    --rv-accent-soft: #2f3b4a;
+    --rv-fg: #e6e6e6;
+    --rv-muted: #9a9a9a;
+    --rv-border: #3a3a3a;
+    --rv-accent: #5b9bd5;
+    --rv-danger: #ff6b6b;
+    --rv-success: #3fbf6a;
+  }
+}
+
+@keyframes scoutSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.scout-col-resize {
+  border-right: 1px solid var(--rv-border);
+}
+.scout-col-resize:hover {
+  border-right-color: var(--rv-muted);
+}
+tr.scout-row:hover {
+  background: var(--rv-surface-2) !important;
+}

--- a/report-viewer/src/scout_report_viewer/routes/searches.py
+++ b/report-viewer/src/scout_report_viewer/routes/searches.py
@@ -612,6 +612,34 @@ def _filter_clause(col: str, values: list[str], *, alias: str = "") -> tuple[str
     return f"LOWER({qcol}) LIKE LOWER(?) ESCAPE '!'", [pattern]
 
 
+def _build_where_and_order(
+    filters: list[tuple[str, list[str]]],
+    sort_spec: tuple[str, str] | None,
+    *,
+    alias: str = "s",
+) -> tuple[str, str, list]:
+    """Shared WHERE + ORDER BY builder for the /rows and /csv views so both
+    apply identical filter and sort semantics. Returns (where_sql, order_sql,
+    filter_params). ORDER BY always tie-breaks on primary_report_identifier so
+    the order is stable."""
+    where_parts: list[str] = []
+    filter_params: list = []
+    for fcol, fvals in filters:
+        clause, p = _filter_clause(fcol, fvals, alias=alias)
+        where_parts.append(clause)
+        filter_params.extend(p)
+    where_sql = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
+    tiebreak = f"{alias}.primary_report_identifier"
+    if sort_spec:
+        scol, sdir = sort_spec
+        order_sql = (
+            f" ORDER BY {alias}.{_quote_ident(scol)} {sdir} NULLS LAST, {tiebreak}"
+        )
+    else:
+        order_sql = f" ORDER BY {tiebreak}"
+    return where_sql, order_sql, filter_params
+
+
 def _rows_query_error(exc: Exception, stage: str) -> HTTPException:
     """400 when the sort/filter column isn't in this search's projection; 502 otherwise."""
     if getattr(exc, "error_name", None) == "COLUMN_NOT_FOUND":
@@ -655,20 +683,7 @@ async def get_search_rows(
     offset = (page - 1) * limit
     sort_spec = _parse_sort(sort)
     filters = _parse_filters(request)
-
-    where_parts: list[str] = []
-    filter_params: list = []
-    for fcol, fvals in filters:
-        clause, p = _filter_clause(fcol, fvals, alias="s")
-        where_parts.append(clause)
-        filter_params.extend(p)
-    where_sql = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
-    if sort_spec:
-        scol, sdir = sort_spec
-        order_sql = f" ORDER BY s.{_quote_ident(scol)} {sdir} NULLS LAST, s.primary_report_identifier"
-    else:
-        # Stable default so OFFSET/LIMIT doesn't drift across pages.
-        order_sql = " ORDER BY s.primary_report_identifier"
+    where_sql, order_sql, filter_params = _build_where_and_order(filters, sort_spec)
 
     rows_sql = (
         f"SELECT s.* FROM ({source_sql}) s"
@@ -773,24 +788,58 @@ def _csv_quote(value: Any) -> str:
     return s
 
 
+def _parse_export_columns(columns: str | None) -> str:
+    """Build the SELECT projection for the CSV export from a comma-separated
+    `columns` list. Each field is validated/quoted via _quote_ident (SQL-injection
+    safe). primary_report_identifier is always included so exported rows stay
+    uniquely identifiable, even if the user hid it. Empty/absent -> `s.*`."""
+    if not columns:
+        return "s.*"
+    fields: list[str] = []
+    seen: set[str] = set()
+    for raw in columns.split(","):
+        name = raw.strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        fields.append(name)
+    if "primary_report_identifier" not in seen:
+        fields.append("primary_report_identifier")
+    return ", ".join(f"s.{_quote_ident(f)}" for f in fields)
+
+
 @router.get("/{search_id}/csv")
 async def export_search_csv(
     search_id: str,
+    request: Request,
+    sort: str | None = Query(default=None, description="col:dir, e.g. message_dt:desc"),
+    columns: str | None = Query(
+        default=None, description="comma-separated fields to export; empty = all"
+    ),
     user: User = Depends(get_current_user),
     store: SearchStore = Depends(get_store),
 ) -> StreamingResponse:
+    """Streaming CSV of a search. Mirrors the /rows view: the same whitelisted
+    filters and sort are applied, and `columns` restricts the projection to the
+    user's visible columns (plus primary_report_identifier)."""
     ds = await store.get_search(search_id, owner_sub=user.sub)
     if ds is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     sql = ds["sql"]
     uploaded_ids = ds.get("uploaded_ids")
+    base_params: list = [uploaded_ids] if uploaded_ids else []
+
+    # Validate up front: a bad sort/filter/column 400s before streaming starts
+    # (a StreamingResponse can't change status mid-stream). An unprojected but
+    # otherwise-valid column still slips through to a mid-stream error.
+    sort_spec = _parse_sort(sort)
+    filters = _parse_filters(request)
+    projection = _parse_export_columns(columns)
+    where_sql, order_sql, filter_params = _build_where_and_order(filters, sort_spec)
 
     async def gen():
-        params = [uploaded_ids] if uploaded_ids else None
-        export_sql = (
-            f"SELECT s.* FROM ({sql}) s "
-            f"ORDER BY s.{_quote_ident('primary_report_identifier')}"
-        )
+        params = (base_params + filter_params) or None
+        export_sql = f"SELECT {projection} FROM ({sql}) s{where_sql}{order_sql}"
         header_written = False
         try:
             with metrics.time_trino("export_csv_query"):

--- a/report-viewer/tests/conftest.py
+++ b/report-viewer/tests/conftest.py
@@ -62,14 +62,19 @@ def fake_trino(monkeypatch) -> Callable[[list[str], list[dict[str, Any]]], None]
     Tests can queue multiple responses so a flow like
     `create_search` -> `get_rows` -> `get_csv` primes a distinct payload
     for each Trino round-trip.
+
+    Every (sql, params) round-trip is recorded on `enqueue.calls` so tests
+    can assert on the SQL/params the service generated.
     """
     queue: list[tuple[list[str], list[dict[str, Any]]]] = []
+    calls: list[tuple[str, list | tuple | None]] = []
 
     async def fake_execute(
         sql: str,
         user: str | None = None,
         params: list | tuple | None = None,
     ):
+        calls.append((sql, params))
         if not queue:
             raise AssertionError(
                 f"fake_trino had no queued response for SQL: {sql[:120]}..."
@@ -82,6 +87,7 @@ def fake_trino(monkeypatch) -> Callable[[list[str], list[dict[str, Any]]], None]
         params: list | tuple | None = None,
         chunk_size: int = 1000,
     ):
+        calls.append((sql, params))
         if not queue:
             raise AssertionError(
                 f"fake_trino had no queued response for SQL: {sql[:120]}..."
@@ -97,6 +103,7 @@ def fake_trino(monkeypatch) -> Callable[[list[str], list[dict[str, Any]]], None]
     def enqueue(columns: list[str], rows: list[dict[str, Any]]) -> None:
         queue.append((columns, rows))
 
+    enqueue.calls = calls
     return enqueue
 
 

--- a/report-viewer/tests/test_viewer.py
+++ b/report-viewer/tests/test_viewer.py
@@ -76,3 +76,77 @@ def test_export_csv_empty_search_returns_header_only(client, auth_headers, fake_
     assert r.status_code == 200
     lines = r.text.strip().splitlines()
     assert lines == ["primary_report_identifier,accession_number"]
+
+
+def _make_search(client, auth_headers, fake_trino) -> str:
+    fake_trino(_SAMPLE_COLS, _sample_rows(2))
+    fake_trino(["n"], [{"n": 2}])
+    return client.post(
+        "/api/searches",
+        json={"sql": _SQL},
+        headers=auth_headers,
+    ).json()["id"]
+
+
+def test_export_csv_restricts_to_selected_columns_plus_id(
+    client, auth_headers, fake_trino
+):
+    dsid = _make_search(client, auth_headers, fake_trino)
+    fake_trino(_SAMPLE_COLS, _sample_rows(1))
+    r = client.get(
+        f"/api/searches/{dsid}/csv?columns=epic_mrn,accession_number",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    export_sql = fake_trino.calls[-1][0]
+    assert 's."epic_mrn"' in export_sql
+    assert 's."accession_number"' in export_sql
+    # ID is appended even though the client omitted it.
+    assert 's."primary_report_identifier"' in export_sql
+    assert "s.*" not in export_sql
+
+
+def test_export_csv_applies_filters(client, auth_headers, fake_trino):
+    dsid = _make_search(client, auth_headers, fake_trino)
+    fake_trino(_SAMPLE_COLS, _sample_rows(1))
+    r = client.get(
+        f"/api/searches/{dsid}/csv?filter.modality=CT",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    export_sql, params = fake_trino.calls[-1]
+    assert 's."modality" IN (?)' in export_sql
+    assert params == ["CT"]
+
+
+def test_export_csv_applies_sort(client, auth_headers, fake_trino):
+    dsid = _make_search(client, auth_headers, fake_trino)
+    fake_trino(_SAMPLE_COLS, _sample_rows(1))
+    r = client.get(
+        f"/api/searches/{dsid}/csv?sort=message_dt:desc",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    export_sql = fake_trino.calls[-1][0]
+    assert 'ORDER BY s."message_dt" DESC NULLS LAST' in export_sql
+
+
+def test_export_csv_does_not_duplicate_id_column(client, auth_headers, fake_trino):
+    dsid = _make_search(client, auth_headers, fake_trino)
+    fake_trino(_SAMPLE_COLS, _sample_rows(1))
+    r = client.get(
+        f"/api/searches/{dsid}/csv?columns=primary_report_identifier,accession_number",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    export_sql = fake_trino.calls[-1][0]
+    assert export_sql.count('s."primary_report_identifier"') == 1
+
+
+def test_export_csv_unsafe_column_is_400(client, auth_headers, fake_trino):
+    dsid = _make_search(client, auth_headers, fake_trino)
+    r = client.get(
+        f"/api/searches/{dsid}/csv?columns=bad;col",
+        headers=auth_headers,
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
## Description

### Product
Dark mode (#542): the viewer now follows the browser's light/dark theme automatically.

CSV export (#535): Download CSV now matches what you see, the filtered rows, chosen columns, and sort order, instead of dumping the whole search. The `primary_report_identifier` is always included so rows stay linked back to the Scout data lake.

### Technical
Dark mode: colors moved into CSS variables in a new `theme.css` (light `:root` defaults plus a `@media (prefers-color-scheme: dark)` block); the inline styles reference the vars. No new deps.

CSV: the `/csv` endpoint now takes the same sort/filter params as `/rows` plus a `columns` list. A shared `_build_where_and_order` (backend) and `buildViewQuery` (frontend) keep the two endpoints from drifting, and `primary_report_identifier` is always included.

Closes #542, #535

## Type of change
- [ ] Work behind a feature flag
- [x] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
No change to the trust model. Export runs as the user through the existing path, same as the rest of the viewer.

##### Appsec
Export columns and sort are validated for identifier charset and quoted via `_quote_ident`; filter values are bound as params. No user values interpolated into SQL.

### Performance
Same query path and streaming response as before, just with the filter/sort/projection applied. No new scale concerns.

### Data
CSV always includes `primary_report_identifier` so rows stay linked back to the Scout data lake. 

### Backward compatibility
`/csv` gains optional query params. No data model or dependency changes.

## Testing
Tested on the dev cluster. Toggled between dark and light mode in Chrome and the viewer theme switched automatically to match. Sorted and filtered the table, then downloaded the CSV and it matched what the user sees, the same rows and columns, plus `primary_report_identifier.`

## Note for reviewers
Screenshots with fake data attached.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [x] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate

<img width="1003" height="1127" alt="RV-LightMode" src="https://github.com/user-attachments/assets/1549524f-42a5-45fe-8749-1657cc4e620e" />

<img width="995" height="1127" alt="RV-DarkMode" src="https://github.com/user-attachments/assets/b126868e-ce71-4ef7-a03f-7a4eba4df438" />

<img width="932" height="867" alt="RV-CSV-Download1" src="https://github.com/user-attachments/assets/fae56fe5-76dc-4c5b-af41-1cd88bbdd1af" />

<img width="784" height="805" alt="RV-CSV-Download2" src="https://github.com/user-attachments/assets/bbf5c55f-6a99-44e7-8b10-b20ce4c4c138" />

