### PR TITLE
fix(security): suppress pip-vendored setuptools/msgpack CVEs in scout…

### DIFF
--- a/helm/scout-notebook/.trivyignore.yaml
+++ b/helm/scout-notebook/.trivyignore.yaml
@@ -27,3 +27,11 @@ vulnerabilities:
   # (rattler.abi3.so). Fix (0.11.15) needs a rebuilt rattler; rattler runs only
   # at package-resolution time, not notebook runtime, and the QUIC path is unused.
   - id: GHSA-4w2j-m93h-cj5j # quinn-proto 0.11.14 -> 0.11.15 (compiled into rattler)
+  # setuptools + msgpack flagged from pip's bundled install-time deps
+  # (site-packages/pip/_vendor/vendor.txt), surfaced only on a fresh full
+  # rebuild. pip is required for the JupyterLab UX (users pip-install in
+  # notebooks), so it cannot be dropped, and the vendored copies are not
+  # independently bumpable (the real top-level msgpack is already 1.2.1). Not
+  # runtime app deps. Drop when a pip release re-vendors the fixes.
+  - id: CVE-2025-47273 # setuptools 70.3.0 (vendored in pip)
+  - id: GHSA-6v7p-g79w-8964 # msgpack 1.1.2 (vendored in pip)


### PR DESCRIPTION
…-notebook

A fresh full rebuild surfaces CVE-2025-47273 (setuptools 70.3.0) and GHSA-6v7p-g79w-8964 (msgpack 1.1.2) in scout-notebook. Both come from pip's bundled install-time deps (site-packages/pip/_vendor/vendor.txt), not our layer: pip is required for the JupyterLab UX (users pip-install in notebooks), so it can't be dropped the way hl7-transformer did in #577, and the vendored copies aren't independently bumpable (the real top-level msgpack is already 1.2.1). Suppress with justification, matching this file's existing vendored/base-image entries. Drop when a pip release re-vendors the fixes.

## Description

### Product
No product or user-facing change. Security-scan hygiene for the scout-notebook
image.

### Technical
A fresh full rebuild (any `ci=true` PR) surfaces two fixable HIGH CVEs in
scout-notebook that fail the `scan-images (scout-notebook)` gate:

- CVE-2025-47273 (setuptools 70.3.0 -> 78.1.1)
- GHSA-6v7p-g79w-8964 (msgpack 1.1.2 -> 1.2.1)

Both come from pip's *bundled* install-time dependencies
(`site-packages/pip/_vendor/vendor.txt`), not from a package we install in our
layer, and the image's *real* top-level msgpack is already 1.2.1. Unlike
hl7-transformer in #577, scout-notebook cannot simply drop pip: it is a
JupyterLab image where pip is part of the user experience (users pip-install in
notebooks), and the vendored copies are not independently upgradable. So these
are suppressed with justification, matching this file's existing
vendored/base-image entries (MathJax, underscore, PyO3, quinn-proto). Drop the
suppression when a pip release re-vendors the fixes.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
No change.

##### Appsec
Neutral-to-positive. The flagged CVEs live in pip's vendored install-time
tooling, not runtime-reachable application code; suppressing them unblocks the
scan gate without hiding a runtime exposure. The real (top-level) msgpack is
already on the fixed 1.2.1.

### Performance
No change.

### Data
No change.

### Backward compatibility
No change. Only adds two `.trivyignore.yaml` entries; the image contents are
untouched.

## Testing
Local rebuild of scout-notebook + Trivy scan (with the image's ignore file)
showed exactly these two fixable HIGH, both resolving to
`site-packages/pip/_vendor/vendor.txt` (PkgPath null, i.e. pip-vendored, not a
top-level dist-info). Adding the two IDs to the ignore file leaves 0 residual
fixable HIGH/CRITICAL.

## Note for reviewers
Main-level fix: scout-notebook is unchanged by any specific feature PR, so this
clears the `scan-images (scout-notebook)` gate for main's next full rebuild and
for any `.github`-touching PR that inherits it (e.g. #589 after a rebase). Same
CVE class and rationale as #577, with the deliberate difference that pip is
retained here because the notebook UX needs it.