### PR TITLE
ci: authenticated ghcr carry for private packages in build_haul

### DIFF
--- a/.github/workflows/publish-haul.yaml
+++ b/.github/workflows/publish-haul.yaml
@@ -67,6 +67,10 @@ jobs:
           merge-multiple: true
 
       - name: Render the Hauler manifest
+        env:
+          # Authenticated carry of unchanged components so private (first-push)
+          # chart/image packages resolve; build_haul reads this from the env.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           python3 tooling/manifest/build_haul.py \
             --digests-dir digests \

--- a/tooling/manifest/build_haul.py
+++ b/tooling/manifest/build_haul.py
@@ -15,7 +15,9 @@ is agnostic to the choice, so only ``carry`` below changes.
 from __future__ import annotations
 
 import argparse
+import base64
 import json
+import os
 import sys
 import urllib.request
 from pathlib import Path
@@ -39,7 +41,7 @@ def ghcr_digest(
     repo: str,
     tag: str,
     *,
-    token: Optional[str] = None,
+    github_token: Optional[str] = None,
     opener: Callable = urllib.request.urlopen,
 ) -> Optional[str]:
     """Resolve the current content digest of a ghcr `repo:tag` (the carry source).
@@ -47,19 +49,24 @@ def ghcr_digest(
     ``repo`` is ``ghcr.io/<path>``; returns the registry's ``Docker-Content-Digest``
     (``sha256:...``) or None if absent. ``opener`` is injectable for tests. Keeping
     this live-inspect I/O here (the glue layer) leaves resolve.py a pure assembler.
-    ``token`` is unused today (anonymous per-repo pulls); wire a GITHUB_TOKEN-derived
-    bearer through when authed pulls of private packages are needed.
+
+    With ``github_token`` (a GITHUB_TOKEN or read:packages PAT) the lookup is
+    authenticated, so first-push *private* chart/image packages are readable; GHCR
+    accepts the base64-encoded token as the bearer directly. Without it the lookup
+    is anonymous via the public scope-token endpoint (public packages only).
     """
     host, _, path = repo.partition("/")
     if host != "ghcr.io" or not path:
         raise ValueError(f"ghcr_digest expects a ghcr.io/<path> repo, got {repo!r}")
-    if token is None:
+    if github_token:
+        bearer = base64.b64encode(github_token.encode()).decode()
+    else:
         with opener(f"https://ghcr.io/token?scope=repository:{path}:pull") as r:
-            token = json.load(r).get("token", "")
+            bearer = json.load(r).get("token", "")
     req = urllib.request.Request(
         f"https://ghcr.io/v2/{path}/manifests/{tag}",
         method="HEAD",
-        headers={"Authorization": f"Bearer {token}", "Accept": _ACCEPT},
+        headers={"Authorization": f"Bearer {bearer}", "Accept": _ACCEPT},
     )
     with opener(req) as r:
         return r.headers.get("Docker-Content-Digest")
@@ -105,13 +112,17 @@ def main(argv=None) -> None:
         if ln.strip() and not ln.lstrip().startswith("#")
     ]
     fresh = parse_fresh(args.digests_dir)
+    # Authenticated carry when a token is present (private first-push packages,
+    # e.g. not-yet-public charts); anonymous otherwise. The workflow passes it
+    # as GITHUB_TOKEN on the render step.
+    gh_token = os.environ.get("GITHUB_TOKEN") or None
 
     def carry(repo: str):
         # A missing carry tag (404) becomes None so resolve_refs fails closed with
         # a clear "neither rebuilt nor carried" naming the repo; any other registry
         # error is surfaced with context instead of a raw urllib traceback.
         try:
-            digest = ghcr_digest(repo, args.carry_tag)
+            digest = ghcr_digest(repo, args.carry_tag, github_token=gh_token)
         except HTTPError as e:
             if e.code == 404:
                 return None

--- a/tooling/manifest/test_build_haul.py
+++ b/tooling/manifest/test_build_haul.py
@@ -74,6 +74,28 @@ def test_ghcr_digest_rejects_non_ghcr_repo():
         ghcr_digest("docker.io/library/alpine", "latest", opener=lambda *a: None)
 
 
+def test_ghcr_digest_authed_uses_base64_bearer_and_skips_token_endpoint():
+    import base64
+
+    seen = []
+
+    def opener(req):
+        seen.append(req)
+        assert not isinstance(req, str), "authed path must not hit the token endpoint"
+        return _FakeResp(headers={"Docker-Content-Digest": D1})
+
+    got = ghcr_digest(
+        "ghcr.io/washu-tag/charts/orthanc",
+        "latest",
+        github_token="ghs_secret",
+        opener=opener,
+    )
+    assert got == D1
+    assert len(seen) == 1  # single HEAD, no separate anonymous token fetch
+    expected = "Bearer " + base64.b64encode(b"ghs_secret").decode()
+    assert seen[0].headers["Authorization"] == expected
+
+
 def _carry_only(tmp_path):
     # empty digests dir -> nothing fresh -> every component is carried
     dd = tmp_path / "digests"


### PR DESCRIPTION
ghcr_digest gains a github_token param: with a token it authenticates (GHCR accepts the base64-encoded token as the bearer), so first-push private chart and image packages resolve; without one the lookup stays anonymous. main() reads GITHUB_TOKEN from the env and the publish-haul render step passes it. Removes one of the two chart-enablement blockers (private packages); the other is publishing every chart at least once.

## Description

### Technical

`build_haul` carries unchanged components by looking up their current registry digest. That lookup was anonymous, so a first-push **private** ghcr package (which is how not-yet-public charts start life) would 403 and the carry would fail. This adds an authenticated path:

- `ghcr_digest` gains a `github_token` parameter. With a token it authenticates (GHCR accepts the base64-encoded token as the bearer), so private chart/image packages resolve; without one the lookup stays anonymous (public packages only), unchanged.
- `main()` reads `GITHUB_TOKEN` from the environment, and the `publish-haul` render step now passes `GITHUB_TOKEN: ${{ github.token }}`.

This removes one of the two chart-enablement blockers documented in `components.txt` (private packages). The other (publishing every chart at least once) is separate.

## Type of change
- [x] Improvement

## Testing
Added `test_ghcr_digest_authed_uses_base64_bearer_and_skips_token_endpoint`: the authed path sends `Authorization: Bearer <base64(token)>` on the manifest HEAD and does not hit the anonymous token endpoint. Full offline suite: 34 passed.

## Note for reviewers
The authed path is unit-tested with an injected opener but not integration-tested against a real private washu-tag package (no token on hand). It follows GHCR's documented base64-token-as-bearer convention. `build_haul` isn't wired into a running job yet (publish-haul is still the inert draft), so this is preparatory.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (`pre-commit` black/prettier)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [x] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate