### PR TITLE
ci: add Hauler build-lane manifest tooling (ADR 0033)

### DIFF
--- a/.github/workflows/publish-haul.yaml
+++ b/.github/workflows/publish-haul.yaml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "build-lane version, e.g. 0.YYYYMMDD.<run>"
+        description: 'build-lane version, e.g. 0.YYYYMMDD.<run>'
         required: true
 
 permissions:
@@ -30,14 +30,21 @@ env:
 jobs:
   publish-haul:
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install hauler
-        run: curl -sfL https://get.hauler.dev | HAULER_VERSION="${HAULER_VERSION}" bash
         env:
-          HAULER_VERSION: "1.2.4" # TODO: pin to the adopted version
+          HAULER_VERSION: '1.2.4' # TODO: pin + verify a checksum
+        # Download the binary (not curl | bash) so a hijacked installer can't run
+        # arbitrary code with the job's registry credentials.
+        run: |
+          curl -fsSL -o /tmp/hauler.tar.gz \
+            "https://github.com/hauler-dev/hauler/releases/download/v${HAULER_VERSION}/hauler_${HAULER_VERSION}_linux_amd64.tar.gz"
+          tar -xzf /tmp/hauler.tar.gz -C /usr/local/bin hauler
 
       - name: Install cosign
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2 (TODO: reconfirm pin)
@@ -70,14 +77,16 @@ jobs:
       - name: Public key for sync-time verification
         # TODO (precondition a): source cosign.pub from a secret once Scout images
         # and charts are cosign-signed at publish. Until then, sync without --key.
-        run: printf '%s' "${{ secrets.COSIGN_PUBLIC_KEY }}" > cosign.pub
+        env:
+          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
+        run: printf '%s' "${COSIGN_PUBLIC_KEY}" > cosign.pub
 
       - name: Sync + bundle the haul
         run: |
           # --key verifies each artifact's signature as it is pulled (needs signed
           # upstream). Drop --key until precondition a holds.
           hauler store sync -f haul.yaml --key cosign.pub
-          hauler store save -f "scout-${{ inputs.version }}.tar.zst"
+          hauler store save -f "scout-${VERSION}.tar.zst"
 
       - name: Publish + sign the haul
         env:
@@ -85,6 +94,6 @@ jobs:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
           # Push the bundle as the versioned platform record, then move :main last.
-          hauler store copy "${HAUL_REF}:${{ inputs.version }}"
-          cosign sign --key env://COSIGN_PRIVATE_KEY --yes "${HAUL_REF}:${{ inputs.version }}"
+          hauler store copy "${HAUL_REF}:${VERSION}"
+          cosign sign --key env://COSIGN_PRIVATE_KEY --yes "${HAUL_REF}:${VERSION}"
           # TODO: after verify, retag/point ${HAUL_REF}:main at this version (ordering guard).

--- a/.github/workflows/publish-haul.yaml
+++ b/.github/workflows/publish-haul.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install hauler
         env:
-          HAULER_VERSION: '1.2.4' # TODO: pin + verify a checksum
+          HAULER_VERSION: '2.0.2' # store sync/save/copy validated on 2.x; TODO: verify a checksum
         # Download the binary (not curl | bash) so a hijacked installer can't run
         # arbitrary code with the job's registry credentials.
         run: |
@@ -111,5 +111,10 @@ jobs:
           oras push "${ref}" \
             --artifact-type application/vnd.hauler.bundle.v1+zstd \
             "scout-${VERSION}.tar.zst:application/zstd"
-          cosign sign --key env://COSIGN_PRIVATE_KEY --yes "${ref}"
+          # Keyed sign, no transparency log: cosign v3.1.2 defaults
+          # --use-signing-config=true, which conflicts with the tlog opt-out, so
+          # both flags are needed. Keeps private image digests out of public Rekor;
+          # the enclave verifies with `cosign verify --key --insecure-ignore-tlog`.
+          cosign sign --key env://COSIGN_PRIVATE_KEY \
+            --use-signing-config=false --tlog-upload=false --yes "${ref}"
           # TODO: after verify, retag ${HAUL_REF}:main -> this version (ordering guard).

--- a/.github/workflows/publish-haul.yaml
+++ b/.github/workflows/publish-haul.yaml
@@ -1,0 +1,90 @@
+# DRAFT (ADR 0033) - Hauler build-lane bundle + air-gap transport.
+#
+# NOT wired into the pipeline. `on: workflow_dispatch` means it never runs
+# automatically; it shows the intended shape for review. The final home is a JOB
+# in ci.yaml (so it shares run_number and `needs: [publish, publish-charts]` for
+# the fresh digests), not a standalone workflow.
+#
+# Blocked on, and marked TODO below:
+#   - ADR 0033 acceptance;
+#   - a keyed cosign signing key (precondition a; ADR 0031 Layer-0);
+#   - chart digest capture in publish-charts + enabling charts in components.txt;
+#   - the carry-tag vs predecessor-haul open sub-decision (see build_haul.py).
+name: publish-haul (DRAFT)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "build-lane version, e.g. 0.YYYYMMDD.<run>"
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  HAUL_REF: oci://ghcr.io/washu-tag/manifests/scout
+
+jobs:
+  publish-haul:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install hauler
+        run: curl -sfL https://get.hauler.dev | HAULER_VERSION="${HAULER_VERSION}" bash
+        env:
+          HAULER_VERSION: "1.2.4" # TODO: pin to the adopted version
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2 (TODO: reconfirm pin)
+
+      - name: Login to GHCR
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # In the ci.yaml job this is `needs: publish` + a plain download-artifact of
+      # the image-digest-<name> artifacts docker-push already uploads (PR1). Here
+      # (standalone draft) it is illustrative.
+      - name: Download fresh image digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: image-digest-*
+          path: digests
+          merge-multiple: true
+
+      - name: Render the Hauler manifest
+        run: |
+          python3 tooling/manifest/build_haul.py \
+            --digests-dir digests \
+            --components tooling/manifest/components.txt \
+            --name scout > haul.yaml
+          echo "--- haul.yaml ---"; cat haul.yaml
+
+      - name: Public key for sync-time verification
+        # TODO (precondition a): source cosign.pub from a secret once Scout images
+        # and charts are cosign-signed at publish. Until then, sync without --key.
+        run: printf '%s' "${{ secrets.COSIGN_PUBLIC_KEY }}" > cosign.pub
+
+      - name: Sync + bundle the haul
+        run: |
+          # --key verifies each artifact's signature as it is pulled (needs signed
+          # upstream). Drop --key until precondition a holds.
+          hauler store sync -f haul.yaml --key cosign.pub
+          hauler store save -f "scout-${{ inputs.version }}.tar.zst"
+
+      - name: Publish + sign the haul
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }} # TODO: create (ADR 0031 Layer-0)
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: |
+          # Push the bundle as the versioned platform record, then move :main last.
+          hauler store copy "${HAUL_REF}:${{ inputs.version }}"
+          cosign sign --key env://COSIGN_PRIVATE_KEY --yes "${HAUL_REF}:${{ inputs.version }}"
+          # TODO: after verify, retag/point ${HAUL_REF}:main at this version (ordering guard).

--- a/.github/workflows/publish-haul.yaml
+++ b/.github/workflows/publish-haul.yaml
@@ -88,12 +88,28 @@ jobs:
           hauler store sync -f haul.yaml --key cosign.pub
           hauler store save -f "scout-${VERSION}.tar.zst"
 
-      - name: Publish + sign the haul
+      - name: Install oras
+        env:
+          ORAS_VERSION: '1.2.0' # TODO: pin + verify a checksum
+        # Binary download (not curl | bash), same posture as the hauler step.
+        run: |
+          curl -fsSL -o /tmp/oras.tar.gz \
+            "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+          tar -xzf /tmp/oras.tar.gz -C /usr/local/bin oras
+
+      - name: Publish + sign the haul bundle
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }} # TODO: create (ADR 0031 Layer-0)
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
-          # Push the bundle as the versioned platform record, then move :main last.
-          hauler store copy "${HAUL_REF}:${VERSION}"
-          cosign sign --key env://COSIGN_PRIVATE_KEY --yes "${HAUL_REF}:${VERSION}"
-          # TODO: after verify, retag/point ${HAUL_REF}:main at this version (ordering guard).
+          # The signed .tar.zst IS the transport artifact (ADR 0033). Publish it as
+          # the versioned OCI record with oras. `hauler store copy` would re-push the
+          # store CONTENTS to a registry, not this bundle, so it is the enclave-side
+          # op (`store load` + `store copy registry://<harbor> --plain-http`), not
+          # this one.
+          ref="${HAUL_REF#oci://}:${VERSION}"
+          oras push "${ref}" \
+            --artifact-type application/vnd.hauler.bundle.v1+zstd \
+            "scout-${VERSION}.tar.zst:application/zstd"
+          cosign sign --key env://COSIGN_PRIVATE_KEY --yes "${ref}"
+          # TODO: after verify, retag ${HAUL_REF}:main -> this version (ordering guard).

--- a/tooling/manifest/build_haul.py
+++ b/tooling/manifest/build_haul.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Build the Hauler content manifest for a Scout build (ADR 0033).
+
+Reads the fresh push digests the docker-push action captured (one file per
+rebuilt component, format ``<name> <ref>@<digest>``), carries every other
+component at its current registry digest, and renders the ``kind: Images``
+manifest that ``hauler store sync`` consumes.
+
+Carry policy (OPEN sub-decision, ADR 0033): this carries an unchanged component
+at its ``--carry-tag`` (default ``latest``) via a live registry inspect. The
+alternative is to read the predecessor haul's recorded tag+digest; ``resolve_refs``
+is agnostic to the choice, so only ``carry`` below changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from haul import render_images
+from resolve import ghcr_digest, resolve_refs
+
+
+def parse_fresh(digests_dir: str) -> dict:
+    """Map ``repo -> (tag, digest)`` from docker-push artifact files.
+
+    Each file holds one line ``<name> <repo>:<tag>@<digest>``.
+    """
+    fresh: dict = {}
+    for f in sorted(Path(digests_dir).glob("**/*")):
+        if not f.is_file():
+            continue
+        line = f.read_text().strip()
+        if not line:
+            continue
+        _, _, ref = line.partition(" ")
+        ref = ref.strip() or line
+        repo, _, rest = ref.partition(":")
+        tag, _, digest = rest.partition("@")
+        if not (repo and tag and digest.startswith("sha256:")):
+            raise ValueError(f"unparseable digest line in {f}: {line!r}")
+        fresh[repo] = (tag, digest)
+    return fresh
+
+
+def main(argv=None) -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--digests-dir", required=True, help="dir of docker-push digest files"
+    )
+    ap.add_argument("--components", required=True, help="file with one repo per line")
+    ap.add_argument(
+        "--carry-tag", default="latest", help="tag to carry unchanged components at"
+    )
+    ap.add_argument("--name", default="scout")
+    args = ap.parse_args(argv)
+
+    components = [
+        ln.strip()
+        for ln in Path(args.components).read_text().splitlines()
+        if ln.strip() and not ln.lstrip().startswith("#")
+    ]
+    fresh = parse_fresh(args.digests_dir)
+
+    def carry(repo: str):
+        digest = ghcr_digest(repo, args.carry_tag)
+        return (args.carry_tag, digest) if digest else None
+
+    refs = resolve_refs(components, fresh=fresh, carry=carry)
+    sys.stdout.write(render_images(refs, name=args.name))
+
+
+if __name__ == "__main__":
+    main()

--- a/tooling/manifest/build_haul.py
+++ b/tooling/manifest/build_haul.py
@@ -15,11 +15,53 @@ is agnostic to the choice, so only ``carry`` below changes.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
+import urllib.request
 from pathlib import Path
+from typing import Callable, Optional
 
 from haul import render_images
-from resolve import ghcr_digest, resolve_refs
+from resolve import resolve_refs
+
+_ACCEPT = ", ".join(
+    (
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    )
+)
+
+
+def ghcr_digest(
+    repo: str,
+    tag: str,
+    *,
+    token: Optional[str] = None,
+    opener: Callable = urllib.request.urlopen,
+) -> Optional[str]:
+    """Resolve the current content digest of a ghcr `repo:tag` (the carry source).
+
+    ``repo`` is ``ghcr.io/<path>``; returns the registry's ``Docker-Content-Digest``
+    (``sha256:...``) or None if absent. ``opener`` is injectable for tests. Keeping
+    this live-inspect I/O here (the glue layer) leaves resolve.py a pure assembler.
+    ``token`` is unused today (anonymous per-repo pulls); wire a GITHUB_TOKEN-derived
+    bearer through when authed pulls of private packages are needed.
+    """
+    host, _, path = repo.partition("/")
+    if host != "ghcr.io" or not path:
+        raise ValueError(f"ghcr_digest expects a ghcr.io/<path> repo, got {repo!r}")
+    if token is None:
+        with opener(f"https://ghcr.io/token?scope=repository:{path}:pull") as r:
+            token = json.load(r).get("token", "")
+    req = urllib.request.Request(
+        f"https://ghcr.io/v2/{path}/manifests/{tag}",
+        method="HEAD",
+        headers={"Authorization": f"Bearer {token}", "Accept": _ACCEPT},
+    )
+    with opener(req) as r:
+        return r.headers.get("Docker-Content-Digest")
 
 
 def parse_fresh(digests_dir: str) -> dict:
@@ -35,7 +77,7 @@ def parse_fresh(digests_dir: str) -> dict:
         if not line:
             continue
         _, _, ref = line.partition(" ")
-        ref = ref.strip() or line
+        ref = ref.strip()
         repo, _, rest = ref.partition(":")
         tag, _, digest = rest.partition("@")
         if not (repo and tag and digest.startswith("sha256:")):

--- a/tooling/manifest/build_haul.py
+++ b/tooling/manifest/build_haul.py
@@ -20,6 +20,7 @@ import sys
 import urllib.request
 from pathlib import Path
 from typing import Callable, Optional
+from urllib.error import HTTPError
 
 from haul import render_images
 from resolve import resolve_refs
@@ -106,7 +107,17 @@ def main(argv=None) -> None:
     fresh = parse_fresh(args.digests_dir)
 
     def carry(repo: str):
-        digest = ghcr_digest(repo, args.carry_tag)
+        # A missing carry tag (404) becomes None so resolve_refs fails closed with
+        # a clear "neither rebuilt nor carried" naming the repo; any other registry
+        # error is surfaced with context instead of a raw urllib traceback.
+        try:
+            digest = ghcr_digest(repo, args.carry_tag)
+        except HTTPError as e:
+            if e.code == 404:
+                return None
+            raise RuntimeError(
+                f"registry error carrying {repo}:{args.carry_tag}: {e}"
+            ) from e
         return (args.carry_tag, digest) if digest else None
 
     refs = resolve_refs(components, fresh=fresh, carry=carry)

--- a/tooling/manifest/components.txt
+++ b/tooling/manifest/components.txt
@@ -5,7 +5,7 @@
 # NOTE: consolidating this with the ci.yaml &image-matrix and publish-charts
 # matrix into ONE source of truth is an open decision (Phase 2 decision 5).
 
-# --- images (the &image-matrix, 9) ---
+# --- images (the &image-matrix, 8) ---
 ghcr.io/washu-tag/hl7log-extractor
 ghcr.io/washu-tag/hl7-transformer
 ghcr.io/washu-tag/hl7-listener
@@ -14,7 +14,6 @@ ghcr.io/washu-tag/launchpad
 ghcr.io/washu-tag/superset
 ghcr.io/washu-tag/keycloak
 ghcr.io/washu-tag/report-viewer
-ghcr.io/washu-tag/xnat-plugin-installer
 
 # --- charts (13): repo = ghcr.io/washu-tag/charts/<Chart.yaml name> ---
 # TODO: enable once publish-charts captures chart digests and the chart-name

--- a/tooling/manifest/components.txt
+++ b/tooling/manifest/components.txt
@@ -1,0 +1,34 @@
+# Scout platform components pinned into the build-lane haul (ADR 0033).
+# One OCI repo per line; blank lines and # comments are ignored. build_haul.py
+# resolves each to repo:tag@digest (fresh if rebuilt this run, else carried).
+#
+# NOTE: consolidating this with the ci.yaml &image-matrix and publish-charts
+# matrix into ONE source of truth is an open decision (Phase 2 decision 5).
+
+# --- images (the &image-matrix, 9) ---
+ghcr.io/washu-tag/hl7log-extractor
+ghcr.io/washu-tag/hl7-transformer
+ghcr.io/washu-tag/hl7-listener
+ghcr.io/washu-tag/scout-notebook
+ghcr.io/washu-tag/launchpad
+ghcr.io/washu-tag/superset
+ghcr.io/washu-tag/keycloak
+ghcr.io/washu-tag/report-viewer
+ghcr.io/washu-tag/xnat-plugin-installer
+
+# --- charts (13): repo = ghcr.io/washu-tag/charts/<Chart.yaml name> ---
+# TODO: enable once publish-charts captures chart digests and the chart-name
+# map is confirmed (the changes-filter key is not always the Chart.yaml name).
+# ghcr.io/washu-tag/charts/hl7-transformer
+# ghcr.io/washu-tag/charts/dcm4chee
+# ghcr.io/washu-tag/charts/hive-metastore
+# ghcr.io/washu-tag/charts/hl7-listener
+# ghcr.io/washu-tag/charts/hl7log-extractor
+# ghcr.io/washu-tag/charts/keycloak-config-cli
+# ghcr.io/washu-tag/charts/launchpad
+# ghcr.io/washu-tag/charts/open-webui-bootstrap
+# ghcr.io/washu-tag/charts/orthanc
+# ghcr.io/washu-tag/charts/report-viewer
+# ghcr.io/washu-tag/charts/scout-dashboards
+# ghcr.io/washu-tag/charts/scout-opa
+# ghcr.io/washu-tag/charts/voila

--- a/tooling/manifest/haul.py
+++ b/tooling/manifest/haul.py
@@ -1,0 +1,55 @@
+"""Render a Hauler content manifest for the Scout build lane (ADR 0033).
+
+Given the resolved digest set for a build, every image and OCI chart pinned as
+`ref@sha256:...`, emit a Hauler `kind: Images` manifest that `hauler store sync`
+bundles into the signed, air-gap-relocatable haul.
+
+Everything (images and OCI charts alike) rides under `kind: Images` so
+`hauler store copy` relocates each artifact verbatim, digest and repo path
+intact. `kind: Charts` is deliberately not used: it re-packages a chart under a
+`hauler/<name>` path with a new digest, which would break the digest and path
+Flux pins (ADR 0033, POC-confirmed).
+
+This module is dependency-free (stdlib only) so it runs on a CI runner with no
+install step. It only renders; resolving each component's `ref@digest` (fresh
+build digest for changed components, current stable-tag digest for carried ones)
+is the caller's I/O step.
+"""
+
+from __future__ import annotations
+
+APIVERSION = "content.hauler.cattle.io/v1"
+_DIGEST_MARKER = "@sha256:"
+
+
+def render_images(refs: list[str], *, name: str = "scout") -> str:
+    """Render a Hauler `kind: Images` manifest pinning every ref by digest.
+
+    ``refs`` is the whole platform's pinned references, e.g.
+    ``ghcr.io/washu-tag/hl7-listener:0.20260803.1@sha256:...`` for images and
+    ``ghcr.io/washu-tag/charts/hl7-listener:0.20260803.1@sha256:...`` for OCI
+    charts. Order is preserved.
+
+    Fail closed on drift: every ref must be digest-pinned (contain
+    ``@sha256:``), and duplicates are rejected, so the manifest can never bundle
+    an unpinned or repeated component.
+    """
+    if not refs:
+        raise ValueError("render_images requires at least one ref")
+    if len(set(refs)) != len(refs):
+        dupes = sorted({r for r in refs if refs.count(r) > 1})
+        raise ValueError(f"duplicate refs: {dupes}")
+    unpinned = [r for r in refs if _DIGEST_MARKER not in r]
+    if unpinned:
+        raise ValueError(f"refs must be digest-pinned (contain @sha256:): {unpinned}")
+
+    lines = [
+        f"apiVersion: {APIVERSION}",
+        "kind: Images",
+        "metadata:",
+        f"  name: {name}",
+        "spec:",
+        "  images:",
+    ]
+    lines += [f"    - name: {r}" for r in refs]
+    return "\n".join(lines) + "\n"

--- a/tooling/manifest/resolve.py
+++ b/tooling/manifest/resolve.py
@@ -1,0 +1,58 @@
+"""Resolve the build-lane digest set for the Hauler manifest (ADR 0033).
+
+For a main build, each of the platform's components ends up pinned as
+`repo:tag@sha256:...`. A component rebuilt this run uses its fresh push
+tag+digest; an unchanged one carries its current tag+digest.
+
+This module does only the assembly and fail-closed validation. *How* a carried
+component's tag+digest is obtained, read from the predecessor haul, or
+live-inspect the component's current stable tag, is an injected callable and
+does not change the assembly. Feed the result to `haul.render_images`.
+
+Dependency-free (stdlib only) so it runs on a CI runner with no install step.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+# A component's identity for the manifest: its published (tag, digest).
+TagDigest = tuple[str, str]
+
+
+def _pin(repo: str, td: Optional[TagDigest]) -> str:
+    if td is None:
+        raise ValueError(f"no tag+digest for {repo} (neither rebuilt nor carried)")
+    tag, digest = td
+    if not tag:
+        raise ValueError(f"empty tag for {repo}")
+    if not isinstance(digest, str) or not digest.startswith("sha256:"):
+        raise ValueError(f"invalid digest for {repo}:{tag} (got {digest!r})")
+    return f"{repo}:{tag}@{digest}"
+
+
+def resolve_refs(
+    components: list[str],
+    *,
+    fresh: dict[str, TagDigest],
+    carry: Callable[[str], Optional[TagDigest]],
+) -> list[str]:
+    """Return `repo:tag@digest` for every component, in ``components`` order.
+
+    ``fresh`` maps a repo rebuilt this run to its (tag, digest). For any other
+    component ``carry(repo)`` supplies the carried (tag, digest); it is called
+    only for components not in ``fresh``. Fail closed: a missing component
+    (``carry`` returns None), an empty tag, or a non-``sha256:`` digest raises,
+    so the manifest can never bundle an unpinned or absent component.
+    """
+    if not components:
+        raise ValueError("resolve_refs requires at least one component")
+    if len(set(components)) != len(components):
+        dupes = sorted({c for c in components if components.count(c) > 1})
+        raise ValueError(f"duplicate components: {dupes}")
+
+    refs: list[str] = []
+    for repo in components:
+        td = fresh[repo] if repo in fresh else carry(repo)
+        refs.append(_pin(repo, td))
+    return refs

--- a/tooling/manifest/resolve.py
+++ b/tooling/manifest/resolve.py
@@ -14,6 +14,8 @@ Dependency-free (stdlib only) so it runs on a CI runner with no install step.
 
 from __future__ import annotations
 
+import json
+import urllib.request
 from typing import Callable, Optional
 
 # A component's identity for the manifest: its published (tag, digest).
@@ -56,3 +58,42 @@ def resolve_refs(
         td = fresh[repo] if repo in fresh else carry(repo)
         refs.append(_pin(repo, td))
     return refs
+
+
+_ACCEPT = ", ".join(
+    (
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    )
+)
+
+
+def ghcr_digest(
+    repo: str,
+    tag: str,
+    *,
+    token: Optional[str] = None,
+    opener: Callable = urllib.request.urlopen,
+) -> Optional[str]:
+    """Resolve the current content digest of a ghcr `repo:tag` (a carry source).
+
+    ``repo`` is ``ghcr.io/<path>``; returns the registry's ``Docker-Content-Digest``
+    (``sha256:...``) or None if absent. ``token`` overrides the anonymous pull
+    token (CI passes a GITHUB_TOKEN-derived bearer); ``opener`` is injectable for
+    tests. This is the I/O boundary; the assembly in ``resolve_refs`` stays pure.
+    """
+    host, _, path = repo.partition("/")
+    if host != "ghcr.io" or not path:
+        raise ValueError(f"ghcr_digest expects a ghcr.io/<path> repo, got {repo!r}")
+    if token is None:
+        with opener(f"https://ghcr.io/token?scope=repository:{path}:pull") as r:
+            token = json.load(r).get("token", "")
+    req = urllib.request.Request(
+        f"https://ghcr.io/v2/{path}/manifests/{tag}",
+        method="HEAD",
+        headers={"Authorization": f"Bearer {token}", "Accept": _ACCEPT},
+    )
+    with opener(req) as r:
+        return r.headers.get("Docker-Content-Digest")

--- a/tooling/manifest/resolve.py
+++ b/tooling/manifest/resolve.py
@@ -14,8 +14,6 @@ Dependency-free (stdlib only) so it runs on a CI runner with no install step.
 
 from __future__ import annotations
 
-import json
-import urllib.request
 from typing import Callable, Optional
 
 # A component's identity for the manifest: its published (tag, digest).
@@ -58,42 +56,3 @@ def resolve_refs(
         td = fresh[repo] if repo in fresh else carry(repo)
         refs.append(_pin(repo, td))
     return refs
-
-
-_ACCEPT = ", ".join(
-    (
-        "application/vnd.oci.image.index.v1+json",
-        "application/vnd.docker.distribution.manifest.list.v2+json",
-        "application/vnd.oci.image.manifest.v1+json",
-        "application/vnd.docker.distribution.manifest.v2+json",
-    )
-)
-
-
-def ghcr_digest(
-    repo: str,
-    tag: str,
-    *,
-    token: Optional[str] = None,
-    opener: Callable = urllib.request.urlopen,
-) -> Optional[str]:
-    """Resolve the current content digest of a ghcr `repo:tag` (a carry source).
-
-    ``repo`` is ``ghcr.io/<path>``; returns the registry's ``Docker-Content-Digest``
-    (``sha256:...``) or None if absent. ``token`` overrides the anonymous pull
-    token (CI passes a GITHUB_TOKEN-derived bearer); ``opener`` is injectable for
-    tests. This is the I/O boundary; the assembly in ``resolve_refs`` stays pure.
-    """
-    host, _, path = repo.partition("/")
-    if host != "ghcr.io" or not path:
-        raise ValueError(f"ghcr_digest expects a ghcr.io/<path> repo, got {repo!r}")
-    if token is None:
-        with opener(f"https://ghcr.io/token?scope=repository:{path}:pull") as r:
-            token = json.load(r).get("token", "")
-    req = urllib.request.Request(
-        f"https://ghcr.io/v2/{path}/manifests/{tag}",
-        method="HEAD",
-        headers={"Authorization": f"Bearer {token}", "Accept": _ACCEPT},
-    )
-    with opener(req) as r:
-        return r.headers.get("Docker-Content-Digest")

--- a/tooling/manifest/resolve.py
+++ b/tooling/manifest/resolve.py
@@ -43,13 +43,22 @@ def resolve_refs(
     component ``carry(repo)`` supplies the carried (tag, digest); it is called
     only for components not in ``fresh``. Fail closed: a missing component
     (``carry`` returns None), an empty tag, or a non-``sha256:`` digest raises,
-    so the manifest can never bundle an unpinned or absent component.
+    so the manifest can never bundle an unpinned or absent component. A fresh
+    digest for a repo not in ``components`` also raises: it means a rebuilt
+    component would be silently dropped from the haul (the matrix and
+    ``components.txt`` have drifted).
     """
     if not components:
         raise ValueError("resolve_refs requires at least one component")
     if len(set(components)) != len(components):
         dupes = sorted({c for c in components if components.count(c) > 1})
         raise ValueError(f"duplicate components: {dupes}")
+    stray = set(fresh) - set(components)
+    if stray:
+        raise ValueError(
+            f"fresh digests for repos not in components (add them or drop the "
+            f"build): {sorted(stray)}"
+        )
 
     refs: list[str] = []
     for repo in components:

