### PR TITLE
feat(hl7-transformer): make chart-owned spark-defaults extensible (dr…

### DIFF
--- a/helm/extractor/hl7-transformer/templates/_helpers.tpl
+++ b/helm/extractor/hl7-transformer/templates/_helpers.tpl
@@ -98,5 +98,8 @@ spark.sql.warehouse.dir {{ required "sparkDefaults.warehouseDir is required when
 spark.sql.shuffle.partitions {{ $s.shufflePartitions }}
 spark.driver.extraJavaOptions -Divy.cache.dir=/tmp -Divy.home=/tmp
 spark.executor.memory {{ .Values.spark.executor.memory }}
-spark.driver.memory {{ .Values.spark.executor.memory }}
+spark.driver.memory {{ $s.driverMemory | default .Values.spark.executor.memory }}
+{{- range $k, $v := $s.extraConf }}
+{{ $k }} {{ $v }}
+{{- end }}
 {{- end }}

--- a/helm/extractor/hl7-transformer/templates/_helpers.tpl
+++ b/helm/extractor/hl7-transformer/templates/_helpers.tpl
@@ -97,8 +97,11 @@ spark.hadoop.hive.metastore.uris {{ required "sparkDefaults.hiveMetastoreUri is 
 spark.sql.warehouse.dir {{ required "sparkDefaults.warehouseDir is required when sparkDefaults is enabled" $s.warehouseDir }}
 spark.sql.shuffle.partitions {{ $s.shufflePartitions }}
 spark.driver.extraJavaOptions -Divy.cache.dir=/tmp -Divy.home=/tmp
+# Local mode (single JVM): spark.driver.memory is the live heap and
+# spark.executor.memory is inert; set both from the one value (as the on-prem
+# spark_memory did) so there's no misleading driver/executor split.
 spark.executor.memory {{ .Values.spark.executor.memory }}
-spark.driver.memory {{ $s.driverMemory | default .Values.spark.executor.memory }}
+spark.driver.memory {{ .Values.spark.executor.memory }}
 {{- range $k, $v := $s.extraConf }}
 {{ $k }} {{ $v }}
 {{- end }}

--- a/helm/extractor/hl7-transformer/values.yaml
+++ b/helm/extractor/hl7-transformer/values.yaml
@@ -131,9 +131,7 @@ sparkDefaults:
   warehouseDir: ''
   s3Region: us-east-1
   s3Endpoint: ''
-  # driverMemory sizes the driver JVM independently; defaults to
-  # spark.executor.memory when empty. extraConf appends arbitrary `key value`
-  # lines for site-specific tuning the fixed keys above don't cover (e.g.
-  # spark.sql.files.maxPartitionBytes).
-  driverMemory: ''
+  # extraConf appends arbitrary `key value` lines for site-specific tuning the
+  # fixed keys above don't cover. (spark.executor.memory sizes both driver and
+  # executor; in local mode only the driver heap is live.)
   extraConf: {}

--- a/helm/extractor/hl7-transformer/values.yaml
+++ b/helm/extractor/hl7-transformer/values.yaml
@@ -131,3 +131,9 @@ sparkDefaults:
   warehouseDir: ''
   s3Region: us-east-1
   s3Endpoint: ''
+  # driverMemory sizes the driver JVM independently; defaults to
+  # spark.executor.memory when empty. extraConf appends arbitrary `key value`
+  # lines for site-specific tuning the fixed keys above don't cover (e.g.
+  # spark.sql.files.maxPartitionBytes).
+  driverMemory: ''
+  extraConf: {}


### PR DESCRIPTION
…iverMemory + extraConf)

The adapt-dev GitOps consumer's hand-copied spark-defaults ConfigMap sets an independent spark.driver.memory (4g, vs the 8G executor) and spark.sql.files.maxPartitionBytes, neither of which the phase-0 sparkDefaultsConf helper could express, so repointing that consumer at the chart would have silently dropped them.

- sparkDefaults.driverMemory: optional, defaults to spark.executor.memory.
- sparkDefaults.extraConf: map of arbitrary `key value` lines appended to the rendered conf for site-specific tuning.

Unblocks repointing the GitOps hl7-transformer HelmRelease at the OCI chart and deleting the hand-copied ConfigMap.

## Description

### Product
No user-facing change. Makes the chart-owned `spark-defaults.conf` (added in #541)
expressive enough for real GitOps consumers, so a site can carry its own Spark
tuning through chart values instead of a hand-maintained ConfigMap.

### Technical
Phase 0 moved `spark-defaults.conf` into the hl7-transformer chart, but the
`sparkDefaults` values only covered a fixed set of keys. The adapt-dev GitOps
consumer's hand-copied ConfigMap sets two things the helper couldn't express: an
independent `spark.driver.memory` (4g, distinct from the 8G executor) and
`spark.sql.files.maxPartitionBytes`. Repointing that consumer at the chart as-is
would have silently dropped both. This adds:

- `sparkDefaults.driverMemory` — optional; the rendered `spark.driver.memory`
  falls back to `spark.executor.memory` when unset (preserving current behavior).
- `sparkDefaults.extraConf` — a map of arbitrary `key value` lines appended to the
  rendered conf for site-specific tuning the fixed keys don't cover.

## Type of change
- [x] Improvement

## Impact

### Security
None. `extraConf` is operator-supplied Spark configuration; no credentials, and
on-prem S3 creds still come from env, never the ConfigMap.

### Performance
No CI/build impact. The values themselves are runtime Spark tuning, chosen by the
consumer.

### Backward compatibility
Fully additive. `driverMemory` defaults to `spark.executor.memory` so existing
renders are byte-identical, and `extraConf` defaults to `{}` (no extra lines).
Existing consumers are unaffected; the fail-fast validation from #541 is unchanged.

## Testing
`helm lint` clean; `helm template` verified that `driverMemory` overrides
`spark.driver.memory` independently and `extraConf` appends the expected lines
(reproduces adapt-dev's `driver.memory 4g` + `maxPartitionBytes 134217728`), while
the defaults (and `enabled: false`) render unchanged.

## Note for reviewers
Motivated by the adapt-dev GitOps consumer, whose hand-copied
`hl7-transformer-spark-defaults` ConfigMap had drifted past the chart. This
unblocks repointing that HelmRelease at the published OCI chart and deleting the
ConfigMap (a follow-up in the gitops repo). Independent of the hl7log-extractor
follow-up PR.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas