### PR TITLE
feat(report-viewer): surface MPI in the viewer

### DIFF
--- a/report-viewer/frontend/src/pages/SearchDetailPage.tsx
+++ b/report-viewer/frontend/src/pages/SearchDetailPage.tsx
@@ -107,6 +107,19 @@ export default function SearchDetailPage() {
     setExpanded({});
   }, [rowsQ.data]);
 
+  // Reveal the hidden patient_mpi column for legacy cohorts whose only
+  // identifier is the mpi (rows with an mpi but no epic_mrn).
+  const autoMpiSearchRef = useRef<string | null>(null);
+  useEffect(() => {
+    const rows = rowsQ.data?.rows;
+    if (!rows || autoMpiSearchRef.current === searchId) return;
+    autoMpiSearchRef.current = searchId;
+    const blank = (v: unknown) => v == null || v === '';
+    if (rows.some((r) => blank(r.epic_mrn) && !blank(r.patient_mpi))) {
+      setColumnVisibility((v) => ({ ...v, patient_mpi: true }));
+    }
+  }, [rowsQ.data, searchId]);
+
   useEffect(() => {
     if (!colPickerOpen) return;
     const onEvent = (e: MouseEvent | KeyboardEvent) => {

--- a/report-viewer/frontend/src/pages/searchDetail/RowDetail.tsx
+++ b/report-viewer/frontend/src/pages/searchDetail/RowDetail.tsx
@@ -116,6 +116,9 @@ export function RowDetail(props: {
           {props.row.resolved_epic_mrn ? (
             <CardField label="Resolved MRN" value={fmt(props.row.resolved_epic_mrn)} mono />
           ) : null}
+          {props.row.patient_mpi ? (
+            <CardField label="Patient MPI" value={fmt(props.row.patient_mpi)} mono />
+          ) : null}
           {props.row.resolved_mpi ? (
             <CardField label="Resolved MPI" value={fmt(props.row.resolved_mpi)} mono />
           ) : null}


### PR DESCRIPTION
## Description

### Product
Legacy reports with no Epic MRN showed no patient identifier by default, and users had to know to add the MPI column from the picker. Now the column auto-reveals when a cohort has any row with an MPI but no Epic MRN, and the row-expand card shows Patient MPI when present. (#529)

### Technical
One effect in `SearchDetailPage.tsx` flips the hidden `patient_mpi` column on, once per search, when `rows.some(r => blank(r.epic_mrn) && !blank(r.patient_mpi))`. It only ever reveals the column, so it doesn't fight the picker, and reads the fields defensively (a missing projection is just `undefined`). `RowDetail.tsx` gets a conditional Patient MPI card field (we already had a conditional Resolved MPI field, so this is more of a bug fix).

Closes #529.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security
N/A. No authz, query, or data-access changes. Reads columns already in the cohort.

### Performance
One short-circuiting O(n) pass over the loaded cohort, once per search. Fine at the 50k cohort cap.

### Data
Handles the legacy v2.3 case (blank `epic_mrn`, populated `patient_mpi`) and missing projections gracefully via blank checks and conditional rendering. If none of the data has an `epic_mrn` the column is still showing, only the MPI column is conditionally shown.

### Backward compatibility
N/A. Client-only, no API or schema change.

## Testing
Tested in dev env to confirm the patient mpi column appears if there is a row missing and mrn

## Note for reviewers
- Targets `528-532-536-546-report-viewer` because of how significant the changes are there. will retarget to `main` once that merges. (UPDATE: I see a new "Start a pull request stack" feature, going to try that for the first time..)
- On the "does 'MPI' even mean anything to our users?" question (#529): not addressing the naming here. Leaning toward keeping the label faithful to the actual column (`patient_mpi`) and the data schema docs rather than inventing a friendlier term. Users can map it back to the docs. We can revisit if it turns out to trip people up.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
