### PR TITLE
ci: add the one-time build-lane haul bootstrap dispatch

### DIFF
--- a/.github/workflows/bootstrap-haul.yaml
+++ b/.github/workflows/bootstrap-haul.yaml
@@ -1,0 +1,116 @@
+# One-time bootstrap for the build-lane haul (ADR 0033, roadmap step 5b-2).
+#
+# The steady-state publish-haul job (in ci.yaml) carries unchanged components
+# from the previous haul, but the FIRST haul has no predecessor, and the publish
+# job only pushes CHANGED images, so no normal run ever has all 8 fresh. This
+# dispatch resolves every image's current digest, signs it, and builds + publishes
+# the first full haul so subsequent builds have a predecessor to carry from.
+#
+# Run once (again only to re-seed from scratch). Dispatch after the predecessor-
+# carry + haul-job PR is merged (it provides build_haul --predecessor).
+#
+# The sync/save/publish tail duplicates the publish-haul job; if that grows, lift
+# it into a `.github/actions/publish-haul` composite used by both.
+name: Bootstrap build-lane haul
+
+on:
+  workflow_dispatch:
+    inputs:
+      superset_tag:
+        description: 'superset has no :latest; seed from this release tag'
+        default: '5.0.0'
+      keycloak_tag:
+        description: 'keycloak has no :latest; seed from this release tag'
+        default: '26.6.3'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  MANIFEST_REPO: ghcr.io/washu-tag/manifests/scout-manifest
+  BUNDLE_REPO: ghcr.io/washu-tag/manifests/scout
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+      - name: Login to GHCR
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Install hauler and oras
+        env:
+          HAULER_VERSION: '2.0.2'
+          ORAS_VERSION: '1.2.0'
+        # Binary downloads (not curl | bash), same posture as ci.yaml.
+        run: |
+          curl -fsSL -o /tmp/hauler.tar.gz \
+            "https://github.com/hauler-dev/hauler/releases/download/v${HAULER_VERSION}/hauler_${HAULER_VERSION}_linux_amd64.tar.gz"
+          tar -xzf /tmp/hauler.tar.gz -C /usr/local/bin hauler
+          curl -fsSL -o /tmp/oras.tar.gz \
+            "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+          tar -xzf /tmp/oras.tar.gz -C /usr/local/bin oras
+      - name: Resolve current image digests, sign, and record as fresh
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          SUPERSET_TAG: ${{ inputs.superset_tag }}
+          KEYCLOAK_TAG: ${{ inputs.keycloak_tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p digests
+          # Scout-built images have :latest; the two vendored-upstream images do
+          # not, so seed them from a release tag (dispatch inputs). Pin by @digest;
+          # the tag is only a label (hauler copies by digest).
+          for name in hl7log-extractor hl7-transformer hl7-listener scout-notebook \
+                      launchpad report-viewer superset keycloak; do
+            case "${name}" in
+              superset) src="${SUPERSET_TAG}" ;;
+              keycloak) src="${KEYCLOAK_TAG}" ;;
+              *) src="latest" ;;
+            esac
+            repo="${REGISTRY}/washu-tag/${name}"
+            digest="$(docker buildx imagetools inspect "${repo}:${src}" --format '{{json .Manifest}}' | jq -r '.digest')"
+            if [ "${digest#sha256:}" = "${digest}" ]; then
+              echo "::error::could not resolve a digest for ${repo}:${src}"
+              exit 1
+            fi
+            cosign sign --key env://COSIGN_PRIVATE_KEY \
+              --use-signing-config=false --tlog-upload=false --yes "${repo}@${digest}"
+            printf '%s %s@%s\n' "${name}" "${repo}:${src}" "${digest}" > "digests/${name}.txt"
+            echo "seeded ${repo}:${src}@${digest}"
+          done
+      - name: Build and publish the first haul (no predecessor)
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          VERSION="0.$(date -u +%Y%m%d).${GITHUB_RUN_NUMBER}"
+          python3 tooling/manifest/build_haul.py \
+            --digests-dir digests \
+            --components tooling/manifest/components.txt \
+            --predecessor "" \
+            --name scout > haul.yaml
+          echo "--- haul.yaml ---"; cat haul.yaml
+          hauler store sync -f haul.yaml
+          hauler store save -f "scout-${VERSION}.tar.zst"
+          # Push both immutable :version artifacts and sign the bundle, then advance
+          # the :main pointers last (ordering guard: a partial failure leaves :main).
+          oras push "${MANIFEST_REPO}:${VERSION}" haul.yaml:application/yaml
+          oras push "${BUNDLE_REPO}:${VERSION}" \
+            --artifact-type application/vnd.hauler.bundle.v1+zstd \
+            "scout-${VERSION}.tar.zst:application/zstd"
+          cosign sign --key env://COSIGN_PRIVATE_KEY \
+            --use-signing-config=false --tlog-upload=false --yes "${BUNDLE_REPO}:${VERSION}"
+          oras tag "${MANIFEST_REPO}:${VERSION}" main
+          oras tag "${BUNDLE_REPO}:${VERSION}" main


