### PR TITLE
ci: track the superset image version with Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -198,6 +198,19 @@
         "FROM\\s+(?<depName>apache/superset):(?<currentValue>[\\d\\.]+)"
       ],
       "datasourceTemplate": "docker"
+    },
+    // scout-dashboards deploys the superset image and pins it through its
+    // appVersion (the appVersion->image coupling), so track that appVersion
+    // against apache/superset too. Same depName as the two managers above, so
+    // Renovate groups all three into one PR per superset release, keeping the
+    // chart's pinned version in lockstep with the image it deploys. (No match
+    // until the appVersion is a real version rather than the "latest" default.)
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["helm/scout-dashboards/Chart.yaml"],
+      "matchStrings": ["appVersion:\\s*\"(?<currentValue>[\\d\\.]+)\""],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "apache/superset"
     }
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -177,6 +177,27 @@
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "quay.io/keycloak/keycloak"
+    },
+    // superset, like keycloak, is a vendored-upstream image with no :latest.
+    // helm/superset/VERSION drives the ghcr image tag (ghcr.io/washu-tag/superset
+    // :<this> via derive-version) and the Dockerfile FROM is the upstream base.
+    // Mirror the keycloak managers so both bump in one PR per apache/superset
+    // release. (The superset HELM CHART version is tracked separately in
+    // versions.yaml; this covers the image the build lane bundles.)
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["helm/superset/VERSION"],
+      "matchStrings": ["^(?<currentValue>\\d[\\d\\.]*)\\s*$"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "apache/superset"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["helm/superset/Dockerfile"],
+      "matchStrings": [
+        "FROM\\s+(?<depName>apache/superset):(?<currentValue>[\\d\\.]+)"
+      ],
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
superset, like keycloak, is a vendored-upstream image with no :latest tag, but unlike keycloak it had no Renovate customManager, so its version (helm/superset/ VERSION, which derive-version turns into the ghcr image tag, plus the Dockerfile FROM) never auto-updated. Mirror the keycloak managers so apache/superset releases bump both in one PR per release.

Closes the auto-update gap flagged in the #602 review and is the prerequisite for having the bootstrap read helm/superset/VERSION instead of embedding the tag. Validated with renovate-config-validator (current Renovate).

## Description

### Product
No product change. CI/dependency hygiene.

### Technical
`superset`, like `keycloak`, is a vendored-upstream image with no `:latest` tag, but unlike `keycloak` it had no Renovate `customManager`, so its version never auto-updated. `helm/superset/VERSION` (which `derive-version` turns into the ghcr image tag) and the Dockerfile `FROM` would only ever change by hand.

This mirrors the existing keycloak managers for `apache/superset`, so a new Superset release bumps both files in one PR. Closes the auto-update gap raised in the #602 review, and is the prerequisite for having the bootstrap read `helm/superset/VERSION` instead of embedding the tag. Validated with `renovate-config-validator` (current Renovate): "Config validated successfully."

## Type of change
- [x] Improvement

## Testing
`npx renovate-config-validator renovate.json5` passes. The two new managers are structurally identical to the live keycloak managers, and the regex was confirmed to match `helm/superset/VERSION` (`5.0.0`) and the `FROM apache/superset:5.0.0` line.

## Note for reviewers
Config-only, additive. First effect: Renovate lists any newer `apache/superset` on the Dependency Dashboard (needs the usual approval to open a PR). `apache/superset` version tracking is separate from the superset *helm chart* version already tracked in `versions.yaml`.

## Checklist
- [x] Adheres to project guidelines
- [x] Commented the manager (why superset needs it)
- [ ] User docs / ADR / tests (N/A)