### PR TITLE
ci: skip CodeQL on docs-only changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,8 +14,13 @@ name: 'CodeQL Advanced'
 on:
   push:
     branches: ['main']
+    # Docs-only changes have no code to analyze; skipping avoids wasted runs and
+    # the transient java-kotlin extraction flake they can hit. The weekly
+    # schedule below still does a full-repo scan.
+    paths-ignore: ['**/*.md', 'docs/**']
   pull_request:
     branches: ['main']
+    paths-ignore: ['**/*.md', 'docs/**']
   schedule:
     - cron: '36 1 * * 2'
 


### PR DESCRIPTION
## Description
### Technical
CodeQL runs all four language analyses on every PR. A docs-only PR (only `*.md`
/ `docs/**`) runs them for no benefit — there's no code to scan — and can
inherit the transient `java-kotlin` (`build-mode: none`) extraction flake, as
PR #586 did.

Add `paths-ignore: ['**/*.md', 'docs/**']` to the `push` and `pull_request`
triggers so docs-only changes skip CodeQL. The weekly `schedule` still does a
full-repo scan, and any PR that touches code still runs CodeQL (paths-ignore
only skips when *every* changed file matches).

## Type of change
- [x] Improvement

## Testing
YAML validates; prettier clean; paths-ignore is scoped to push + pull_request
only (schedule left unfiltered). The `Analyze` checks are not required-for-merge
(a failing one leaves a PR "unstable", not "blocked"), so skipping them on docs
PRs does not create a pending-required check that would block merge.