### PR TITLE
ci: publish build-lane image tags and capture digests (phase 2)

### DIFF
--- a/.github/actions/docker-push/action.yaml
+++ b/.github/actions/docker-push/action.yaml
@@ -1,9 +1,23 @@
 name: 'Docker push'
-description: 'Downloads docker image and pushes to ghcr'
+description: >-
+  Loads the built image tar and pushes it to ghcr at the derived tag. When a
+  build-lane version is given, also publishes an immutable 0.YYYYMMDD.<run> tag
+  and records the pushed digest for the ADR 0030 build manifest.
 inputs:
   image-name:
     description: 'Name for docker image'
     required: true
+  version:
+    description: >-
+      Build-lane version (0.YYYYMMDD.<run>) to publish alongside the derived
+      tag. Leave empty (e.g. demo publishes) to push only the derived tag and
+      record no digest.
+    required: false
+    default: ''
+outputs:
+  digest:
+    description: 'Registry digest (sha256:...) of the pushed image; empty when no build-lane version was given.'
+    value: ${{ steps.push.outputs.digest }}
 runs:
   using: 'composite'
   steps:
@@ -13,11 +27,48 @@ runs:
         name: ${{ inputs.image-name }}
         path: ${{ runner.temp }}
     - name: Push image
+      id: push
       shell: bash
       env:
         IMAGE_NAME: ${{ inputs.image-name }}
+        VERSION: ${{ inputs.version }}
       run: |
-        docker push "$(docker load --input "${RUNNER_TEMP}/${IMAGE_NAME}.tar" | sed -e 's/.*: //g')"
+        set -euo pipefail
+        # docker load prints "Loaded image: <ref>"; that ref carries the derived
+        # tag baked into the tar by docker-build-cache. Push it (existing behavior).
+        loaded_ref="$(docker load --input "${RUNNER_TEMP}/${IMAGE_NAME}.tar" | sed -e 's/.*: //g')"
+        docker push "${loaded_ref}"
+
+        # No build-lane version (e.g. demo publish): derived tag only, done.
+        if [ -z "${VERSION}" ]; then
+          echo "digest=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Also publish the immutable build-lane tag so the build manifest can pin
+        # this image by name:tag@digest. It aliases the same image, so the registry
+        # returns the same content digest.
+        repo="${loaded_ref%:*}"
+        build_ref="${repo}:${VERSION}"
+        docker tag "${loaded_ref}" "${build_ref}"
+        push_out="$(docker push "${build_ref}")"
+        digest="$(printf '%s\n' "${push_out}" | sed -n 's/.*digest: \(sha256:[0-9a-f]\{64\}\).*/\1/p' | head -1)"
+        if [ -z "${digest}" ]; then
+          echo "::error::could not parse pushed digest for ${build_ref}"
+          exit 1
+        fi
+        echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+        # Record "<name> <repo>:<version>@<digest>" for the build-manifest job.
+        mkdir -p "${RUNNER_TEMP}/image-digests"
+        printf '%s %s@%s\n' "${IMAGE_NAME}" "${build_ref}" "${digest}" \
+          > "${RUNNER_TEMP}/image-digests/${IMAGE_NAME}.txt"
+    - name: Upload image digest
+      if: inputs.version != ''
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: image-digest-${{ inputs.image-name }}
+        path: ${{ runner.temp }}/image-digests/${{ inputs.image-name }}.txt
     - name: Cleanup temp image tar
       shell: bash
       env:

--- a/.github/actions/docker-push/action.yaml
+++ b/.github/actions/docker-push/action.yaml
@@ -51,10 +51,12 @@ runs:
         repo="${loaded_ref%:*}"
         build_ref="${repo}:${VERSION}"
         docker tag "${loaded_ref}" "${build_ref}"
-        push_out="$(docker push "${build_ref}")"
-        digest="$(printf '%s\n' "${push_out}" | sed -n 's/.*digest: \(sha256:[0-9a-f]\{64\}\).*/\1/p' | head -1)"
-        if [ -z "${digest}" ]; then
-          echo "::error::could not parse pushed digest for ${build_ref}"
+        docker push "${build_ref}"
+        # Read the authoritative content digest back from the registry as structured
+        # JSON (a stable contract), rather than parsing docker push's human output.
+        digest="$(docker buildx imagetools inspect "${build_ref}" --format '{{json .Manifest}}' | jq -r '.digest')"
+        if [ "${digest#sha256:}" = "${digest}" ]; then
+          echo "::error::could not resolve pushed digest for ${build_ref}"
           exit 1
         fi
         echo "digest=${digest}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -877,46 +877,55 @@ jobs:
         uses: ./.github/actions/docker-push
         with:
           image-name: hl7log-extractor
