### PR TITLE
ci: sha256-pin the hauler and oras downloads in the haul workflows

### DIFF
--- a/.github/workflows/bootstrap-haul.yaml
+++ b/.github/workflows/bootstrap-haul.yaml
@@ -50,14 +50,20 @@ jobs:
       - name: Install hauler and oras
         env:
           HAULER_VERSION: '2.0.2'
+          HAULER_SHA256: 'd96ac67cac3c9e4fc2d24c8347fba956b2a165a2237318cc2564e44bbaabc4c3'
           ORAS_VERSION: '1.2.0'
-        # Binary downloads (not curl | bash), same posture as ci.yaml.
+          ORAS_SHA256: '5b3f1cbb86d869eee68120b9b45b9be983f3738442f87ee5f06b00edd0bab336'
+        # Binary downloads (not curl | bash), sha256-verified before extract so a
+        # tampered/hijacked release asset can't execute in the job. Bump the
+        # version and its checksum together (from the release's checksums.txt).
         run: |
           curl -fsSL -o /tmp/hauler.tar.gz \
             "https://github.com/hauler-dev/hauler/releases/download/v${HAULER_VERSION}/hauler_${HAULER_VERSION}_linux_amd64.tar.gz"
+          echo "${HAULER_SHA256}  /tmp/hauler.tar.gz" | sha256sum -c -
           tar -xzf /tmp/hauler.tar.gz -C /usr/local/bin hauler
           curl -fsSL -o /tmp/oras.tar.gz \
             "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+          echo "${ORAS_SHA256}  /tmp/oras.tar.gz" | sha256sum -c -
           tar -xzf /tmp/oras.tar.gz -C /usr/local/bin oras
       - name: Resolve current image digests, sign, and record as fresh
         env:

--- a/.github/workflows/bootstrap-haul.yaml
+++ b/.github/workflows/bootstrap-haul.yaml
@@ -48,6 +48,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Install hauler and oras
+        shell: bash # default shell is `bash -e` (no pipefail); be explicit
         env:
           HAULER_VERSION: '2.0.2'
           HAULER_SHA256: 'd96ac67cac3c9e4fc2d24c8347fba956b2a165a2237318cc2564e44bbaabc4c3'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1178,6 +1178,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Install hauler and oras
+        shell: bash # default shell is `bash -e` (no pipefail); be explicit
         env:
           HAULER_VERSION: '2.0.2'
           HAULER_SHA256: 'd96ac67cac3c9e4fc2d24c8347fba956b2a165a2237318cc2564e44bbaabc4c3'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1180,14 +1180,20 @@ jobs:
       - name: Install hauler and oras
         env:
           HAULER_VERSION: '2.0.2'
+          HAULER_SHA256: 'd96ac67cac3c9e4fc2d24c8347fba956b2a165a2237318cc2564e44bbaabc4c3'
           ORAS_VERSION: '1.2.0'
-        # Binary downloads (not curl | bash), same posture as the other installs.
+          ORAS_SHA256: '5b3f1cbb86d869eee68120b9b45b9be983f3738442f87ee5f06b00edd0bab336'
+        # Binary downloads (not curl | bash), sha256-verified before extract so a
+        # tampered/hijacked release asset can't execute in the job. Bump the
+        # version and its checksum together (from the release's checksums.txt).
         run: |
           curl -fsSL -o /tmp/hauler.tar.gz \
             "https://github.com/hauler-dev/hauler/releases/download/v${HAULER_VERSION}/hauler_${HAULER_VERSION}_linux_amd64.tar.gz"
+          echo "${HAULER_SHA256}  /tmp/hauler.tar.gz" | sha256sum -c -
           tar -xzf /tmp/hauler.tar.gz -C /usr/local/bin hauler
           curl -fsSL -o /tmp/oras.tar.gz \
             "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+          echo "${ORAS_SHA256}  /tmp/oras.tar.gz" | sha256sum -c -
           tar -xzf /tmp/oras.tar.gz -C /usr/local/bin oras
       - name: Download this run's fresh image digests
         # No continue-on-error: a failed/partial download must fail the job (which


### PR DESCRIPTION
The haul job (ci.yaml) and the bootstrap dispatch download the hauler + oras binaries by version but didn't verify them. Pin each asset's sha256 (from the release checksums.txt) and check it before extract, so a tampered or hijacked release asset can't execute with the job's registry credentials. Verified both checksums against the real v2.0.2 / v1.2.0 assets; bump version + checksum together on future updates.

## Description
### Technical
The haul job (`ci.yaml`) and the bootstrap dispatch download the `hauler` + `oras` binaries by version but didn't verify them. This pins each asset's `sha256` (from the release `checksums.txt`) and checks it with `sha256sum -c` before extract, so a tampered or hijacked release asset can't execute with the job's `packages: write` credentials. Closes the "TODO: verify a checksum" left in both installs.

## Type of change
- [x] Improvement (supply-chain hardening)

## Testing
Both files parse; prettier passes. Verified the embedded checksums against the real `v2.0.2` / `v1.2.0` assets by downloading and recomputing `sha256`, both match, so this won't break the install.

## Note for reviewers
`cosign` is installed via the pinned `sigstore/cosign-installer` action, so it's already covered. On a version bump, update the version and its checksum together (both in `env:`). The two installs are duplicated across the haul job + bootstrap; the planned `.github/actions/publish-haul` composite would dedup them.

## Checklist
- [x] Adheres to guidelines
- [x] Commented (why + how to bump)
- [ ] Docs / tests (N/A)