### PR TITLE
ci: verify component signatures at haul sync, with a completeness guard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1226,9 +1226,19 @@ jobs:
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
         run: |
           set -euo pipefail
-          hauler store sync -f haul.yaml
+          # Verify each component's cosign signature as it is pulled. hauler SKIPS
+          # an image it can't verify and still exits 0, so guard against a silently
+          # incomplete haul: fail if the sync log reports any verification miss.
+          # (Log strings are hauler 2.0.2's; recheck them when bumping hauler.)
+          printf '%s' "${COSIGN_PUBLIC_KEY}" > cosign.pub
+          hauler store sync -f haul.yaml --key cosign.pub 2>&1 | tee sync.log
+          if grep -qiE "signature verification failed|no signatures found" sync.log; then
+            echo "::error::a component failed cosign verification and was skipped; the haul would be incomplete"
+            exit 1
+          fi
           hauler store save -f "scout-${VERSION}.tar.zst"
           # Push both immutable :version artifacts and sign the bundle, THEN advance
           # the :main pointers last, so :main only moves after a complete, signed

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1236,14 +1236,14 @@ jobs:
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           # hauler 2.0.2 SKIPS an image it can't verify yet still exits 0, so an
           # exit-code or failure-string check fails OPEN. Fail CLOSED: require one
           # "signature verified" line per image in haul.yaml (dash-anchored count so
           # metadata.name isn't included). (Strings are 2.0.2's; recheck on bump.)
-          printf '%s' "${COSIGN_PUBLIC_KEY}" > cosign.pub
+          # Derive the public key from the signing key -- no separate COSIGN_PUBLIC_KEY secret.
+          cosign public-key --key env://COSIGN_PRIVATE_KEY > cosign.pub
           expected=$(grep -cE '^[[:space:]]*-[[:space:]]+name:' haul.yaml || true)
           hauler store sync -f haul.yaml --key cosign.pub 2>&1 | tee sync.log
           verified=$(grep -cF 'signature verified for image [' sync.log || true)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1151,8 +1151,8 @@ jobs:
     # a .tar.zst bundle, and publish the bundle + the manifest so the next run can
     # carry from it. continue-on-error so it never gates a release; it fails closed
     # (harmless) on partial builds until a one-time bootstrap seeds the first
-    # predecessor. Sync is unsigned for now; `--key` verification is a follow-up
-    # once every image is signed at publish.
+    # predecessor. Sync verifies every component's cosign signature (--key) and
+    # fails closed if any image is unsigned or unverifiable.
     if: github.ref_name == 'main' && needs.publish.result == 'success'
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -1196,6 +1196,16 @@ jobs:
             "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
           echo "${ORAS_SHA256}  /tmp/oras.tar.gz" | sha256sum -c -
           tar -xzf /tmp/oras.tar.gz -C /usr/local/bin oras
+      - name: Assert hauler's verification success string (guard canary)
+        # The sync step's fail-closed guard counts "signature verified for image ["
+        # log lines; if a hauler bump changed that wording the count would silently
+        # drop to zero and block every publish. Catch a wording change here, up front.
+        run: |
+          set -euo pipefail
+          if ! grep -aqF 'signature verified for image [' "$(command -v hauler)"; then
+            echo "::error::this hauler build lacks the 'signature verified for image [' success string; update the verified-line guard in the sync step to match this version"
+            exit 1
+          fi
       - name: Download this run's fresh image digests
         # No continue-on-error: a failed/partial download must fail the job (which
         # is job-level continue-on-error, so non-blocking) rather than be swallowed.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1229,14 +1229,16 @@ jobs:
           COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
         run: |
           set -euo pipefail
-          # Verify each component's cosign signature as it is pulled. hauler SKIPS
-          # an image it can't verify and still exits 0, so guard against a silently
-          # incomplete haul: fail if the sync log reports any verification miss.
-          # (Log strings are hauler 2.0.2's; recheck them when bumping hauler.)
+          # hauler 2.0.2 SKIPS an image it can't verify yet still exits 0, so an
+          # exit-code or failure-string check fails OPEN. Fail CLOSED: require one
+          # "signature verified" line per image in haul.yaml (dash-anchored count so
+          # metadata.name isn't included). (Strings are 2.0.2's; recheck on bump.)
           printf '%s' "${COSIGN_PUBLIC_KEY}" > cosign.pub
+          expected=$(grep -cE '^[[:space:]]*-[[:space:]]+name:' haul.yaml || true)
           hauler store sync -f haul.yaml --key cosign.pub 2>&1 | tee sync.log
-          if grep -qiE "signature verification failed|no signatures found" sync.log; then
-            echo "::error::a component failed cosign verification and was skipped; the haul would be incomplete"
+          verified=$(grep -cF 'signature verified for image [' sync.log || true)
+          if [ "$expected" -lt 1 ] || [ "$verified" -ne "$expected" ]; then
+            echo "::error::cosign verification incomplete: ${verified}/${expected} components verified; the haul would be missing unverified images"
             exit 1
           fi
           hauler store save -f "scout-${VERSION}.tar.zst"


### PR DESCRIPTION
Turn on cosign verification in the haul job's `hauler store sync` (--key from COSIGN_PUBLIC_KEY), now that images and charts are signed at publish. hauler SKIPS an image it can't verify and still exits 0, so a naive --key would silently drop a component and publish an incomplete haul; guard against that by failing the step if the sync log reports any verification miss.

Validated locally against a throwaway registry: --key verifies a signed image, rejects an unsigned one, and the guard trips on the skip. The job stays continue-on-error, so a miss is non-blocking and visible rather than a wrong publish. Log strings are hauler 2.0.2's; recheck on a hauler bump.

## Description
### Technical
Turns on cosign verification in the haul job's `hauler store sync` (`--key` from `COSIGN_PUBLIC_KEY`), now that images + charts are signed at publish, so a tampered component can't be bundled.

Important hauler behaviour I verified locally: `hauler store sync --key` **skips** an image it can't verify and **still exits 0** ("processing completed successfully"), so a naive `--key` would silently drop a component and publish an *incomplete* haul. This adds a completeness guard, the step fails if the sync log reports any verification miss.

## Type of change
- [x] New feature (supply-chain: sync-time signature verification)

## Testing
Validated against a throwaway registry: `--key` logged "signature verified" and added a signed image, rejected an unsigned one ("no signatures found"), and the guard grep trips on the skip / passes a clean log. YAML + prettier clean.

## Note for reviewers
Depends on every carried image being signed (the bootstrap signed the seed; the sign-at-publish steps sign future builds). The job stays `continue-on-error`, so a verification miss is non-blocking and visible rather than a wrong publish. The guard's log strings are hauler 2.0.2's, recheck them on a hauler bump.

## Checklist
- [x] Adheres to guidelines
- [x] Commented (the skip-and-exit-0 gotcha + guard)
- [ ] Docs / tests (N/A, workflow)