### PR TITLE
fix(hl7-transformer): drop unused pip to clear vendored CVEs

### DIFF
--- a/extractor/hl7-transformer/Dockerfile
+++ b/extractor/hl7-transformer/Dockerfile
@@ -34,12 +34,15 @@ RUN venv/bin/python3 -m pip install --no-cache .
 # Copy the current directory contents into the container at /app
 COPY --chown=spark . /app
 
-# Install the applicationp
+# Install the application, then trim the runtime image. The pyspark wheel bundles
+# a full duplicate of the Spark jars (runtime uses SPARK_HOME's copy), and pip is
+# unused at runtime; its vendored msgpack/setuptools are the only fixable CVEs the
+# scanner still flags in our layers. Dropping both keeps the image and scan clean.
 RUN venv/bin/python3 -m pip install . \
-    # The pyspark wheel ships its own full copy of the Spark jars; the runtime
-    # resolves jars from SPARK_HOME (that's where the Delta/S3A jars above
-    # live), so the duplicate copy is dead weight and CVE-scan noise.
-    && rm -rf venv/lib/python3.10/site-packages/pyspark/jars
+    && rm -rf venv/lib/python3.10/site-packages/pyspark/jars \
+              venv/lib/python3.10/site-packages/pip \
+              venv/lib/python3.10/site-packages/pip-*.dist-info \
+              venv/bin/pip venv/bin/pip3 venv/bin/pip3.10
 
 # Define environment variable
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
A fresh image build upgrades pip to 26.2, whose vendored deps (msgpack 1.1.2, setuptools 70.3.0 in pip/_vendor/vendor.txt) carry fixable HIGH advisories (GHSA-6v7p-g79w-8964, CVE-2025-47273) that fail the scan-images gate. pip is unused at runtime (CMD runs the worker via python -m; ensurepip is retained for debugging), so drop it alongside the existing pyspark/jars cleanup. The venv's real setuptools (83.0.0) stays and is clean. Local rebuild + scan with the CI ignore files shows 0 residual fixable HIGH/CRIT.

## Description

### Product
No product or user-facing change. This is a build-hygiene and security fix to
the hl7-transformer container image; behavior of the ingest worker is unchanged.

### Technical
Any change under `.github/` flips `ci=true`, which rebuilds every image from
scratch. A fresh rebuild runs `pip install --upgrade pip`, pulling pip 26.2,
whose vendored dependencies recorded in `pip/_vendor/vendor.txt` now carry
fixable HIGH advisories:

- `msgpack` 1.1.2 -> 1.2.1 (GHSA-6v7p-g79w-8964)
- `setuptools` 70.3.0 -> 78.1.1 (CVE-2025-47273)

These fail the `scan-images (hl7-transformer)` gate. The published image scans
clean because it shipped an older pip, so the finding only surfaces on a full
rebuild, and it will hit main's next full rebuild too.

The fix drops pip from the runtime image in the same final `RUN` that already
strips the duplicate `pyspark/jars` (build-time cleanup). pip is build-time
only: the container CMD runs `python3 -m hl7scout.ingesthl7worker`, the worker
and health server never call pip or subprocess, and the SparkSession uses jars
baked into `SPARK_HOME` (no runtime package resolution). The venv's real
`setuptools` (83.0.0) stays and is clean. `ensurepip` is untouched, so pip is
re-materializable in a debug session via `python3 -m ensurepip`.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
No change. No user roles, data visibility, or API paths are affected.

##### Appsec
Positive. Removes two fixable HIGH CVEs from the shipped image. They lived in
pip's vendored copies and are not reachable by the runtime worker, but deleting
pip eliminates them rather than suppressing the scanner. Chosen over a
`.trivyignore` entry deliberately: that file is scoped to unfixable upstream
spark base-image CVEs, whereas these are in a package we install in our own
layer and can delete, and a per-ID suppression would go stale the next time
pip's vendored pins shift (the same churn that moved jline/netty to `.rego`).

### Performance
No runtime performance change. The image is marginally smaller.

### Data
No change to data handling or the ingest path.

### Backward compatibility
No data model, API, or application dependency changes. The only image change is
that pip is no longer present at runtime (it was build-time only); `ensurepip`
is retained so pip can be restored on demand for debugging.

## Testing
Local amd64 rebuild of the image + Trivy scan using the same
`.trivyignore.yaml` and `.trivyignore.rego` the CI gate uses -> 0 residual
fixable HIGH/CRITICAL. `import hl7scout.ingesthl7worker` imports identically
before and after removal. Runtime behavior is exercised by the existing
`deploy-and-test` and `smoke-test` gates.

## Note for reviewers
No new tests are needed: the `scan-images` gate is the regression check for the
CVEs, and `deploy-and-test` covers runtime behavior. This is a main-level fix
(main's next full rebuild would fail the same way), so it is intentionally a
standalone PR rather than folded into the phase-2 branches, which will rebase
onto it.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate