### PR TITLE
ci: bootstrap reads seed tags from VERSION instead of embedding them

### DIFF
--- a/.github/workflows/bootstrap-haul.yaml
+++ b/.github/workflows/bootstrap-haul.yaml
@@ -17,11 +17,11 @@ on:
   workflow_dispatch:
     inputs:
       superset_tag:
-        description: 'superset has no :latest; seed from this release tag'
-        default: '5.0.0'
+        description: 'Optional override for the superset seed tag; defaults to helm/superset/VERSION'
+        default: ''
       keycloak_tag:
-        description: 'keycloak has no :latest; seed from this release tag'
-        default: '26.6.3'
+        description: 'Optional override for the keycloak seed tag; defaults to keycloak/VERSION'
+        default: ''
 
 permissions:
   contents: read
@@ -69,19 +69,21 @@ jobs:
           set -euo pipefail
           mkdir -p digests
           # Scout-built images have :latest; the two vendored-upstream images do
-          # not, so seed them from a release tag (dispatch inputs). Pin by @digest;
-          # the tag is only a label (hauler copies by digest).
+          # not, so seed them from their VERSION file -- the same source
+          # derive-version tags the published image from, kept current by Renovate
+          # -- unless a dispatch override is given. Pin by @digest; the tag is only
+          # a label (hauler copies by digest).
           for name in hl7log-extractor hl7-transformer hl7-listener scout-notebook \
                       launchpad report-viewer superset keycloak; do
             case "${name}" in
-              superset) src="${SUPERSET_TAG}" ;;
-              keycloak) src="${KEYCLOAK_TAG}" ;;
+              superset) src="${SUPERSET_TAG:-$(cat helm/superset/VERSION)}" ;;
+              keycloak) src="${KEYCLOAK_TAG:-$(cat keycloak/VERSION)}" ;;
               *) src="latest" ;;
             esac
             repo="${REGISTRY}/washu-tag/${name}"
             digest="$(docker buildx imagetools inspect "${repo}:${src}" --format '{{json .Manifest}}' | jq -r '.digest')"
             if [ "${digest#sha256:}" = "${digest}" ]; then
-              echo "::error::could not resolve a digest for ${repo}:${src}"
+              echo "::error::${repo}:${src} is not published in ghcr. If VERSION is ahead of the last build, re-run with the *_tag override set to a currently-published tag."
               exit 1
             fi
             cosign sign --key env://COSIGN_PRIVATE_KEY \


### PR DESCRIPTION
The superset/keycloak seed tags were hardcoded input defaults (5.0.0 / 26.6.3) that drift, and 26.6.3 was already stale vs keycloak/VERSION=26.6.4. Read them from the same source derive-version tags the published image from (helm/superset/VERSION, keycloak/VERSION, kept current by Renovate). The dispatch inputs become optional overrides (empty default) for the window where VERSION is ahead of the last published build; the digest resolve now fails loud with a message pointing at the override. Closes the drift raised in the #602 review.

## Description
### Technical
The bootstrap's superset/keycloak seed tags were hardcoded input defaults (`5.0.0` / `26.6.3`) that drift, and `26.6.3` was already stale vs `keycloak/VERSION` = `26.6.4`. This reads them from the same source `derive-version` tags the published image from (`helm/superset/VERSION`, `keycloak/VERSION`, kept current by Renovate once #`ci/renovate-track-superset` lands). The dispatch inputs become optional overrides (empty default) for the window where `VERSION` is ahead of the last published build; the digest-resolve step fails loud with a message pointing at the override.

Closes the embedded-version drift raised in the #602 review, at the source.

## Type of change
- [x] Improvement

## Testing
YAML parses, prettier passes, no `${{ }}` in run blocks. Verified locally: default reads `VERSION` (superset→`5.0.0`, keycloak→`26.6.4`), override wins (`4.1.2`), and the fail-loud path triggers when `VERSION` (`26.6.4`) is ahead of what's published (`26.6.3`).

## Note for reviewers
Pairs with `ci/renovate-track-superset` (that keeps `helm/superset/VERSION` current; this reads it). Touches `bootstrap-haul.yaml` in a different region than `ci/checksum-pin-tools`, so no conflict. Bootstrap is a rare re-seed op, so the fail-loud + override during a VERSION-ahead window is acceptable friction.

## Checklist
- [x] Adheres to guidelines
- [x] Commented (source-of-truth + override rationale)
- [ ] Docs / tests (N/A)