### PR TITLE
feat(gitops): fan out chart publishing to all Scout charts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,17 @@ jobs:
       report-viewer: ${{ steps.filter.outputs.report-viewer }}
       xnat-plugin-installer: ${{ steps.filter.outputs.xnat-plugin-installer }}
       hl7-transformer-chart: ${{ steps.filter.outputs.hl7-transformer-chart }}
+      dcm4chee-chart: ${{ steps.filter.outputs.dcm4chee-chart }}
+      hive-metastore-chart: ${{ steps.filter.outputs.hive-metastore-chart }}
+      hl7-listener-chart: ${{ steps.filter.outputs.hl7-listener-chart }}
+      keycloak-config-cli-chart: ${{ steps.filter.outputs.keycloak-config-cli-chart }}
+      launchpad-chart: ${{ steps.filter.outputs.launchpad-chart }}
+      open-webui-bootstrap-chart: ${{ steps.filter.outputs.open-webui-bootstrap-chart }}
+      orthanc-chart: ${{ steps.filter.outputs.orthanc-chart }}
+      report-viewer-chart: ${{ steps.filter.outputs.report-viewer-chart }}
+      scout-dashboards-chart: ${{ steps.filter.outputs.scout-dashboards-chart }}
+      scout-opa-chart: ${{ steps.filter.outputs.scout-opa-chart }}
+      voila-chart: ${{ steps.filter.outputs.voila-chart }}
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -72,6 +83,28 @@ jobs:
               - 'docker/xnat-plugin-installer/**'
             hl7-transformer-chart:
               - 'helm/extractor/hl7-transformer/**'
+            dcm4chee-chart:
+              - 'helm/dcm4chee/**'
+            hive-metastore-chart:
+              - 'helm/hive-metastore/**'
+            hl7-listener-chart:
+              - 'helm/hl7-listener/**'
+            keycloak-config-cli-chart:
+              - 'helm/keycloak-config-cli/**'
+            launchpad-chart:
+              - 'helm/launchpad/**'
+            open-webui-bootstrap-chart:
+              - 'helm/open-webui-bootstrap/**'
+            orthanc-chart:
+              - 'helm/orthanc/**'
+            report-viewer-chart:
+              - 'helm/report-viewer/**'
+            scout-dashboards-chart:
+              - 'helm/scout-dashboards/**'
+            scout-opa-chart:
+              - 'helm/scout-opa/**'
+            voila-chart:
+              - 'helm/voila/**'
       - name: 'Mint build version'
         id: version
         shell: bash
@@ -870,6 +903,39 @@ jobs:
           - chart-name: hl7-transformer
             chart-dir: helm/extractor/hl7-transformer
             changed: hl7-transformer-chart
+          - chart-name: dcm4chee
+            chart-dir: helm/dcm4chee
+            changed: dcm4chee-chart
+          - chart-name: hive-metastore
+            chart-dir: helm/hive-metastore
+            changed: hive-metastore-chart
+          - chart-name: hl7-listener
+            chart-dir: helm/hl7-listener
+            changed: hl7-listener-chart
+          - chart-name: keycloak-config-cli
+            chart-dir: helm/keycloak-config-cli
+            changed: keycloak-config-cli-chart
+          - chart-name: launchpad
+            chart-dir: helm/launchpad
+            changed: launchpad-chart
+          - chart-name: open-webui-bootstrap
+            chart-dir: helm/open-webui-bootstrap
+            changed: open-webui-bootstrap-chart
+          - chart-name: orthanc
+            chart-dir: helm/orthanc
+            changed: orthanc-chart
+          - chart-name: report-viewer
+            chart-dir: helm/report-viewer
+            changed: report-viewer-chart
+          - chart-name: scout-dashboards
+            chart-dir: helm/scout-dashboards
+            changed: scout-dashboards-chart
+          - chart-name: scout-opa
+            chart-dir: helm/scout-opa
+            changed: scout-opa-chart
+          - chart-name: voila
+            chart-dir: helm/voila
+            changed: voila-chart
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: 'Publish chart - ${{ matrix.chart-name }}'


### PR DESCRIPTION
Extends the phase-0 publish-charts job (previously hl7-transformer only) to the remaining Scout charts: dcm4chee, hive-metastore, hl7-listener, keycloak-config-cli, launchpad, open-webui-bootstrap, orthanc, report-viewer, scout-dashboards, scout-opa, voila. Each gets a changed-path filter, a changes output, and a publish-charts matrix entry; changed-charts-only publishing is preserved (chart version lands in helm.sh/chart pod labels, so publishing an unchanged chart would needlessly roll pods).

Publish side only; Ansible consume-side OCI-ref swaps are per-chart follow-ups. hl7log-extractor is added on its own branch. Verified: all charts helm-package cleanly (no chart dependencies); ci.yaml valid + actionlint clean.

## Description

### Product
No user-facing change. Completes phase-0 chart publishing: every Scout chart is
now published as a versioned OCI artifact on merge to main, so GitOps consumers
can pin/pull them instead of sourcing from a git branch.

### Technical
Extends the `publish-charts` job (previously `hl7-transformer` only) to the
remaining charts: dcm4chee, hive-metastore, hl7-listener, keycloak-config-cli,
launchpad, open-webui-bootstrap, orthanc, report-viewer, scout-dashboards,
scout-opa, voila. Each gets a changed-path filter, a `changes` output, and a
matrix entry. Changed-charts-only publishing is preserved (the chart version
lands in the `helm.sh/chart` pod label, so republishing an unchanged chart
would needlessly roll pods).

Publish side only; the Ansible consume-side OCI-ref swaps are per-chart
follow-ups. `hl7log-extractor` is added on its own branch.

## Type of change
- [x] Improvement

## Impact

### Security
No roles/RBAC/data-access changes; reuses the existing `packages: write` on the
publish job.

### Performance
`main`-only, after `deploy-and-test`/`smoke-test`, changed-charts-only, so the
added cost is one lightweight package + push per changed chart.

### Backward compatibility
Additive. Existing `hl7-transformer` publishing is unchanged, and existing
consumers are unaffected until they opt to pull from OCI.

## Testing
All 11 charts `helm package` cleanly (none carry chart dependencies, so no
`helm dependency build` is needed); `ci.yaml` is valid and `actionlint`-clean;
the matrix now covers 12 charts.

## Note for reviewers
Kept the explicit static matrix rather than a dynamic changed-chart discovery
matrix, for predictability and consistency with the just-merged pipeline (dynamic
discovery is a reasonable future cleanup but needs careful CI fetch-depth
handling). This is publish-only, no deployment/consumer changes.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas