### PR TITLE
feat(gitops): publish + OCI-deploy hl7log-extractor (phase 0 follow-up)

### DIFF
--- a/.github/ci_resources/inventory.yaml
+++ b/.github/ci_resources/inventory.yaml
@@ -115,9 +115,10 @@ k3s_cluster:
     base_dir: K3S_DATA_DIR/storage
     scout_repo_dir: WORK_DIR
     extractor_data_dir: '{{ scout_repo_dir }}/tests/ingest/staging_test_data'
-    # Deploy the in-repo hl7-transformer chart (unpublished on PRs); production
-    # pulls the OCI chart pinned to hl7_transformer_chart_version.
+    # Deploy the in-repo extractor charts (unpublished on PRs); production pulls
+    # the OCI charts pinned to the matching *_chart_version.
     hl7_transformer_chart_path: '{{ scout_repo_dir }}/helm/extractor/hl7-transformer'
+    hl7log_extractor_chart_path: '{{ scout_repo_dir }}/helm/extractor/hl7log-extractor'
 
     # Object storage paths
     lake_bucket: ci-lake

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
       report-viewer: ${{ steps.filter.outputs.report-viewer }}
       xnat-plugin-installer: ${{ steps.filter.outputs.xnat-plugin-installer }}
       hl7-transformer-chart: ${{ steps.filter.outputs.hl7-transformer-chart }}
+      hl7log-extractor-chart: ${{ steps.filter.outputs.hl7log-extractor-chart }}
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -72,6 +73,8 @@ jobs:
               - 'docker/xnat-plugin-installer/**'
             hl7-transformer-chart:
               - 'helm/extractor/hl7-transformer/**'
+            hl7log-extractor-chart:
+              - 'helm/extractor/hl7log-extractor/**'
       - name: 'Mint build version'
         id: version
         shell: bash
@@ -870,6 +873,9 @@ jobs:
           - chart-name: hl7-transformer
             chart-dir: helm/extractor/hl7-transformer
             changed: hl7-transformer-chart
+          - chart-name: hl7log-extractor
+            chart-dir: helm/extractor/hl7log-extractor
+            changed: hl7log-extractor-chart
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: 'Publish chart - ${{ matrix.chart-name }}'

--- a/ansible/group_vars/all/versions.yaml
+++ b/ansible/group_vars/all/versions.yaml
@@ -188,3 +188,9 @@ data_generator_chart_version: 1.0.0
 # bumped by hand when the extractor is repointed to the OCI chart; the GitOps lane
 # owns the real version via its OCIRepository (ADR 0031).
 hl7_transformer_chart_version: 0.0.0
+# hl7log-extractor Helm chart, built and published to GHCR by this repo's own CI
+# (ADR 0030 phase 0). Not Renovate-tracked (self-built, like hl7-transformer
+# above). On-prem Ansible pin only, bumped by hand when the extractor is
+# repointed to the OCI chart; the GitOps lane owns the real version via its
+# OCIRepository (ADR 0031).
+hl7log_extractor_chart_version: 0.0.0

--- a/ansible/roles/extractor/defaults/main.yaml
+++ b/ansible/roles/extractor/defaults/main.yaml
@@ -1,11 +1,12 @@
 ---
 # Default values for Extractor deployment
 
-# hl7-transformer Helm chart, published to GHCR by CI (ADR 0030/0031 phase 0).
-# Pulled by helm from the OCI ref pinned to hl7_transformer_chart_version
-# (group_vars/all/versions.yaml). Dev/CI override: set hl7_transformer_chart_path
+# Extractor Helm charts, published to GHCR by this repo's CI (ADR 0030/0031 phase 0).
+# Pulled by helm from the OCI ref pinned to the matching *_chart_version
+# (group_vars/all/versions.yaml). Dev/CI override: set the matching *_chart_path
 # to a local chart dir, in which case no --version is passed.
 hl7_transformer_chart_oci_ref: oci://ghcr.io/washu-tag/charts/hl7-transformer
+hl7log_extractor_chart_oci_ref: oci://ghcr.io/washu-tag/charts/hl7log-extractor
 
 hl7log_extractor_timezone: '{{ timezone }}'
 

--- a/ansible/roles/extractor/tasks/deploy.yaml
+++ b/ansible/roles/extractor/tasks/deploy.yaml
@@ -102,7 +102,11 @@
     tasks_from: deploy_helm_chart
   vars:
     helm_chart_name: hl7log-extractor
-    helm_chart_ref: '{{ scout_repo_dir }}/helm/extractor/hl7log-extractor'
+    # Pull the published OCI chart from GHCR (ADR 0030/0031). Dev/CI override:
+    # hl7log_extractor_chart_path points helm at a local chart dir, in which case
+    # no --version is passed (helm rejects --version with a local path).
+    helm_chart_ref: '{{ hl7log_extractor_chart_path | default(hl7log_extractor_chart_oci_ref) }}'
+    helm_chart_version: '{{ hl7log_extractor_chart_version if hl7log_extractor_chart_path is not defined else omit }}'
     helm_chart_namespace: '{{ extractor_namespace }}'
     helm_chart_create_namespace: false
     helm_chart_values: "{{ lookup('template', 'hl7log-extractor.values.yaml.j2') | from_yaml }}"


### PR DESCRIPTION
Follow-up to #541. Extends the phase-0 chart pattern to the sibling hl7log-extractor chart so the extractor role deploys both charts the same way.

- publish-charts: add hl7log-extractor to the matrix and its changed-path filter.
- extractor role: deploy hl7log-extractor from oci://ghcr.io/washu-tag/charts/hl7log-extractor with a hl7log_extractor_chart_path local override (CI inventory points at the in-repo chart). Plain on-prem pin, not Renovate-tracked (self-built, matching the hl7-transformer pin).

hl7log-extractor has no spark-defaults, so this is a deploy-pattern change only.

## Description
### Technical
Follow-up to #541. Extends the phase-0 chart pattern to the sibling hl7log-extractor
chart so the extractor role deploys both charts the same way.
- publish-charts: adds hl7log-extractor to the matrix + a changed-path filter.
- extractor role: deploys hl7log-extractor from oci://ghcr.io/washu-tag/charts/hl7log-extractor
  with a hl7log_extractor_chart_path local override (CI uses the in-repo chart). Plain
  on-prem pin, not Renovate-tracked (self-built, matching hl7-transformer).

## Type of change
- [x] Improvement

## Testing
helm lint + package clean; ci.yaml actionlint clean; deploy-and-test exercises the chart.

## Note for reviewers
hl7log-extractor has no spark-defaults, so this is a deploy-pattern change only.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas