### PR TITLE
fix(security): resolve pgjdbc CVE-2026-54291 in scan-images gate

### DIFF
--- a/extractor/hl7log-extractor/build.gradle
+++ b/extractor/hl7log-extractor/build.gradle
@@ -22,10 +22,11 @@ def temporalVersion = "1.34.0"
 def s3Version = "2.20.0"
 def checkstyleVersion = "13.4.2"
 
-// TODO: Remove once Spring Boot ships a release that manages postgresql >= 42.7.11.
-// Overrides the Spring Boot BOM's pinned 42.7.10 to address GHSA-98qh-xjc8-98pq
-// (CVE-2026-42198, HIGH: pgjdbc SCRAM PBKDF2 DoS).
-ext['postgresql.version'] = '42.7.11'
+// TODO: Remove once Spring Boot ships a release that manages postgresql >= 42.7.13.
+// Overrides the Spring Boot BOM's pinned 42.7.10 to stay ahead of a run of pgjdbc
+// SCRAM CVEs: CVE-2026-42198 (HIGH, SCRAM PBKDF2 DoS, fixed 42.7.11) and
+// CVE-2026-54291 (HIGH, SCRAM channel-binding downgrade, fixed 42.7.12).
+ext['postgresql.version'] = '42.7.13'
 
 // TODO: Remove once Spring Boot manages netty >= 4.2.15.Final.
 // Overrides the Spring Boot BOM's pinned 4.2.12.Final to address

--- a/keycloak/.trivyignore.yaml
+++ b/keycloak/.trivyignore.yaml
@@ -11,3 +11,9 @@ vulnerabilities:
   # jackson-databind bundled by Keycloak
   - id: CVE-2026-54512 # jackson-databind
   - id: CVE-2026-54513 # jackson-databind
+  # postgresql JDBC driver bundled by Keycloak (the driver Scout actually uses).
+  # CVE-2026-54291 is a SCRAM channel-binding downgrade that only bites when the
+  # client sets channelBinding=require over a MITM'd TLS link; Scout's Keycloak DB
+  # connection doesn't. Fixed in pgjdbc 42.7.12, which Keycloak 26.6.4 doesn't
+  # bundle yet; drop this once a newer Keycloak base ships the fixed driver.
+  - id: CVE-2026-54291 # org.postgresql:postgresql 42.7.11


### PR DESCRIPTION
The scan-images gate started failing for the keycloak and hl7log-extractor images on a fresh rebuild: pgjdbc 42.7.11 trips CVE-2026-54291 (HIGH, SCRAM channel-binding downgrade), fixable in 42.7.12.

- hl7log-extractor: bump the Spring Boot BOM postgresql override 42.7.11 -> 42.7.13 (latest 42.7.x), which carries the fix. We own this pin, so it's a real bump.
- keycloak: the driver is bundled by the upstream quay.io/keycloak/keycloak:26.6.4 base (opt/keycloak/lib/lib/main), nothing in our layer to bump and no fixed Keycloak release to adopt yet, so suppress it in .trivyignore.yaml with the same documented-and-revisit pattern the file already uses. The vuln only bites with channelBinding=require over a MITM'd TLS link, which Scout's DB connection doesn't set.

## Description

### Technical
The `scan-images` gate began failing for the `keycloak` and `hl7log-extractor`
images on a fresh rebuild. pgjdbc 42.7.11 trips CVE-2026-54291 (HIGH, a SCRAM
channel-binding downgrade fixed in pgjdbc 42.7.12), which is the only new fixable
HIGH/CRITICAL CVE in either image.

- **hl7log-extractor**: bump the Spring Boot BOM `postgresql.version` override from
  42.7.11 to 42.7.13 (latest 42.7.x). We own this pin, so it's a genuine dependency
  bump, and being on the latest patch avoids re-tripping the gate on a subsequent
  pgjdbc CVE.
- **keycloak**: the driver is bundled by the upstream `quay.io/keycloak/keycloak:26.6.4`
  base (`opt/keycloak/lib/lib/main`), not our event-listener layer, and there is no
  fixed Keycloak release to adopt yet. Suppress it in `keycloak/.trivyignore.yaml`
  using the same documented-and-revisit pattern the file already uses for the other
  upstream-bundled jars.

## Type of change
- [x] Bug fix

## Impact

### Security
CVE-2026-54291 only bites when a client sets `channelBinding=require` over a
TLS connection an attacker can MITM. Scout's Keycloak DB connection does not set
`channelBinding=require`, so the practical exposure is low; the hl7log-extractor
bump removes the vulnerable jar outright, and the keycloak suppression is scoped
to a single CVE ID with the rationale inline.

### Backward compatibility
pgjdbc 42.7.13 is a drop-in patch release over 42.7.11 (same 42.7.x line, JDBC
driver only). No API or data-model changes.

## Testing
Scanned the published `ghcr.io/washu-tag/keycloak:26.6.4` image with Trivy plus the
updated ignore file and confirmed 0 fixable HIGH/CRITICAL findings remain. The
hl7log-extractor bump is validated by this PR's own `build-and-upload` +
`scan-images` run against the freshly built image.

## Note for reviewers
The keycloak entry is a suppression rather than a bump on purpose: the driver ships
in the upstream base image, so there's nothing in our layer to fix until a newer
Keycloak base bundles pgjdbc >= 42.7.12. Drop the ignore entry when that happens.
Merge order: this should land before #550 and #553 are rebased, so their scans pass.