+          version: ${{ needs.changes.outputs.version }}
       - name: 'Push Image - hl7-transformer'
         if: needs.changes.outputs.hl7-transformer == 'true'
         uses: ./.github/actions/docker-push
         with:
           image-name: hl7-transformer
+          version: ${{ needs.changes.outputs.version }}
       - name: 'Push Image - hl7-listener'
         if: needs.changes.outputs.hl7-listener == 'true'
         uses: ./.github/actions/docker-push
         with:
           image-name: hl7-listener
+          version: ${{ needs.changes.outputs.version }}
       - name: 'Push Image - scout-notebook'
         if: needs.changes.outputs.scout-notebook == 'true'
         uses: ./.github/actions/docker-push
         with:
           image-name: scout-notebook
+          version: ${{ needs.changes.outputs.version }}
       - name: 'Push Image - launchpad'
         if: needs.changes.outputs.launchpad == 'true'
         uses: ./.github/actions/docker-push
         with:
           image-name: launchpad
+          version: ${{ needs.changes.outputs.version }}
       - name: 'Push Image - superset'
         if: needs.changes.outputs.superset == 'true'
         uses: ./.github/actions/docker-push
         with:
           image-name: superset
+          version: ${{ needs.changes.outputs.version }}
       - name: 'Push Image - keycloak'
         if: needs.changes.outputs.keycloak == 'true'
         uses: ./.github/actions/docker-push
         with:
           image-name: keycloak
+          version: ${{ needs.changes.outputs.version }}
       - name: 'Push Image - report-viewer'
         if: needs.changes.outputs.report-viewer == 'true'
         uses: ./.github/actions/docker-push
         with:
           image-name: report-viewer
+          version: ${{ needs.changes.outputs.version }}
       - name: 'Push Image - xnat-plugin-installer'
         if: needs.changes.outputs.xnat-plugin-installer == 'true'
         uses: ./.github/actions/docker-push
         with:
           image-name: xnat-plugin-installer
+          version: ${{ needs.changes.outputs.version }}
   # Publish changed Helm charts as versioned OCI artifacts (ADR 0030/0031 phase 0),
   # gated like the image `publish` job. Vertical slice: hl7-transformer only.
   publish-charts:


### PR DESCRIPTION
First slice of Phase 2 (ADR 0030 build lane). Today images publish only the derived tag (mostly `latest`) and the pushed digest is thrown away, so nothing can pin an image immutably. This adds the foundation the build manifest needs, without changing what deploys.

- docker-push: new optional `version` input. When set, it additionally tags and pushes the immutable build-lane tag (0.YYYYMMDD.<run>, minted once in the changes job), captures the registry digest, and writes "<name> <ref>@<digest>" as an `image-digest-<name>` artifact for the manifest job to aggregate. When empty (demo publishes) it behaves exactly as before, so publish-demo is untouched.
- publish (main only): pass the build-lane version to all nine image pushes.

Keeps the existing build-tar flow (scan-images + in-cluster image import both consume that tar) rather than switching to push-by-digest. Dual-publishing the derived tag alongside the build tag is intentional until the ADR 0031 cutover. No new permissions (packages:write already present); no deploy behavior changes.

## Description
### Technical
First slice of Phase 2 (ADR 0030 build lane). Images currently publish only the
derived tag and discard the pushed digest, so nothing can pin an image immutably.

- docker-push: optional `version` input. When set, additionally tags+pushes the
  immutable 0.YYYYMMDD.<run> tag, captures the registry digest, and uploads an
  `image-digest-<name>` artifact ("<name> <ref>@<digest>") for the manifest job.
  Empty (demo publishes) = unchanged behavior; publish-demo is untouched.
- publish (main only): pass the build-lane version to all nine image pushes.

Keeps the build-tar flow (scan-images + in-cluster import consume the tar) rather
than push-by-digest. Dual-publishing the derived tag alongside the build tag is
intentional until the 0031 cutover. No new permissions; no deploy changes.

## Type of change
- [x] Improvement

## Note for reviewers
This is the foundation the build manifest (a later PR) aggregates. Digest is parsed
from `docker push` output; keeping the tar was decision 1 from the Phase 2 design
(push-by-digest would break the tar consumers). Only exercises on merge to main
(publish is main-gated).