### PR TITLE
fix(security): bump spring-framework to clear scan-images HIGH findings

### DIFF
--- a/extractor/hl7log-extractor/build.gradle
+++ b/extractor/hl7log-extractor/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.6'
+	id 'org.springframework.boot' version '4.0.7'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'checkstyle'
 }
@@ -44,11 +44,6 @@ ext['netty.version'] = '4.2.16.Final'
 // (tools.jackson, jackson-bom).
 ext['jackson-2-bom.version'] = '2.21.4'
 ext['jackson-bom.version'] = '3.1.4'
-
-// TODO: Remove once Spring Boot 4 manages spring-framework >= 7.0.8.
-// Overrides the Spring Boot BOM's pinned 7.0.7 to address CVE-2026-41842
-// (spring-webflux) and CVE-2026-41850 (spring-expression), both HIGH.
-ext['spring-framework.version'] = '7.0.8'
 
 // TODO: Remove once Temporal ships a release that brings opentelemetry >= 1.62.0.
 // Pins the io.opentelemetry:* family (transitively from temporal-sdk) to 1.62.0

--- a/extractor/hl7log-extractor/build.gradle
+++ b/extractor/hl7log-extractor/build.gradle
@@ -45,6 +45,11 @@ ext['netty.version'] = '4.2.16.Final'
 ext['jackson-2-bom.version'] = '2.21.4'
 ext['jackson-bom.version'] = '3.1.4'
 
+// TODO: Remove once Spring Boot 4 manages spring-framework >= 7.0.8.
+// Overrides the Spring Boot BOM's pinned 7.0.7 to address CVE-2026-41842
+// (spring-webflux) and CVE-2026-41850 (spring-expression), both HIGH.
+ext['spring-framework.version'] = '7.0.8'
+
 // TODO: Remove once Temporal ships a release that brings opentelemetry >= 1.62.0.
 // Pins the io.opentelemetry:* family (transitively from temporal-sdk) to 1.62.0
 // to address the opentelemetry-api vulnerability CVE-2026-45292. Imported via

--- a/hl7-listener/build.gradle
+++ b/hl7-listener/build.gradle
@@ -80,6 +80,9 @@ configurations.all {
 		} else if (g == 'org.apache.tomcat.embed') {
 			details.useVersion '10.1.55' // CVE-2026-41293/-43512/-43515 (CRITICAL) + -34483/-41284/-42498/-43513
 			details.because 'Trivy CRITICAL/HIGH'
+		} else if (g == 'org.springframework' && n.startsWith('spring')) {
+			details.useVersion '6.2.19' // CVE-2026-41842/-41845/-41850 (spring-webmvc, spring-expression)
+			details.because 'Trivy HIGH'
 		}
 	}
 }

--- a/hl7-listener/build.gradle
+++ b/hl7-listener/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.14'
+	id 'org.springframework.boot' version '3.5.16'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -66,7 +66,8 @@ dependencies {
 // are pinned by the camel-spring-boot-dependencies / Spring Boot BOMs; resolutionStrategy
 // runs after BOM resolution, so it overrides those pins unconditionally. All are patch-level
 // bumps within the same minor line. Drop each entry once the managing BOM ships the fix.
-// (spring-boot itself, CVE-2026-40973, is handled by the 3.5.14 plugin bump above.)
+// (spring-boot + spring-framework, incl. CVE-2026-40973 and the spring-webmvc/-expression
+// CVE-2026-41842/-41845/-41850, are handled by the 3.5.16 plugin bump above.)
 configurations.all {
 	resolutionStrategy.eachDependency { details ->
 		def g = details.requested.group
@@ -80,9 +81,6 @@ configurations.all {
 		} else if (g == 'org.apache.tomcat.embed') {
 			details.useVersion '10.1.55' // CVE-2026-41293/-43512/-43515 (CRITICAL) + -34483/-41284/-42498/-43513
 			details.because 'Trivy CRITICAL/HIGH'
-		} else if (g == 'org.springframework' && n.startsWith('spring')) {
-			details.useVersion '6.2.19' // CVE-2026-41842/-41845/-41850 (spring-webmvc, spring-expression)
-			details.because 'Trivy HIGH'
 		}
 	}
 }


### PR DESCRIPTION
A fresh image build pulls the Spring Framework version managed by each service's Spring Boot BOM, which just picked up HIGH advisories:

- hl7-listener (Spring 6.2.18): CVE-2026-41842, CVE-2026-41845 (spring-webmvc), CVE-2026-41850 (spring-expression) -> 6.2.19
- hl7log-extractor (Spring 7.0.7): CVE-2026-41842 (spring-webflux), CVE-2026-41850 (spring-expression) -> 7.0.8

Both are patch bumps within the same minor line, overridden the same way the repo already pins netty/jackson/tomcat: resolutionStrategy for hl7-listener, an ext[...] BOM property for hl7log-extractor. Local rebuild + Trivy scan (same ignore files as the CI gate) shows 0 residual fixable HIGH/CRITICAL for both images.

## Description

### Product
No product or user-facing change. Security patch bump of Spring Framework in
two Java service images.

### Technical
A full rebuild (any change under `.github/` flips `ci=true`) resolves the Spring
Framework version managed by each service's Spring Boot BOM, and those versions
just picked up HIGH advisories:

- hl7-listener (Spring 6.2.18): CVE-2026-41842, CVE-2026-41845 (spring-webmvc),
  CVE-2026-41850 (spring-expression) -> 6.2.19
- hl7log-extractor (Spring 7.0.7): CVE-2026-41842 (spring-webflux),
  CVE-2026-41850 (spring-expression) -> 7.0.8

The published images scan clean because they shipped an older Spring, so the
finding only surfaces on a full rebuild (and would hit main's next full rebuild
too). Both are patch bumps within the same minor line, overridden the same way
the repo already pins netty/jackson/tomcat: `resolutionStrategy` in hl7-listener,
an `ext[...]` BOM property in hl7log-extractor.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
No change. No roles, data visibility, or API paths affected.

##### Appsec
Positive. Clears three HIGH Spring Framework CVEs from both shipped images.

### Performance
No change.

### Data
No change.

### Backward compatibility
Patch bumps within the same Spring Framework minor line (6.2.x, 7.0.x). No API,
data model, or behavior change.

## Testing
Local rebuild of both images + Trivy scan with the same ignore files the CI gate
uses -> 0 residual fixable HIGH/CRITICAL. Confirmed spring-core/webmvc/webflux/
expression resolve to 6.2.19 / 7.0.8 in the built jars.

## Note for reviewers
Main-level fix, same pattern and rationale as #563 and #577. Phase-2 PRs #574 and
#575 fail only on these two images and go green once they rebase onto this.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate