### PR TITLE
ci: scope the rebuild-all trigger to build-affecting paths

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,8 +68,14 @@ jobs:
         id: filter
         with:
           filters: |
+            # Only ci.yaml (this build/scan/push workflow) and the composite
+            # actions it calls affect image contents. Sibling workflows (codeql,
+            # security, lint, release-please, renovate, ...) must NOT force a full
+            # rebuild+rescan of every image, or an unrelated CI edit surfaces the
+            # newest fixable CVE on all images. ci.yaml calls no reusable workflows,
+            # so this pair is complete.
             ci:
-              - '.github/workflows/**'
+              - '.github/workflows/ci.yaml'
               - '.github/actions/**'
             hl7log-extractor:
               - 'extractor/hl7log-extractor/**'


### PR DESCRIPTION
The `ci` paths-filter globbed `.github/workflows/**`, so any sibling workflow change (codeql, security, lint, release-please, renovate, ...) flipped ci=true and forced a full rebuild+rescan of all 8 images. On a fresh rebuild the scan gate surfaces the newest fixable HIGH/CRIT CVE and fails the PR for a reason unrelated to its change (hit on #589 and #591).

Narrow the trigger to ci.yaml (the only workflow with build logic) plus the composite actions it calls. ci.yaml uses no reusable workflows, so image contents can only change via those paths; a real source change still rebuilds via its own per-image filter, and release.yaml is unaffected (separate pipeline).

## Description

### Product

No product/user-facing change. CI hygiene: an unrelated workflow edit no longer fails a PR on a freshly-surfaced CVE in an image the PR never touched.

### Technical

The `changes` job's `ci` paths-filter globbed `.github/workflows/**`, and the image-build gate ORs `needs.changes.outputs.ci == 'true'` into every image's rebuild condition (`.github/workflows/ci.yaml`, line 185). So a change to **any** workflow file, codeql.yml, security.yaml, pr-title-lint, release-please, renovate, dependency-review, and 6 others, none of which affect image contents, flips `ci=true` and forces a full rebuild + rescan of all 8 images.

On a fresh rebuild, `scan-images` evaluates the current Trivy DB and fails the PR on the newest fixable HIGH/CRIT CVE, which the published `:latest` doesn't have. That is unrelated to the PR's actual change and has now bitten #589 and #591 (both `.github`-only), each of which had to inherit or wait on a scout-notebook CVE fix they had nothing to do with.

The change narrows the trigger to the paths that actually determine image contents:

```yaml
ci:
  - '.github/workflows/ci.yaml'
  - '.github/actions/**'
```

Verified before narrowing:
- ci.yaml calls **no** reusable workflows (`uses: ./.github/workflows/...`), only composite actions under `.github/actions/**`, so image contents can only change via those two paths.
- `changes.outputs.ci` is consumed in exactly one place (the build gate at line 185), so nothing else is affected.
- `release.yaml` also builds images but is a separate pipeline that does not consume this output, so it is untouched.

A real source change still rebuilds via its own per-image filter (`extractor/hl7-transformer/**`, etc.); this only stops *unrelated* workflow edits from rebuilding everything.

## Type of change
- [x] Improvement

## Impact

### Security

##### Authorization
None.

##### Appsec
Slightly reduces scan coverage on the changed PR only: editing ci.yaml or a composite action still rebuilds + rescans everything, and the weekly/scheduled scans still cover the full image set on the current DB. The trade-off is that a `.github`-only PR no longer rescans images whose source is unchanged. Net effect is fewer false-positive gate failures, not fewer real scans of changed images.

### Performance
Fewer wasted full-rebuild CI runs (8 images) on workflow/lint/bot PRs.

### Data
N/A.

### Backward compatibility
No change to the data model, APIs, or dependencies. CI-only.

## Testing
- `ci.yaml` parses; pinned `prettier` passes.
- Confirmed the `ci` output has a single consumer and ci.yaml has no reusable-workflow dependencies, so the narrowed filter is complete.
- The real behavioral proof is this PR's own CI: it touches `ci.yaml`, so `ci=true` still fires here and all images rebuild, exactly as intended for a build-workflow change.

## Note for reviewers

This changes shared-pipeline behavior, so it's worth a deliberate look. The residual is that `.github/actions/**` is still broad (a change to a non-build action would rebuild everything), which errs safe; it can be tightened to the specific build/scan/publish actions later if you want. Open question for you: is there any case where you *want* a sibling-workflow edit to force a full image rebuild? I couldn't find one, but you own the pipeline.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (`pre-commit` prettier run)
- [x] I have commented my code, particularly in hard-to-understand areas (the filter now carries a why-comment)
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate