### PR TITLE
fix(staging): download k3s install script via curl, not get_url

### DIFF
--- a/ansible/playbooks/staging.yaml
+++ b/ansible/playbooks/staging.yaml
@@ -31,10 +31,17 @@
         state: directory
         mode: '0700'
 
+    # get_url/uri use Python's ssl (_ssl.c), which on EL9 openssl-libs 3.5.5-5.el9_8
+    # (RHEL-178642 asn1_d2i_read_bio change) fails with "[ASN1: NOT_ENOUGH_DATA]".
+    # curl uses libcurl and is unaffected. See rpm-software-management/librepo#380.
     - name: Download K3s installation script
-      ansible.builtin.get_url:
-        url: https://get.k3s.io
-        dest: /root/bin/get.k3s.io.sh
+      ansible.builtin.command:
+        cmd: curl -fsSL --retry 3 --connect-timeout 30 --max-time 120 -o /root/bin/get.k3s.io.sh https://get.k3s.io
+      changed_when: true
+
+    - name: Ensure K3s installation script is executable
+      ansible.builtin.file:
+        path: /root/bin/get.k3s.io.sh
         mode: '0755'
 
     - name: Install python kubernetes library


### PR DESCRIPTION
## Description

### Product
No user-facing change. Unblocks air-gapped deployments whose staging node runs a patched EL9 (RHEL / CentOS Stream 9) host, where the k3s bootstrap step was failing.

### Technical
`staging.yaml` fetched the k3s install script with `get_url`. On EL9 hosts running `openssl-libs-3.5.5-5.el9_8`, the `asn1_d2i_read_bio` change (RHEL-178642, a backport of OpenSSL 3.5.7 behavior) regressed the ASN.1 BIO-read path that Python's `ssl` module — and therefore Ansible's `get_url`/`uri` — relies on. The task fails immediately with:

```
Connection failure: [ASN1: NOT_ENOUGH_DATA] not enough data (_ssl.c:4192)
```

`curl`, `openssl s_client`, and the `dnf` CLI are unaffected (different code path). This swaps that one on-node `get_url` to `curl` (`-fsSL`, TLS verification preserved, `--connect-timeout`/`--max-time` bounds, `--retry`), plus a `file` task to keep the `0755` mode. It is the only TLS download that runs *on* the EL9 staging host in the air-gapped path — the k3s role's other downloads are `delegate_to: localhost`. Same class of regression as [rpm-software-management/librepo#380](https://github.com/rpm-software-management/librepo/issues/380).

## Type of change
- [x] Bug fix

## Impact

### Security

##### Authorization
No change — no roles, data visibility, or API surface touched.

##### Appsec
`curl -fsSL` keeps TLS certificate verification on (system trust store, same as `get_url`); no `-k`/`--insecure`. `-f` ensures HTTP 4xx/5xx abort the play instead of silently saving an error page as the "script".

### Performance
N/A — one small file download at deploy time.

### Data
N/A.

### Backward compatibility
Backward compatible. On unaffected hosts `curl` fetches the same script. Minor behavior change: the task now always downloads, where `get_url` did a conditional GET (skip if unchanged).

## Testing
- Reproduced the `get_url` failure on an affected EL9 staging node and confirmed the error originates in the Python `ssl` path (Ansible `open_url`), while `curl` / `openssl s_client` succeed against the same endpoint with a valid, fully-trusted cert.
- Ran the swapped task via Ansible in the same connection/interpreter context — downloads successfully.
- Verified error propagation: HTTP 4xx/5xx (`-f`), DNS failure, connection refused, and TLS errors all exit non-zero, so the `command` task fails the play; only a 200 proceeds. Added `--connect-timeout`/`--max-time` so a stalled connection also errors out promptly rather than hanging.

## Note for reviewers
Targeted workaround for an EL9 openssl z-stream regression, not a Scout bug. The alternative is pinning/downgrading `openssl-libs` to `3.5.5-4.el9_8` on affected hosts (security-neutral — `-5` added only the regressing patch, no CVE fixes).

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
