### PR TITLE
ci: sign published OCI charts with cosign

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1045,6 +1045,24 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/chart-digests"
           printf '%s %s@%s\n' "${CHART_NAME}" "${ref}" "${digest}" \
             > "${RUNNER_TEMP}/chart-digests/${CHART_NAME}.txt"
+      - name: Install cosign
+        if: needs.changes.outputs[matrix.changed] == 'true'
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: 'Sign chart - ${{ matrix.chart-name }}'
+        if: needs.changes.outputs[matrix.changed] == 'true'
+        # Sign the pushed OCI chart by digest with the keyed cosign pair, matching
+        # the image signing in `publish`, so the build-lane haul verifies charts and
+        # images alike at sync time (ADR 0033). Keyed, no transparency log.
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          CHART_NAME: ${{ matrix.chart-name }}
+        run: |
+          set -euo pipefail
+          ref="$(awk '{print $2}' "${RUNNER_TEMP}/chart-digests/${CHART_NAME}.txt")"
+          echo "signing ${ref}"
+          cosign sign --key env://COSIGN_PRIVATE_KEY \
+            --use-signing-config=false --tlog-upload=false --yes "${ref}"
       - name: 'Upload chart digest - ${{ matrix.chart-name }}'
         if: needs.changes.outputs[matrix.changed] == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
Mirror of the image signing in `publish`: after each chart's helm push and digest capture, sign it by digest with the keyed cosign pair, so the ADR 0033 haul verifies charts and images alike at sync time. Keyed, no transparency log. Roadmap step 4b.

## Description

### Technical

Mirrors the image signing (companion PR `ci/sign-images-at-publish`) into `publish-charts`. After each chart's `helm push` and digest read-back, a step signs the pushed OCI chart by digest with the keyed cosign pair, so the ADR 0033 haul verifies charts and images alike at `hauler store sync --key`. Per-chart (matrix), keyed, no transparency log.

## Type of change
- [x] New feature

## Testing
Same keyed `--key env://` invocation validated locally as the image-signing PR. In-pipeline on the next main build that changes a chart.

## Note for reviewers
Pairs with the image-signing PR; merge order doesn't matter (different jobs). Signing is required (a failure fails that chart's publish). Needs the `COSIGN_*` secrets (present).

## Checklist
- [x] My code adheres to the coding and style guidelines of the project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] User documentation
- [ ] Technical documentation / ADR
- [ ] Unit tests
- [ ] End-to-end tests
