### PR TITLE
ci: remove CodeQL paths-ignore so the required check can't deadlock

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,9 +12,6 @@
 name: 'CodeQL Advanced'
 
 on:
-  # No paths-ignore: CodeQL is a required check, and a skipped required check
-  # never reports, so it blocks the PR forever (deadlocked docs-only #605).
-  # Keep it on every PR; docs-only is a fast build-mode:none run.
   push:
     branches: ['main']
   pull_request:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,15 +12,15 @@
 name: 'CodeQL Advanced'
 
 on:
+  # No paths-ignore here: CodeQL is a REQUIRED status check, and skipping a
+  # required check via paths-ignore leaves it permanently "Expected - waiting"
+  # and blocks the PR (a skipped required check never reports). That deadlocked
+  # docs-only PRs like #605. Keep CodeQL running on every PR; on a docs-only
+  # change it is a fast build-mode:none run that reports quickly.
   push:
     branches: ['main']
-    # Docs-only changes have no code to analyze; skipping avoids wasted runs and
-    # the transient java-kotlin extraction flake they can hit. The weekly
-    # schedule below still does a full-repo scan.
-    paths-ignore: ['**/*.md', 'docs/**']
   pull_request:
     branches: ['main']
-    paths-ignore: ['**/*.md', 'docs/**']
   schedule:
     - cron: '36 1 * * 2'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,11 +12,9 @@
 name: 'CodeQL Advanced'
 
 on:
-  # No paths-ignore here: CodeQL is a REQUIRED status check, and skipping a
-  # required check via paths-ignore leaves it permanently "Expected - waiting"
-  # and blocks the PR (a skipped required check never reports). That deadlocked
-  # docs-only PRs like #605. Keep CodeQL running on every PR; on a docs-only
-  # change it is a fast build-mode:none run that reports quickly.
+  # No paths-ignore: CodeQL is a required check, and a skipped required check
+  # never reports, so it blocks the PR forever (deadlocked docs-only #605).
+  # Keep it on every PR; docs-only is a fast build-mode:none run.
   push:
     branches: ['main']
   pull_request:


### PR DESCRIPTION
#591 added paths-ignore to codeql.yml to skip CodeQL on docs-only changes, but CodeQL is a required status check. A skipped required check never reports, so it sits permanently "Expected - waiting" and blocks the PR. This deadlocked docs-only PRs (e.g. #605, all docs/source/*.md). Remove the paths-ignore so CodeQL runs on every PR and always reports; a docs-only change is a fast build-mode:none run. Comment added so it isn't reintroduced.

## Description
### Technical
#591 added `paths-ignore: ['**/*.md', 'docs/**']` to `codeql.yml` to skip CodeQL on docs-only changes. But CodeQL is a **required** status check, and a required check whose workflow is *skipped* never reports a status, so GitHub leaves it "Expected — Waiting for status to be reported" permanently and blocks the PR. This deadlocked docs-only PRs, e.g. #605 (all `docs/source/*.md`), where CodeQL never scheduled.

Removes the `paths-ignore` so CodeQL runs on every PR and always reports; a docs-only change is a fast `build-mode: none` run. A comment is added so it isn't reintroduced.

## Type of change
- [x] Bug fix (unblocks merging of docs-only PRs)

## Testing
`codeql.yml` parses; prettier passes; no `paths-ignore:` key remains.

## Note for reviewers
Reverts the effect of #591. There's no clean way to both skip CodeQL on docs and not block, since a skipped required check can't clear.