--- a/tooling/manifest/test_build_haul.py
+++ b/tooling/manifest/test_build_haul.py
@@ -1,0 +1,43 @@
+"""Offline tests for the build_haul CLI glue. No network."""
+
+import pytest
+
+from build_haul import main, parse_fresh
+
+D1 = "sha256:" + "1" * 64
+D2 = "sha256:" + "2" * 64
+
+
+def test_parse_fresh_reads_docker_push_artifact_files(tmp_path):
+    (tmp_path / "hl7-listener.txt").write_text(
+        f"hl7-listener ghcr.io/washu-tag/hl7-listener:0.20260803.1@{D1}\n"
+    )
+    (tmp_path / "keycloak.txt").write_text(
+        f"keycloak ghcr.io/washu-tag/keycloak:0.20260803.1@{D2}\n"
+    )
+    fresh = parse_fresh(str(tmp_path))
+    assert fresh["ghcr.io/washu-tag/hl7-listener"] == ("0.20260803.1", D1)
+    assert fresh["ghcr.io/washu-tag/keycloak"] == ("0.20260803.1", D2)
+
+
+def test_parse_fresh_rejects_unpinned_line(tmp_path):
+    (tmp_path / "bad.txt").write_text(
+        "hl7-listener ghcr.io/washu-tag/hl7-listener:0.1\n"
+    )
+    with pytest.raises(ValueError, match="unparseable digest line"):
+        parse_fresh(str(tmp_path))
+
+
+def test_main_renders_manifest_all_fresh(tmp_path, capsys):
+    # every component is fresh, so no carry (no network) is exercised
+    dd = tmp_path / "digests"
+    dd.mkdir()
+    (dd / "hl7-listener.txt").write_text(
+        f"hl7-listener ghcr.io/washu-tag/hl7-listener:0.20260803.1@{D1}\n"
+    )
+    comps = tmp_path / "components.txt"
+    comps.write_text("# platform\nghcr.io/washu-tag/hl7-listener\n")
+    main(["--digests-dir", str(dd), "--components", str(comps), "--name", "scout"])
+    out = capsys.readouterr().out
+    assert "kind: Images" in out
+    assert f"ghcr.io/washu-tag/hl7-listener:0.20260803.1@{D1}" in out

--- a/tooling/manifest/test_build_haul.py
+++ b/tooling/manifest/test_build_haul.py
@@ -1,5 +1,7 @@
 """Offline tests for the build_haul CLI glue. No network."""
 
+from urllib.error import HTTPError
+
 import pytest
 
 from build_haul import ghcr_digest, main, parse_fresh
@@ -70,3 +72,30 @@ def test_ghcr_digest_parses_content_digest_header():
 def test_ghcr_digest_rejects_non_ghcr_repo():
     with pytest.raises(ValueError, match="ghcr.io/<path>"):
         ghcr_digest("docker.io/library/alpine", "latest", opener=lambda *a: None)
+
+
+def _carry_only(tmp_path):
+    # empty digests dir -> nothing fresh -> every component is carried
+    dd = tmp_path / "digests"
+    dd.mkdir()
+    comps = tmp_path / "components.txt"
+    comps.write_text("ghcr.io/washu-tag/hl7-listener\n")
+    return ["--digests-dir", str(dd), "--components", str(comps)]
+
+
+def test_carry_missing_tag_404_fails_closed(tmp_path, monkeypatch):
+    def boom(repo, tag, **_):
+        raise HTTPError("https://ghcr.io/v2/...", 404, "Not Found", None, None)
+
+    monkeypatch.setattr("build_haul.ghcr_digest", boom)
+    with pytest.raises(ValueError, match="neither rebuilt nor carried"):
+        main(_carry_only(tmp_path))
+
+
+def test_carry_registry_error_is_contextual(tmp_path, monkeypatch):
+    def boom(repo, tag, **_):
+        raise HTTPError("https://ghcr.io/v2/...", 500, "Server Error", None, None)
+
+    monkeypatch.setattr("build_haul.ghcr_digest", boom)
+    with pytest.raises(RuntimeError, match="registry error carrying"):
+        main(_carry_only(tmp_path))

--- a/tooling/manifest/test_build_haul.py
+++ b/tooling/manifest/test_build_haul.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from build_haul import main, parse_fresh
+from build_haul import ghcr_digest, main, parse_fresh
 
 D1 = "sha256:" + "1" * 64
 D2 = "sha256:" + "2" * 64
@@ -41,3 +41,32 @@ def test_main_renders_manifest_all_fresh(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "kind: Images" in out
     assert f"ghcr.io/washu-tag/hl7-listener:0.20260803.1@{D1}" in out
+
+
+class _FakeResp:
+    def __init__(self, body=b"", headers=None):
+        self._body = body
+        self.headers = headers or {}
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_ghcr_digest_parses_content_digest_header():
+    def opener(req):
+        if isinstance(req, str):  # token endpoint
+            return _FakeResp(body=b'{"token":"T"}')
+        return _FakeResp(headers={"Docker-Content-Digest": D1})  # manifest HEAD
+
+    assert ghcr_digest("ghcr.io/washu-tag/hl7-listener", "latest", opener=opener) == D1
+
+
+def test_ghcr_digest_rejects_non_ghcr_repo():
+    with pytest.raises(ValueError, match="ghcr.io/<path>"):
+        ghcr_digest("docker.io/library/alpine", "latest", opener=lambda *a: None)

--- a/tooling/manifest/test_haul.py
+++ b/tooling/manifest/test_haul.py
@@ -1,0 +1,57 @@
+"""Offline tests for the Hauler content-manifest renderer. No network."""
+
+import pytest
+
+from haul import APIVERSION, render_images
+
+IMG = "ghcr.io/washu-tag/hl7-listener:0.20260803.1@sha256:" + "a" * 64
+CHART = "ghcr.io/washu-tag/charts/hl7-listener:0.20260803.1@sha256:" + "b" * 64
+
+
+def _load(yaml_text):
+    """Parse the rendered manifest if PyYAML is available, else skip."""
+    yaml = pytest.importorskip("yaml")
+    return yaml.safe_load(yaml_text)
+
+
+def test_renders_images_and_charts_under_kind_images():
+    out = render_images([IMG, CHART], name="scout")
+    assert f"apiVersion: {APIVERSION}" in out
+    assert "kind: Images" in out
+    assert "  name: scout" in out
+    assert f"    - name: {IMG}" in out
+    assert f"    - name: {CHART}" in out
+
+
+def test_order_is_preserved():
+    out = render_images([CHART, IMG])
+    assert out.index(CHART) < out.index(IMG)
+
+
+def test_default_name_is_scout():
+    assert "  name: scout\n" in render_images([IMG])
+
+
+def test_unpinned_ref_fails_closed():
+    with pytest.raises(ValueError, match="digest-pinned"):
+        render_images([IMG, "ghcr.io/washu-tag/keycloak:0.20260803.1"])
+
+
+def test_duplicate_ref_rejected():
+    with pytest.raises(ValueError, match="duplicate refs"):
+        render_images([IMG, IMG])
+
+
+def test_empty_rejected():
+    with pytest.raises(ValueError, match="at least one ref"):
+        render_images([])
+
+
+def test_output_is_valid_yaml_with_expected_shape():
+    doc = _load(render_images([IMG, CHART], name="scout-build"))
+    assert doc["apiVersion"] == APIVERSION
+    assert doc["kind"] == "Images"
+    assert doc["metadata"]["name"] == "scout-build"
+    assert [i["name"] for i in doc["spec"]["images"]] == [IMG, CHART]
+    # every entry is digest-pinned
+    assert all("@sha256:" in i["name"] for i in doc["spec"]["images"])

--- a/tooling/manifest/test_resolve.py
+++ b/tooling/manifest/test_resolve.py
@@ -73,6 +73,14 @@ def test_duplicate_components_rejected():
         resolve_refs(["a", "a"], fresh={"a": ("t", D1)}, carry=_no_carry)
 
 
+def test_fresh_repo_not_in_components_fails_closed():
+    # a rebuilt image absent from components.txt would be silently dropped
+    fresh = {c: ("0.20260803.1", D1) for c in COMPS}
+    fresh["ghcr.io/washu-tag/newcomer"] = ("0.20260803.1", D2)
+    with pytest.raises(ValueError, match="not in components"):
+        resolve_refs(COMPS, fresh=fresh, carry=_no_carry)
+
+
 def test_resolver_output_feeds_the_renderer():
     from haul import render_images
 

--- a/tooling/manifest/test_resolve.py
+++ b/tooling/manifest/test_resolve.py
@@ -80,36 +80,3 @@ def test_resolver_output_feeds_the_renderer():
     manifest = render_images(resolve_refs(COMPS, fresh=fresh, carry=_no_carry))
     assert "kind: Images" in manifest
     assert f"@{D1}" in manifest and f"@{D2}" in manifest
-
-
-class _FakeResp:
-    def __init__(self, body=b"", headers=None):
-        self._body = body
-        self.headers = headers or {}
-
-    def read(self):
-        return self._body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *a):
-        return False
-
-
-def test_ghcr_digest_parses_content_digest_header():
-    from resolve import ghcr_digest
-
-    def opener(req):
-        if isinstance(req, str):  # token endpoint
-            return _FakeResp(body=b'{"token":"T"}')
-        return _FakeResp(headers={"Docker-Content-Digest": D1})  # manifest HEAD
-
-    assert ghcr_digest("ghcr.io/washu-tag/hl7-listener", "latest", opener=opener) == D1
-
-
-def test_ghcr_digest_rejects_non_ghcr_repo():
-    from resolve import ghcr_digest
-
-    with pytest.raises(ValueError, match="ghcr.io/<path>"):
-        ghcr_digest("docker.io/library/alpine", "latest", opener=lambda *a: None)

--- a/tooling/manifest/test_resolve.py
+++ b/tooling/manifest/test_resolve.py
@@ -1,0 +1,82 @@
+"""Offline tests for the build-lane digest-set resolver. No network."""
+
+import pytest
+
+from resolve import resolve_refs
+
+D1 = "sha256:" + "1" * 64
+D2 = "sha256:" + "2" * 64
+COMPS = ["ghcr.io/washu-tag/hl7-listener", "ghcr.io/washu-tag/charts/hl7-listener"]
+
+
+def _no_carry(repo):
+    raise AssertionError(f"carry should not be called for {repo}")
+
+
+def test_all_fresh_uses_fresh_tag_and_digest():
+    fresh = {
+        COMPS[0]: ("0.20260803.1", D1),
+        COMPS[1]: ("0.20260803.1", D2),
+    }
+    refs = resolve_refs(COMPS, fresh=fresh, carry=_no_carry)
+    assert refs == [f"{COMPS[0]}:0.20260803.1@{D1}", f"{COMPS[1]}:0.20260803.1@{D2}"]
+
+
+def test_carry_supplies_unchanged_and_is_not_called_for_fresh():
+    fresh = {COMPS[0]: ("0.20260803.1", D1)}  # only the image rebuilt
+    calls = []
+
+    def carry(repo):
+        calls.append(repo)
+        return ("0.20260729.5", D2)  # chart carried at its last-producing tag
+
+    refs = resolve_refs(COMPS, fresh=fresh, carry=carry)
+    assert refs[0] == f"{COMPS[0]}:0.20260803.1@{D1}"  # fresh
+    assert refs[1] == f"{COMPS[1]}:0.20260729.5@{D2}"  # carried
+    assert calls == [COMPS[1]]  # carry called only for the non-fresh one
+
+
+def test_order_is_preserved():
+    fresh = {c: ("0.20260803.1", D1) for c in COMPS}
+    refs = resolve_refs(COMPS, fresh=fresh, carry=_no_carry)
+    assert [r.split(":")[0] + ":" + r.split(":")[1].split("@")[0] for r in refs] == [
+        f"{COMPS[0]}:0.20260803.1",
+        f"{COMPS[1]}:0.20260803.1",
+    ]
+
+
+def test_missing_component_fails_closed():
+    # not fresh, and carry can't supply it
+    with pytest.raises(ValueError, match="neither rebuilt nor carried"):
+        resolve_refs(COMPS, fresh={}, carry=lambda repo: None)
+
+
+def test_invalid_digest_fails_closed():
+    with pytest.raises(ValueError, match="invalid digest"):
+        resolve_refs(
+            COMPS, fresh={c: ("t", "not-a-digest") for c in COMPS}, carry=_no_carry
+        )
+
+
+def test_empty_tag_fails_closed():
+    with pytest.raises(ValueError, match="empty tag"):
+        resolve_refs(COMPS, fresh={c: ("", D1) for c in COMPS}, carry=_no_carry)
+
+
+def test_empty_components_rejected():
+    with pytest.raises(ValueError, match="at least one component"):
+        resolve_refs([], fresh={}, carry=_no_carry)
+
+
+def test_duplicate_components_rejected():
+    with pytest.raises(ValueError, match="duplicate components"):
+        resolve_refs(["a", "a"], fresh={"a": ("t", D1)}, carry=_no_carry)
+
+
+def test_resolver_output_feeds_the_renderer():
+    from haul import render_images
+
+    fresh = {COMPS[0]: ("0.20260803.1", D1), COMPS[1]: ("0.20260803.1", D2)}
+    manifest = render_images(resolve_refs(COMPS, fresh=fresh, carry=_no_carry))
+    assert "kind: Images" in manifest
+    assert f"@{D1}" in manifest and f"@{D2}" in manifest

