### PR TITLE
fix(scout-notebook): pin setuptools and msgpack above base to clear trivy HIGH findings

### DIFF
--- a/helm/scout-notebook/Dockerfile
+++ b/helm/scout-notebook/Dockerfile
@@ -1,11 +1,7 @@
 FROM quay.io/jupyter/scipy-notebook:python-3.13.14
 
-# Platform packages + Jupyter extensions via mamba. Everything else
-# (torch, transformers, scikit-learn, etc.) is user-installed via the
-# package proxy. gitpython, jupyterlab, setuptools, and msgpack-python are
-# pinned above the scipy-notebook base to clear Trivy HIGH findings; drop each
-# pin once a newer base ships the fix (Trivy will re-flag if a pin is dropped
-# too early).
+# Platform packages + Jupyter extensions. gitpython/jupyterlab pinned above the
+# base to clear Trivy HIGH findings; drop when the base ships the fix.
 RUN mamba install -y -n base \
     trino-python-client \
     voila \
@@ -15,11 +11,13 @@ RUN mamba install -y -n base \
     nb_conda_kernels \
     'gitpython>=3.1.57' \
     'jupyterlab>=4.6.2' \
-    'setuptools>=78.1.1' \
-    'msgpack-python>=1.2.1' \
     && mamba clean -afy \
     && fix-permissions "${CONDA_DIR}" \
     && fix-permissions "/home/${NB_USER}"
+
+# pip-managed in the base, so mamba can't bump them. Pinned for Trivy HIGH
+# findings; drop when the base ships the fix.
+RUN pip install --no-cache-dir --upgrade 'setuptools>=78.1.1' 'msgpack>=1.2.1'
 
 # Scout SDK (scout.query, scout.connect, scout.current_user). Installed
 # system-wide so it's importable from every kernel without per-user setup.

--- a/helm/scout-notebook/Dockerfile
+++ b/helm/scout-notebook/Dockerfile
@@ -2,9 +2,10 @@ FROM quay.io/jupyter/scipy-notebook:python-3.13.14
 
 # Platform packages + Jupyter extensions via mamba. Everything else
 # (torch, transformers, scikit-learn, etc.) is user-installed via the
-# package proxy. gitpython and jupyterlab are pinned above the scipy-notebook
-# base to clear Trivy HIGH findings (GitPython >=3.1.57, JupyterLab >=4.6.2);
-# drop the pins once a newer base ships them.
+# package proxy. gitpython, jupyterlab, setuptools, and msgpack-python are
+# pinned above the scipy-notebook base to clear Trivy HIGH findings; drop each
+# pin once a newer base ships the fix (Trivy will re-flag if a pin is dropped
+# too early).
 RUN mamba install -y -n base \
     trino-python-client \
     voila \
@@ -14,6 +15,8 @@ RUN mamba install -y -n base \
     nb_conda_kernels \
     'gitpython>=3.1.57' \
     'jupyterlab>=4.6.2' \
+    'setuptools>=78.1.1' \
+    'msgpack-python>=1.2.1' \
     && mamba clean -afy \
     && fix-permissions "${CONDA_DIR}" \
     && fix-permissions "/home/${NB_USER}"


### PR DESCRIPTION
## Description

### Product
N/A

### Technical
Main is red on the scout-notebook trivy scan. Nothing changed in our code, the trivy DB just started flagging two newly published advisories on packages the pinned scipy-notebook base bundles: setuptools 70.3.0 (CVE-2025-47273) and msgpack 1.1.2 (GHSA-6v7p-g79w-8964). Both are fixable so the scan-images gate fails.

Both are conda-forge bumpable, pinned them above the base in the Dockerfile the same way gitpython and jupyterlab already are. Drop the pins whenever a newer base ships the fixes, trivy re-flags if a pin is dropped too early.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
N/A

##### Appsec
This is the appsec fix. Clears two HIGH CVEs from the notebook image.

### Performance
N/A

### Data
N/A

### Backward compatibility
Just version bumps to setuptools (>=78.1.1) and msgpack-python (>=1.2.1) in the notebook image. No API or data model change.

## Testing
No testing yet, real test is CI rebuilding the image and the scan going green.

## Note for reviewers
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
