### PR TITLE
fix(jupyter): mount branding outside ~/.jupyter to fix first-spawn saves

### DIFF
--- a/ansible/roles/jupyter/templates/values.yaml.j2
+++ b/ansible/roles/jupyter/templates/values.yaml.j2
@@ -255,6 +255,19 @@ singleuser:
               ln -sfn /opt/scout/samples /home/$NB_USER/Scout
               chown -h $NB_USER:$NB_GID /home/$NB_USER/Scout
             fi
+
+            # #496: surface branding into ~/.jupyter/custom via symlink instead
+            # of mounting there. A subPath mount under ~/.jupyter makes kubelet
+            # create the dir as root on first spawn, blocking ~/.jupyter/lab and
+            # 500-ing every settings/workspace save. Creating it here (as
+            # $NB_USER) keeps it user-owned. Same pattern as ~/Scout above.
+            mkdir -p /home/$NB_USER/.jupyter/custom
+            for asset in custom.css scout.png; do
+              if [ -f /opt/scout/branding/$asset ]; then
+                ln -sfn /opt/scout/branding/$asset /home/$NB_USER/.jupyter/custom/$asset
+                chown -h $NB_USER:$NB_GID /home/$NB_USER/.jupyter/custom/$asset
+              fi
+            done
   extraEnv:
 {% if _package_proxy_needs_staging_cert | default(false) | bool %}
     # Combined CA bundle (system CAs + staging CA) — built by staging-ca-setup init container.
@@ -373,12 +386,14 @@ singleuser:
     extraVolumeMounts:
       jupyterlab-custom-css:
         name: jupyterlab-custom-css
-        mountPath: /home/jovyan/.jupyter/custom/custom.css
+        mountPath: /opt/scout/branding/custom.css
         subPath: custom.css
+        readOnly: true
       jupyterlab-scout-logo:
         name: jupyterlab-scout-logo
-        mountPath: /home/jovyan/.jupyter/custom/scout.png
+        mountPath: /opt/scout/branding/scout.png
         subPath: scout.png
+        readOnly: true
       scout-samples:
         name: scout-samples
         mountPath: /opt/scout/samples


### PR DESCRIPTION
Mounting custom.css/scout.png via subPath under /home/jovyan/.jupyter/custom/ (added in #224) made kubelet create ~/.jupyter as root on a new user's first spawn, blocking creation of ~/.jupyter/lab and 500-ing every settings and workspace save until a server restart.

Mount the branding ConfigMaps at /opt/scout/branding/ (read-only) instead and symlink them into ~/.jupyter/custom/ from the postStart hook as $NB_USER, mirroring the existing ~/Scout pattern, so the Jupyter config dir stays user-owned.

Fixes #496

## Description

### Product
Operations such as updating settings should now work for users in their first notebook server.

### Technical
Leans on existing pattern.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [X] Improvement
- [X] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
Worked for both accounts with and without a pre-existing jupyter PVC.

## Testing
Worked for both accounts with and without a pre-existing jupyter PVC.


## Note for reviewers
<!-- Any additional information or direction for reviewers. -->

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
