### PR TITLE
ci: enforce Conventional Commit PR titles

### DIFF
--- a/.github/workflows/pr-title-lint.yaml
+++ b/.github/workflows/pr-title-lint.yaml
@@ -1,0 +1,24 @@
+name: PR Title Lint
+
+# PR titles are the source for the release lane's version + changelog (ADR 0030):
+# `fix:` -> patch, `feat:` -> minor, a `!` breaking marker -> major. Squash merges
+# use the PR title as the commit subject, so this gates exactly what the release
+# automation will parse. Validates against the default Conventional Commit types
+# (feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert).
+on:
+  pull_request:
+    # `synchronize` re-runs on every push so the check reports on each head SHA
+    # (required-check status must exist on the SHA being merged); `edited` re-runs
+    # when the title itself changes.
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a PR Title Lint check (amannn/action-semantic-pull-request) that validates every PR title against the Conventional Commit spec. Squash merges use the PR title as the commit subject, so this makes the commit type a reliable, machine- parseable contract, the input the ADR 0030 release lane will use to compute the version (fix -> patch, feat -> minor, `!` -> major) and changelog.

First step of Phase 1 (release automation); release-please wiring builds on this. Uses the default Conventional Commit types; runs on synchronize too so the check reports on every head SHA and can be a required status check.

## Description
### Technical
Adds a PR Title Lint check validating every PR title against the Conventional
Commit spec. Squash merges use the PR title as the commit subject, so this makes
the commit type a reliable, machine-parseable contract, the input the ADR 0030
release lane computes the version (fix→patch, feat→minor, `!`→major) and changelog
from. First step of Phase 1 (release automation); release-please wiring builds on it.

## Type of change
- [x] Improvement

## Impact
### Backward compatibility
Enforcement only starts once the check is marked required (see reviewer note). Uses
default Conventional Commit types; the one historical bare `security:` title becomes
`fix(security):`/`feat(security):` (already the repo's pattern).

## Testing
Workflow YAML validated; the action reads the title from the PR event payload (no
checkout). This PR's own title is the first live case.

## Note for reviewers
Two admin steps make this real (they can't be done in-repo):
1. Mark **PR Title Lint / lint-title** a required status check on `main`.
2. Set merge method to **squash-only** and enable **require linear history** on `main`
   (ADR 0030: squash keeps the subject = PR title, and the build lane's run_number
   ordering guard needs linear history).