### PR TITLE
docs: confirm build-lane chart-name map and record the real enablemen…

### DIFF
--- a/tooling/manifest/components.txt
+++ b/tooling/manifest/components.txt
@@ -15,9 +15,23 @@ ghcr.io/washu-tag/superset
 ghcr.io/washu-tag/keycloak
 ghcr.io/washu-tag/report-viewer
 
-# --- charts (13): repo = ghcr.io/washu-tag/charts/<Chart.yaml name> ---
-# TODO: enable once publish-charts captures chart digests and the chart-name
-# map is confirmed (the changes-filter key is not always the Chart.yaml name).
+# --- charts (14): repo = ghcr.io/washu-tag/charts/<name> ---
+# Map CONFIRMED: <name> is the Chart.yaml name == chart dir basename ==
+# publish-charts matrix chart-name for all 14; the dorny changes-filter key is
+# that name plus a "-chart" suffix. (Phase 2 decision 5 = fold these three lists
+# into one source of truth.)
+#
+# STILL COMMENTED. Chart digest capture (PR #588) is done, but two preconditions
+# remain before a chart can be carried into the haul:
+#   1. It must have been published at least once. publish-charts is changed-only,
+#      so a chart whose files have not changed since the job went live is absent
+#      from the registry and build_haul carry() (a live ghcr lookup) fails closed
+#      on it. Today only hl7-transformer, launchpad, open-webui-bootstrap, and
+#      temporal-bootstrap exist in ghcr.io/washu-tag/charts; full coverage needs
+#      a one-time publish-all (or waiting for each chart to change).
+#   2. First-push ghcr packages are private by default; carrying a private chart
+#      needs a GITHUB_TOKEN bearer wired into build_haul.ghcr_digest (anonymous
+#      today).
 # ghcr.io/washu-tag/charts/hl7-transformer
 # ghcr.io/washu-tag/charts/dcm4chee
 # ghcr.io/washu-tag/charts/hive-metastore
@@ -30,4 +44,5 @@ ghcr.io/washu-tag/report-viewer
 # ghcr.io/washu-tag/charts/report-viewer
 # ghcr.io/washu-tag/charts/scout-dashboards
 # ghcr.io/washu-tag/charts/scout-opa
+# ghcr.io/washu-tag/charts/temporal-bootstrap
 # ghcr.io/washu-tag/charts/voila


### PR DESCRIPTION
…t blocker

The map precondition in components.txt is resolved: OCI repo is ghcr.io/washu-tag/charts/<name>, where <name> is the Chart.yaml name == chart dir basename == publish-charts matrix chart-name for all 14 charts. Fix the stale count (13 -> 14; temporal-bootstrap was missing) and replace the vague TODO with the two preconditions that still gate enablement: a chart must be published at least once (publish-charts is changed-only, so 10 of 14 are not yet in the registry and carry() fails closed on them), and carrying a private first-push package needs a token wired into ghcr_digest. Charts stay commented.

## Description

### Technical

Resolves the "chart-name map is confirmed" precondition in `components.txt`: the OCI repo is `ghcr.io/washu-tag/charts/<name>`, where `<name>` is the `Chart.yaml` name == chart dir basename == `publish-charts` matrix `chart-name` for all 14 charts (the dorny changes-filter key is that name plus a `-chart` suffix). Also fixes the stale count (13 -> 14; `temporal-bootstrap` was missing).

The charts stay commented, because enablement is still blocked by two preconditions this PR now records inline:

1. A chart must be published at least once. `publish-charts` is changed-only, so a chart whose files haven't changed since the job went live is absent from the registry, and `build_haul` `carry()` (a live ghcr lookup) fails closed on it. Today only `hl7-transformer`, `launchpad`, `open-webui-bootstrap`, and `temporal-bootstrap` exist in `ghcr.io/washu-tag/charts`.
2. First-push ghcr packages are private; carrying a private chart needs a `GITHUB_TOKEN` bearer wired into `build_haul.ghcr_digest` (anonymous today).

## Type of change
- [x] Documentation update

## Testing
`components.txt` still parses to the 8 active image components with all 14 charts commented (checked with the same skip-blank/`#` logic `build_haul` uses).

## Note for reviewers
No functional change. The two blockers point at the real next steps for chart coverage: a one-time publish-all-charts, and authing `ghcr_digest`. Both are candidates for the follow-up plan (and relate to Phase 2 decision 5, folding the image-matrix / publish-charts matrix / this file into one source of truth).

## Checklist
- [x] My code adheres to the coding and style guidelines of the project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate