### PR TITLE
ci: sign published build-lane images with cosign

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -926,6 +926,29 @@ jobs:
         with:
           image-name: report-viewer
           version: ${{ needs.changes.outputs.version }}
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Sign published build-lane images
+        # Sign every image docker-push recorded this run (each file holds
+        # "<name> <repo>:<version>@<digest>") with the keyed cosign pair, so the
+        # build-lane haul can verify signatures at sync time (ADR 0033). The @digest
+        # is what cosign signs. Keyed, no transparency log: cosign v3 defaults
+        # --use-signing-config=true, which conflicts with --tlog-upload=false, so both
+        # are needed; keeps private image digests off public Rekor.
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: |
+          shopt -s nullglob
+          signed=0
+          for f in "${RUNNER_TEMP}"/image-digests/*.txt; do
+            ref="$(awk '{print $2}' "$f")"
+            echo "signing ${ref}"
+            cosign sign --key env://COSIGN_PRIVATE_KEY \
+              --use-signing-config=false --tlog-upload=false --yes "${ref}"
+            signed=$((signed + 1))
+          done
+          echo "signed ${signed} image(s)"
   # Publish changed Helm charts as versioned OCI artifacts (ADR 0030/0031 phase 0),
   # gated like the image `publish` job. Vertical slice: hl7-transformer only.
   publish-charts:


### PR DESCRIPTION
After the build-lane image pushes, sign each digest docker-push recorded this run (repo:version@digest) with the keyed cosign pair (COSIGN_PRIVATE_KEY / COSIGN_PASSWORD secrets), so the ADR 0033 haul can verify signatures at sync time. Keyed with no transparency log (--use-signing-config=false --tlog-upload=false) so private image digests stay off public Rekor; the enclave verifies offline with the public key. Roadmap step 4a; the exact env:// keyed invocation was validated locally against a throwaway registry.

## Description

### Technical

Adds keyed cosign signing to the `publish` job. After the build-lane image pushes, a step loops the digest files `docker-push` records (`<name> <repo>:<version>@<digest>`) and signs each with the `COSIGN_PRIVATE_KEY` / `COSIGN_PASSWORD` secrets. This is precondition (a) for the ADR 0033 haul: `hauler store sync --key` can then verify each artifact's signature at sync time, and the air-gapped enclave verifies offline with the public key.

Keyed, no transparency log (`--use-signing-config=false --tlog-upload=false`), so private image digests never hit public Rekor. The exact `--key env://` invocation was validated locally against a throwaway registry (sign + offline verify).

## Type of change
- [x] New feature

## Impact / Security
Supply-chain: published images are now signed, enabling downstream signature verification. Signatures are OCI referrers pushed to the same ghcr repo (`packages: write`, already granted).

## Testing
Validated the exact keyed env:// sign + offline verify locally. In-pipeline signing runs on the next main build.

## Note for reviewers
Signing is **required** here: a signing failure fails `publish` rather than shipping unsigned images. If you'd prefer availability over strict signing during rollout, add `continue-on-error: true` to the sign step. Needs the three `COSIGN_*` repo secrets to exist (they do).

## Checklist
- [x] My code adheres to the coding and style guidelines of the project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] User documentation
- [ ] Technical documentation / ADR
- [ ] Unit tests
- [ ] End-to-end tests
