### PR TITLE
ci: cancel superseded PR runs to speed up feedback

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,15 @@ on:
       - 'ci-**'
       - 'demo**'
 
+# Cancel a PR's superseded runs so a new push doesn't sit behind a stale ~35m
+# pipeline (and free the runners it was holding). Keyed on head_ref, which is
+# set only for pull_request events; push events (main / ci-** / demo**) fall
+# back to a unique run_id group and are never cancelled, so an in-flight
+# publish / publish-charts on main is never killed mid-release.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   JAVA_DIST: 'zulu'
   JAVA_VERSION: '21'


### PR DESCRIPTION
Adds a concurrency group so a new push to a PR cancels the still-running ~35m pipeline for the previous push, instead of queuing behind it and holding runners. Keyed on github.head_ref (set only for pull_request); push events (main / ci-** / demo**) fall back to a unique github.run_id group, so they never cancel each other and an in-flight publish/publish-charts on main is never killed mid-release.

Improves time-to-green on the latest commit; no change to any single run's wall-clock (that's the deploy-and-test / ingest-gate work, separate).

## Description

### Product
No product/user-facing change. CI infrastructure only.

### Technical
Adds a top-level `concurrency` block to `ci.yaml`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
  cancel-in-progress: true
```

github.head_ref is set only for pull_request events, so all runs for a given
PR branch share one group and a new push cancels the still-running ~35m pipeline
for the previous push. push events (main / ci-** / demo**) have an empty
head_ref and fall back to github.run_id, which is unique per run, so they get
their own group and are never cancelled. That keeps an in-flight publish /
publish-charts on main from being killed mid-release.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security 

##### Authorization
No change. No roles, permissions, or data access affected

##### Appsec
No injection surface: head_ref/run_id are used only as the concurrency group
key (consumed by Actions internally, never interpolated into a shell). No
pull_request_target, no secret exposure

### Performance
This is the point of the change. Today every push to a PR starts a fresh ~36m
pipeline while the prior push's run keeps running and holding runners. Cancelling
the superseded run improves time-to-green on the latest commit and frees runner
capacity. It does not change any single run's wall-clock (that's the
deploy-and-test / ingest-gate work, tracked separately)

### Data
N/A

### Backward compatibility
No API, data-model, or dependency changes. Only affects how CI runs are
scheduled. One visible behavior change: a superseded PR run now ends as
cancelled (previously it ran to completion). main/tag/publish runs are
unaffected

## Testing
ci.yaml still parses (yaml.safe_load) and the job graph is unchanged (12
jobs). The cancel behavior is observable by pushing a follow-up commit to any PR
after this lands: the earlier run switches to cancelled and the new one starts
immediately. main is verified safe by construction, empty head_ref on push
means each main run gets a unique run_id group, so none cancel each other

## Note for reviewers
The only design decision is the group key. ${{ github.head_ref || github.run_id }}
is the standard pattern for "cancel stale PR runs but never cancel push/release
runs"; the run_id fallback is what protects main publishes. Composes cleanly
with the in-flight ci/ingest-fast-gate work, which touches a different region
of the file

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