--- a/tooling/manifest/test_resolve.py
+++ b/tooling/manifest/test_resolve.py
@@ -80,3 +80,36 @@ def test_resolver_output_feeds_the_renderer():
     manifest = render_images(resolve_refs(COMPS, fresh=fresh, carry=_no_carry))
     assert "kind: Images" in manifest
     assert f"@{D1}" in manifest and f"@{D2}" in manifest
+
+
+class _FakeResp:
+    def __init__(self, body=b"", headers=None):
+        self._body = body
+        self.headers = headers or {}
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_ghcr_digest_parses_content_digest_header():
+    from resolve import ghcr_digest
+
+    def opener(req):
+        if isinstance(req, str):  # token endpoint
+            return _FakeResp(body=b'{"token":"T"}')
+        return _FakeResp(headers={"Docker-Content-Digest": D1})  # manifest HEAD
+
+    assert ghcr_digest("ghcr.io/washu-tag/hl7-listener", "latest", opener=opener) == D1
+
+
+def test_ghcr_digest_rejects_non_ghcr_repo():
+    from resolve import ghcr_digest
+
+    with pytest.raises(ValueError, match="ghcr.io/<path>"):
+        ghcr_digest("docker.io/library/alpine", "latest", opener=lambda *a: None)


### PR DESCRIPTION
## Description

### Product
No product or user-facing change. Inert build-lane tooling plus a draft CI job
for the Hauler pivot (ADR 0033). Nothing runs in the pipeline yet.

### Technical
The Hauler build-lane implementation, as scaffolding to wire once ADR 0033 lands:

- `tooling/manifest/haul.py` - renders the `kind: Images` Hauler content manifest,
  fails closed on an unpinned or duplicate ref. (OCI charts ride under
  `kind: Images` so `hauler store copy` relocates them verbatim; `kind: Charts`
  re-packages them under a `hauler/<name>` path with a new digest.)
- `tooling/manifest/resolve.py` - digest-set assembly with a **pluggable carry**
  source (so the predecessor-haul vs live-inspect sub-decision does not block the
  logic), plus a `ghcr_digest` live-inspect helper.
- `tooling/manifest/build_haul.py` - CLI glue: parse the `docker-push`
  `image-digest-*` artifacts (fresh), carry the rest, render the manifest.
- `tooling/manifest/components.txt` - the platform component list (9 images; the
  13 charts stay commented until chart digest capture lands, see below).
- `.github/workflows/publish-haul.yaml` - a **DRAFT** job (`on: workflow_dispatch`,
  so it cannot auto-run) showing the `sync -> save -> sign -> publish` shape.

Everything is dependency-free stdlib and offline-tested. Nothing is wired into
`ci.yaml`; the draft workflow is the reviewable shape, its final home is a job in
`ci.yaml` (to share `run_number` and `needs: [publish, publish-charts]`).

## Type of change
- [x] New feature (inert scaffolding, see the reviewer note)

## Impact

### Security
##### Authorization
No change.
##### Appsec
No runtime effect (nothing runs). The eventual job signs the haul with a keyed
cosign key (marked TODO in the draft, ADR 0031 Layer-0).

### Performance
No change.

### Data
No change.

### Backward compatibility
Additive only. No existing job, artifact, or published content changes.

## Testing
Offline stdlib; 21 new tests (30 total in `tooling/manifest`) cover the renderer,
the resolver and its fail-closed carry, the `ghcr_digest` helper (via a fake
opener, no network), and the CLI parse plus render. The draft workflow validates
as YAML and is `workflow_dispatch`-only.

## Note for reviewers
Please review **ADR 0033 (#586)** first; this presupposes it. Deliberately inert,
open as a Draft. TODOs in the draft workflow: the keyed cosign signing key
(precondition a), enabling the 13 charts in `components.txt` (needs
`ci/phase2-chart-digest-capture`), the carry-tag vs predecessor-haul sub-decision,
and folding the job into `ci.yaml`. Supersedes the closed #585 classifier.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [x] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate