### PR TITLE
ci: add build-manifest schema and reader/writer lib (phase 2)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -260,7 +260,10 @@ jobs:
           python-version: '3.12'
       - name: Install Molecule and dependencies
         run: |
-          pip install molecule ansible-core pytest pydantic tiktoken httpx pytest-asyncio trino requests
+          pip install molecule ansible-core pytest pydantic tiktoken httpx pytest-asyncio trino requests jsonschema
+      - name: 'Unit tests: build manifest'
+        shell: bash
+        run: cd tooling/manifest && pytest -v
       - name: 'Unit tests: filter plugins'
         shell: bash
         run: cd ansible && pytest tests/unit/filter_plugins/ -v

--- a/tooling/manifest/manifest.py
+++ b/tooling/manifest/manifest.py
@@ -128,7 +128,11 @@ def carry_section(
     out: list[Artifact] = []
     for name in all_names:
         if name in fresh_by:
-            out.append(replace(fresh_by[name], changedThisBuild=True, producedByBuild=build_version))
+            out.append(
+                replace(
+                    fresh_by[name], changedThisBuild=True, producedByBuild=build_version
+                )
+            )
         elif name in prev_by:
             out.append(replace(prev_by[name], changedThisBuild=False))
         else:
@@ -163,8 +167,12 @@ def assemble(
         version=version,
         sourceCommit=source_commit,
         rebuildScope=rebuild_scope,
-        images=carry_section(prev_images, fresh_images, all_image_names, build_version=version),
-        charts=carry_section(prev_charts, fresh_charts, all_chart_names, build_version=version),
+        images=carry_section(
+            prev_images, fresh_images, all_image_names, build_version=version
+        ),
+        charts=carry_section(
+            prev_charts, fresh_charts, all_chart_names, build_version=version
+        ),
         predecessor=predecessor,
         kind=kind,
     )

--- a/tooling/manifest/manifest.py
+++ b/tooling/manifest/manifest.py
@@ -1,0 +1,215 @@
+"""Scout build manifest (ADR 0030 build lane).
+
+A build manifest is the authoritative record of the whole Scout platform for one
+build- or release-lane version: every image and chart pinned by ref + digest,
+the source commit it describes, and a link to its predecessor. Deployments
+(ADR 0031) resolve components from it, so content that did not change this build
+carries the SAME digest forward and its pods do not restart.
+
+This module is dependency-free (stdlib only) so it runs on a CI runner with no
+install step. ``schema.json`` beside it is the canonical wire contract;
+``validate(...)`` checks a manifest against it and imports ``jsonschema`` lazily
+(dev/test only).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Optional
+
+SCHEMA_VERSION = 1
+MEDIA_TYPE = "application/vnd.scout.build-manifest.v1+json"
+SCHEMA_PATH = Path(__file__).with_name("schema.json")
+
+
+@dataclass
+class Artifact:
+    """One image or chart, pinned immutably by ``ref@digest``."""
+
+    name: str
+    ref: str  # e.g. ghcr.io/washu-tag/hl7-transformer:0.20260730.412
+    digest: str  # sha256:...
+    producedByBuild: str  # build version whose run produced this content
+    changedThisBuild: bool
+    appVersion: Optional[str] = None  # charts only (Phase 2 PR5); None for images
+    primaryImage: Optional[str] = None  # charts only (Phase 2 PR5)
+
+    def pinned(self) -> str:
+        """The immutable ``ref@digest`` a deployment should pull."""
+        return f"{self.ref}@{self.digest}"
+
+
+@dataclass
+class Predecessor:
+    version: str
+    sourceCommit: str
+    digest: Optional[str] = None
+
+
+@dataclass
+class Manifest:
+    version: str
+    sourceCommit: str
+    rebuildScope: str  # "changed" | "all"
+    images: list[Artifact] = field(default_factory=list)
+    charts: list[Artifact] = field(default_factory=list)
+    predecessor: Optional[Predecessor] = None
+    kind: str = "scout.build"  # "scout.build" | "scout.release"
+    schemaVersion: int = SCHEMA_VERSION
+    configArtifact: Optional[dict] = None  # ADR 0031 (Phase 3); null here
+    bom: Optional[list] = None  # ADR 0031 (Phase 3); null here
+
+    def resolve(self, name: str) -> str:
+        """Return the pinned ``ref@digest`` for image or chart ``name``."""
+        for a in (*self.images, *self.charts):
+            if a.name == name:
+                return a.pinned()
+        raise KeyError(f"{name!r} is not in build manifest {self.version}")
+
+    def to_dict(self) -> dict:
+        return {
+            "schemaVersion": self.schemaVersion,
+            "kind": self.kind,
+            "version": self.version,
+            "sourceCommit": self.sourceCommit,
+            "rebuildScope": self.rebuildScope,
+            "predecessor": _pred_dict(self.predecessor),
+            "images": [_artifact_dict(a) for a in self.images],
+            "charts": [_artifact_dict(a) for a in self.charts],
+            "configArtifact": self.configArtifact,
+            "bom": self.bom,
+        }
+
+    def dumps(self, *, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent) + "\n"
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Manifest":
+        pred = d.get("predecessor")
+        return cls(
+            version=d["version"],
+            sourceCommit=d["sourceCommit"],
+            rebuildScope=d["rebuildScope"],
+            images=[_artifact_from(a) for a in d.get("images", [])],
+            charts=[_artifact_from(a) for a in d.get("charts", [])],
+            predecessor=Predecessor(**pred) if pred else None,
+            kind=d.get("kind", "scout.build"),
+            schemaVersion=d.get("schemaVersion", SCHEMA_VERSION),
+            configArtifact=d.get("configArtifact"),
+            bom=d.get("bom"),
+        )
+
+    @classmethod
+    def loads(cls, s: str) -> "Manifest":
+        return cls.from_dict(json.loads(s))
+
+
+def carry_section(
+    previous: list[Artifact],
+    fresh: list[Artifact],
+    all_names: list[str],
+    *,
+    build_version: str,
+) -> list[Artifact]:
+    """Assemble one section (images or charts) for a new manifest.
+
+    For each name in ``all_names``: if it was rebuilt this run it is taken from
+    ``fresh`` (stamped ``changedThisBuild=True`` and ``producedByBuild`` = this
+    build); otherwise it is carried from ``previous`` unchanged
+    (``changedThisBuild=False``, digest preserved).
+
+    Fail closed: a name that is neither fresh nor present in ``previous`` raises,
+    the caller must rebuild it rather than publish a manifest with a hole.
+    """
+    fresh_by = {a.name: a for a in fresh}
+    prev_by = {a.name: a for a in previous}
+    out: list[Artifact] = []
+    for name in all_names:
+        if name in fresh_by:
+            out.append(replace(fresh_by[name], changedThisBuild=True, producedByBuild=build_version))
+        elif name in prev_by:
+            out.append(replace(prev_by[name], changedThisBuild=False))
+        else:
+            raise ValueError(
+                f"{name!r} did not change this build but is absent from the "
+                f"predecessor manifest; rebuild it instead of shipping a hole"
+            )
+    return out
+
+
+def assemble(
+    *,
+    version: str,
+    source_commit: str,
+    rebuild_scope: str,
+    previous: Optional[Manifest],
+    fresh_images: list[Artifact],
+    fresh_charts: list[Artifact],
+    all_image_names: list[str],
+    all_chart_names: list[str],
+    kind: str = "scout.build",
+) -> Manifest:
+    """Build a full manifest, carrying unchanged components from ``previous``."""
+    prev_images = previous.images if previous else []
+    prev_charts = previous.charts if previous else []
+    predecessor = (
+        Predecessor(version=previous.version, sourceCommit=previous.sourceCommit)
+        if previous
+        else None
+    )
+    return Manifest(
+        version=version,
+        sourceCommit=source_commit,
+        rebuildScope=rebuild_scope,
+        images=carry_section(prev_images, fresh_images, all_image_names, build_version=version),
+        charts=carry_section(prev_charts, fresh_charts, all_chart_names, build_version=version),
+        predecessor=predecessor,
+        kind=kind,
+    )
+
+
+def validate(manifest_dict: dict) -> None:
+    """Validate a manifest dict against schema.json. Raises on violation.
+
+    Imports ``jsonschema`` lazily so the read/write/assemble paths stay
+    dependency-free on a CI runner.
+    """
+    import jsonschema  # noqa: PLC0415  (lazy: dev/test-only dependency)
+
+    schema = json.loads(SCHEMA_PATH.read_text())
+    jsonschema.validate(instance=manifest_dict, schema=schema)
+
+
+def _artifact_dict(a: Artifact) -> dict:
+    d = {
+        "name": a.name,
+        "ref": a.ref,
+        "digest": a.digest,
+        "producedByBuild": a.producedByBuild,
+        "changedThisBuild": a.changedThisBuild,
+    }
+    if a.appVersion is not None:
+        d["appVersion"] = a.appVersion
+    if a.primaryImage is not None:
+        d["primaryImage"] = a.primaryImage
+    return d
+
+
+def _artifact_from(d: dict) -> Artifact:
+    return Artifact(
+        name=d["name"],
+        ref=d["ref"],
+        digest=d["digest"],
+        producedByBuild=d["producedByBuild"],
+        changedThisBuild=d["changedThisBuild"],
+        appVersion=d.get("appVersion"),
+        primaryImage=d.get("primaryImage"),
+    )
+
+
+def _pred_dict(p: Optional[Predecessor]) -> Optional[dict]:
+    if p is None:
+        return None
+    return {"version": p.version, "sourceCommit": p.sourceCommit, "digest": p.digest}

--- a/tooling/manifest/schema.json
+++ b/tooling/manifest/schema.json
@@ -5,7 +5,15 @@
   "description": "Authoritative record of the whole Scout platform for one build- or release-lane version (ADR 0030). Every image and chart is pinned by ref + digest; unchanged content carries its digest forward so deployments (ADR 0031) restart pods only on real change.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schemaVersion", "kind", "version", "sourceCommit", "rebuildScope", "images", "charts"],
+  "required": [
+    "schemaVersion",
+    "kind",
+    "version",
+    "sourceCommit",
+    "rebuildScope",
+    "images",
+    "charts"
+  ],
   "properties": {
     "schemaVersion": { "const": 1 },
     "kind": { "enum": ["scout.build", "scout.release"] },

--- a/tooling/manifest/schema.json
+++ b/tooling/manifest/schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://washu-tag.github.io/scout/build-manifest.v1.json",
+  "title": "Scout build manifest",
+  "description": "Authoritative record of the whole Scout platform for one build- or release-lane version (ADR 0030). Every image and chart is pinned by ref + digest; unchanged content carries its digest forward so deployments (ADR 0031) restart pods only on real change.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "version", "sourceCommit", "rebuildScope", "images", "charts"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "kind": { "enum": ["scout.build", "scout.release"] },
+    "version": { "type": "string", "minLength": 1 },
+    "sourceCommit": { "type": "string", "pattern": "^[0-9a-f]{7,40}$" },
+    "rebuildScope": { "enum": ["changed", "all"] },
+    "predecessor": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["version", "sourceCommit"],
+      "properties": {
+        "version": { "type": "string" },
+        "sourceCommit": { "type": "string" },
+        "digest": { "type": ["string", "null"] }
+      }
+    },
+    "images": { "type": "array", "items": { "$ref": "#/$defs/artifact" } },
+    "charts": { "type": "array", "items": { "$ref": "#/$defs/artifact" } },
+    "configArtifact": {
+      "type": ["object", "null"],
+      "description": "ADR 0031 deployment-config artifact; null until Phase 3."
+    },
+    "bom": {
+      "type": ["array", "null"],
+      "description": "Third-party image bill of materials; null/empty until Phase 3."
+    }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "ref", "digest", "producedByBuild", "changedThisBuild"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "ref": { "type": "string", "minLength": 1 },
+        "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "producedByBuild": { "type": "string", "minLength": 1 },
+        "changedThisBuild": { "type": "boolean" },
+        "appVersion": { "type": ["string", "null"] },
+        "primaryImage": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/tooling/manifest/test_manifest.py
+++ b/tooling/manifest/test_manifest.py
@@ -1,0 +1,147 @@
+"""Offline unit tests for the Scout build manifest lib. No registry, no network."""
+
+import pytest
+
+from manifest import Artifact, Manifest, Predecessor, assemble, carry_section, validate
+
+D1 = "sha256:" + "1" * 64
+D2 = "sha256:" + "2" * 64
+D3 = "sha256:" + "3" * 64
+
+
+def img(name, digest, build, changed, tag="0.20260730.1"):
+    return Artifact(
+        name=name,
+        ref=f"ghcr.io/washu-tag/{name}:{tag}",
+        digest=digest,
+        producedByBuild=build,
+        changedThisBuild=changed,
+    )
+
+
+def test_pinned_ref():
+    a = img("hl7-transformer", D1, "0.20260730.1", True)
+    assert a.pinned() == f"ghcr.io/washu-tag/hl7-transformer:0.20260730.1@{D1}"
+
+
+def test_resolve_image_and_chart():
+    m = Manifest(
+        version="0.20260730.1",
+        sourceCommit="abc1234",
+        rebuildScope="changed",
+        images=[img("hl7-transformer", D1, "0.20260730.1", True)],
+        charts=[img("scout-opa", D2, "0.20260730.1", False)],
+    )
+    assert m.resolve("hl7-transformer").endswith(f"@{D1}")
+    assert m.resolve("scout-opa").endswith(f"@{D2}")
+    with pytest.raises(KeyError):
+        m.resolve("nope")
+
+
+def test_roundtrip_dumps_loads():
+    m = Manifest(
+        version="0.20260730.1",
+        sourceCommit="abc1234",
+        rebuildScope="changed",
+        images=[img("hl7-transformer", D1, "0.20260730.1", True)],
+        charts=[],
+        predecessor=Predecessor(version="0.20260729.9", sourceCommit="def5678"),
+    )
+    assert Manifest.loads(m.dumps()).to_dict() == m.to_dict()
+
+
+def test_carry_section_changed_vs_carried():
+    previous = [
+        img("a", D1, "0.20260729.9", True),
+        img("b", D2, "0.20260728.5", True),
+    ]
+    fresh = [img("a", D3, "0.20260730.1", False)]  # 'a' rebuilt this run
+    out = {x.name: x for x in carry_section(previous, fresh, ["a", "b"], build_version="0.20260730.1")}
+
+    # 'a' changed this build: fresh digest, stamped changed + producedByBuild=this build
+    assert out["a"].digest == D3
+    assert out["a"].changedThisBuild is True
+    assert out["a"].producedByBuild == "0.20260730.1"
+    # 'b' unchanged: carried at its old digest + producing build, marked not-changed
+    assert out["b"].digest == D2
+    assert out["b"].changedThisBuild is False
+    assert out["b"].producedByBuild == "0.20260728.5"
+
+
+def test_carry_section_fails_closed_on_missing_predecessor_entry():
+    # 'b' did not change this build but is absent from the predecessor -> must rebuild.
+    with pytest.raises(ValueError, match="absent from the predecessor"):
+        carry_section([img("a", D1, "0.20260729.9", True)], [], ["a", "b"], build_version="0.20260730.1")
+
+
+def test_assemble_carries_predecessor_and_bootstraps():
+    prev = Manifest(
+        version="0.20260729.9",
+        sourceCommit="def5678",
+        rebuildScope="all",
+        images=[img("a", D1, "0.20260729.9", True), img("b", D2, "0.20260729.9", True)],
+        charts=[],
+    )
+    m = assemble(
+        version="0.20260730.1",
+        source_commit="abc1234",
+        rebuild_scope="changed",
+        previous=prev,
+        fresh_images=[img("a", D3, "0.20260730.1", False)],
+        fresh_charts=[],
+        all_image_names=["a", "b"],
+        all_chart_names=[],
+    )
+    assert m.predecessor.version == "0.20260729.9"
+    assert m.resolve("a").endswith(f"@{D3}")  # rebuilt
+    assert m.resolve("b").endswith(f"@{D2}")  # carried forward unchanged
+    assert [i.changedThisBuild for i in m.images] == [True, False]
+
+
+def test_assemble_bootstrap_no_predecessor():
+    m = assemble(
+        version="0.20260730.1",
+        source_commit="abc1234",
+        rebuild_scope="all",
+        previous=None,
+        fresh_images=[img("a", D1, "0.20260730.1", True)],
+        fresh_charts=[],
+        all_image_names=["a"],
+        all_chart_names=[],
+    )
+    assert m.predecessor is None
+    assert m.resolve("a").endswith(f"@{D1}")
+
+
+def test_assembled_manifest_matches_schema():
+    m = assemble(
+        version="0.20260730.1",
+        source_commit="abc1234def",
+        rebuild_scope="changed",
+        previous=Manifest(
+            version="0.20260729.9",
+            sourceCommit="def5678",
+            rebuildScope="all",
+            images=[img("b", D2, "0.20260729.9", True)],
+            charts=[],
+        ),
+        fresh_images=[img("a", D1, "0.20260730.1", False)],
+        fresh_charts=[],
+        all_image_names=["a", "b"],
+        all_chart_names=[],
+    )
+    validate(m.to_dict())  # raises if the wire shape drifts from schema.json
+
+
+def test_schema_rejects_bad_digest():
+    import jsonschema
+
+    m = Manifest(
+        version="0.20260730.1",
+        sourceCommit="abc1234",
+        rebuildScope="changed",
+        images=[img("a", "sha256:not-a-real-digest", "0.20260730.1", True)],
+        charts=[],
+    )
+    with pytest.raises(jsonschema.ValidationError):
+        validate(m.to_dict())

--- a/tooling/manifest/test_manifest.py
+++ b/tooling/manifest/test_manifest.py
@@ -56,7 +56,12 @@ def test_carry_section_changed_vs_carried():
         img("b", D2, "0.20260728.5", True),
     ]
     fresh = [img("a", D3, "0.20260730.1", False)]  # 'a' rebuilt this run
-    out = {x.name: x for x in carry_section(previous, fresh, ["a", "b"], build_version="0.20260730.1")}
+    out = {
+        x.name: x
+        for x in carry_section(
+            previous, fresh, ["a", "b"], build_version="0.20260730.1"
+        )
+    }
 
     # 'a' changed this build: fresh digest, stamped changed + producedByBuild=this build
     assert out["a"].digest == D3
@@ -71,7 +76,12 @@ def test_carry_section_changed_vs_carried():
 def test_carry_section_fails_closed_on_missing_predecessor_entry():
     # 'b' did not change this build but is absent from the predecessor -> must rebuild.
     with pytest.raises(ValueError, match="absent from the predecessor"):
-        carry_section([img("a", D1, "0.20260729.9", True)], [], ["a", "b"], build_version="0.20260730.1")
+        carry_section(
+            [img("a", D1, "0.20260729.9", True)],
+            [],
+            ["a", "b"],
+            build_version="0.20260730.1",
+        )
 
 
 def test_assemble_carries_predecessor_and_bootstraps():


### PR DESCRIPTION
Second slice of Phase 2 (ADR 0030 build lane): the wire contract the later manifest-publish job and Phase 3 deployment stamping build against, landed early and independently so that interface is frozen and tested before anything emits or consumes a manifest.

- tooling/manifest/schema.json: the canonical build-manifest v1 JSON Schema (images + charts pinned by ref + sha256 digest, predecessor link, rebuildScope; configArtifact/bom reserved null for Phase 3).
- tooling/manifest/manifest.py: dependency-free (stdlib) lib — Manifest/Artifact models, (de)serialization, resolve(name) -> ref@digest, and assemble(): carry unchanged components from the predecessor at their existing digest, stamp the rebuilt ones, and fail closed if an unchanged component is missing upstream. validate() checks against schema.json (lazy jsonschema import, dev/test only).
- tooling/manifest/test_manifest.py: offline unit tests (round-trip, resolve, carry-forward, bootstrap, fail-closed, schema conformance). Wired into the ansible-and-python-tests job; jsonschema added to that job's install.

No pipeline behavior change and nothing emits a manifest yet; this is pure lib + tests. All 9 tests pass locally.

## Description
### Technical
Phase 2 slice 2 (ADR 0030 build lane): the manifest wire contract, landed early
and independently so the interface is frozen + tested before the manifest job
(later PR) or Phase 3 deployment stamping build against it.

- tooling/manifest/schema.json: build-manifest v1 JSON Schema.
- tooling/manifest/manifest.py: dependency-free lib (models, (de)serialize,
  resolve() -> ref@digest, assemble() carries unchanged components at their
  existing digest and fails closed on a missing one; validate() via jsonschema).
- tooling/manifest/test_manifest.py: 9 offline tests, wired into
  ansible-and-python-tests (jsonschema added to that job's install).

Pure lib + tests, no pipeline behavior change, nothing emits a manifest yet.

## Type of change
- [x] Improvement
## Testing
9/9 unit tests pass (round-trip, resolve, carry-forward, bootstrap, fail-closed,
schema conformance). Offline, no registry or network.