### PR DESCRIPTION
The steady-state haul job carries unchanged components from the previous haul, but the first haul has no predecessor and publish only pushes changed images, so no normal run has all 8 fresh. This workflow_dispatch resolves each image's current digest (superset/keycloak from a release tag since they have no :latest), signs it, and builds + publishes the first full haul to seed the predecessor.

No retag: docker buildx imagetools create rewraps the source into a new index with a different digest (verified locally), so we pin the source tag by @digest instead. Dispatch after the predecessor-carry PR (#601) lands build_haul --predecessor. Roadmap step 5b-2.

## Description

### Product

No product/user-facing change. Operational tooling to seed the air-gap build-lane haul once.

### Technical

One-time `workflow_dispatch` that produces the first build-lane haul (ADR 0033). The steady-state `publish-haul` job carries unchanged components from the previous haul, but the first haul has no predecessor, and `publish` only pushes changed images, so no normal run ever has all 8 images fresh. This job resolves each image's current registry digest, cosign-signs it, records it as fresh, and builds + publishes the first full haul (bundle + manifest, `:main` advanced last) so subsequent builds have a predecessor to carry from.

superset and keycloak have no `:latest` tag, so they seed from a release tag (dispatch inputs, default `5.0.0` / `26.6.3`). No retag is done: `docker buildx imagetools create` rewraps the source into a new image index with a different digest (verified locally), which would break digest fidelity, so the source tag is pinned by `@digest` instead (hauler copies by digest, the tag is only a label).

## Type of change
- [x] New feature

## Impact

### Security

##### Authorization
None. No user roles or data access change.

##### Appsec
Uses the keyed cosign pair (`COSIGN_PRIVATE_KEY` / `COSIGN_PASSWORD`) to sign each seeded image and the bundle; secrets are passed via `env:`, never interpolated into `run:` scripts. Dispatch inputs are consumed as double-quoted shell values, so a crafted tag cannot inject commands. Signing is keyed with no transparency log, so private digests stay off public Rekor.

### Performance
One-time manual dispatch. No effect on normal CI.

### Data
N/A.

### Backward compatibility
Additive: a new `workflow_dispatch`-only workflow that never runs automatically. Nothing else references it.

## Testing
- `bootstrap-haul.yaml` parses; pinned `prettier` passes; no `${{ }}` in any `run:` block.
- Validated the render locally against the `--predecessor` `build_haul` (from #601): 8 images pinned, superset at `5.0.0`, keycloak at `26.6.3`, rest `:latest`, all `@sha256:`.
- Validated locally that `imagetools create` does not preserve the digest (the reason this pins the source tag instead).
- The full sign + sync + publish path runs when dispatched (after #601 merges).

## Note for reviewers
Dispatch-only and inert until run. Run it **after #601 merges** (it provides `build_haul --predecessor`). The sync/save/publish tail duplicates the `publish-haul` job in ci.yaml; a `.github/actions/publish-haul` composite can dedup both in a follow-up.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate