### PR TITLE
docs: fix admonition rendering, document chat-sharing removal, repair SQL Lab link

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,6 +20,11 @@ extensions = [
     "myst_parser",
 ]
 
+# Enable the colon-fence directive syntax (:::{note} … :::) in addition to the
+# default backtick fence, so admonitions can be authored with ::: without the
+# fence clashing with the backtick code blocks they sit alongside.
+myst_enable_extensions = ["colon_fence"]
+
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),

--- a/docs/source/user/chat.md
+++ b/docs/source/user/chat.md
@@ -179,7 +179,7 @@ For visualizations, copy the data to {ref}`Analytics <analytics>` and build char
 **Chat sharing is disabled.** Scout has turned off Open WebUI's share-link
 feature. Scout users are authorized to see different subsets of the report data,
 so a shared conversation could expose results to a recipient who is not
-authorized to see them — and we have not yet designed a solution for that. To
+authorized to see them. To
 share findings, see whether {ref}`Scout Analytics <analytics>` or
 {ref}`Scout Notebooks <notebooks>` fits your need; each applies the viewer's own
 data authorization.

--- a/docs/source/user/chat.md
+++ b/docs/source/user/chat.md
@@ -155,7 +155,7 @@ For visualizations, copy results to {ref}`Analytics <analytics>`.
 - **Authentication required**: Keycloak authentication (same as other Scout services)
 - **Read-only access**: Chat cannot modify or delete data
 - **External content blocked**: Scout blocks loading images and resources from external websites
-- **Conversation privacy**: Chat history is stored on the server and associated with your user account. Other users cannot see your chats unless you share them.
+- **Conversation privacy**: Chat history is stored on the server and associated with your user account. Other users cannot see your chats.
 
 ```{note}
 **Admin visibility**: Scout administrators have the ability to view user chat histories for quality assurance and support. Avoid including sensitive personal information in your conversations.
@@ -175,56 +175,23 @@ For visualizations, copy the data to {ref}`Analytics <analytics>` and build char
 
 ## Chat Sharing
 
-You can share chat conversations with other authenticated Scout users via share links.
-
-```{warning}
-**PHI Risk**: Chat conversations may contain Protected Health Information (PHI) from query results. Before sharing or downloading chats, ensure you are complying with your institution's data governance policies and HIPAA requirements.
+```{note}
+**Chat sharing is disabled.** Scout has turned off Open WebUI's share-link
+feature. Scout users are authorized to see different subsets of the report data,
+so a shared conversation could expose results to a recipient who is not
+authorized to see them — and we have not yet designed a solution for that. To
+share findings, see whether {ref}`Scout Analytics <analytics>` or
+{ref}`Scout Notebooks <notebooks>` fits your need; each applies the viewer's own
+data authorization.
 ```
 
-### Creating a Share Link
-
-1. Open the chat you want to share
-2. Click the **three-dot menu** (⋮) on the chat
-3. Select **Share**
-4. Click **Copy Link** to generate a shareable URL
-
-The link creates a **snapshot** of the conversation at that moment. New messages added after sharing won't appear unless you update the link.
-
-### Who Can View Shared Chats
-
-Shared chats are **only accessible to authenticated users** on your Scout instance. Recipients must:
-
-- Have a Scout account
-- Be logged in to Scout Chat
-
-Unauthenticated users will be redirected to the login page.
-
-### Updating a Share Link
-
-If you add messages to a shared chat and want to include them:
-
-1. Open the chat and click the **three-dot menu**
-2. Select **Share**
-3. The share modal shows the previously shared snapshot
-4. Click **Update** to refresh the snapshot with new messages
-
-### Deleting a Share Link
-
-To revoke access to a shared chat:
-
-1. Open the chat and click the **three-dot menu**
-2. Select **Share**
-3. Click **Delete this link**
-
-Once deleted, the share link becomes invalid and viewers can no longer access the chat.
-
-### Downloading Chats
+## Downloading Chats
 
 ```{warning}
 **Do not download chats containing PHI** unless you have appropriate authorization and secure storage. Downloaded chat files may contain patient identifiers, diagnosis codes, and other sensitive information extracted from query results.
 ```
 
-Because of PHI concerns, we recommend using chat sharing instead of download when you can. If this is not suitable for your use case, consider whether {ref}`Scout Analytics <analytics>` or {ref}`Scout Notebooks <notebooks>` would meet your need.
+Because of these PHI concerns, consider whether {ref}`Scout Analytics <analytics>` or {ref}`Scout Notebooks <notebooks>` would meet your need instead.
 
 ## Limitations
 

--- a/docs/source/user/quickstart.md
+++ b/docs/source/user/quickstart.md
@@ -16,7 +16,7 @@ Selecting **Analytics** opens [Apache Superset](https://superset.apache.org/), a
 data visualization and exploration tool. Your landing page is the Scout
 Dashboard, an overview of all report data. From there you can explore the data
 with the no-code [visualization builder](https://superset.apache.org/docs/using-superset/creating-your-first-dashboard)
-or run direct queries in [SQL Lab](https://superset.apache.org/docs/using-superset/using-sql-lab/)
+or run direct queries in [SQL Lab](https://superset.apache.org/user-docs/using-superset/exploring-data#sql-lab-tips)
 (see the [Trino SQL reference](https://trino.io/docs/current/language.html)).
 
 ![Scout Dashboard](../images/ScoutDashboard.png)


### PR DESCRIPTION
## Description

### Product
Three fixes to the user-facing docs, spotted while reviewing the reorganized site:

- **Chat sharing is documented as disabled.** The Chat page previously walked users through creating/sharing chat links. Sharing has been turned off because Scout users are authorized to see different subsets of the data and a shared conversation could expose results to someone not authorized to see them — we haven't designed a solution for that yet. The page now says so and points users to Analytics/Notebooks, which apply the viewer's own authorization.
- **Dead SQL Lab link fixed.** The Quickstart linked to Superset's old SQL Lab page, which now 404s (Superset removed the dedicated page).
- **Broken admonitions render correctly.** Several callouts in the inventory reference were showing their raw `:::{note}` / `:::{deprecated}` source instead of rendering as boxes.

### Technical
`conf.py`: enable MyST's `colon_fence` extension. The default MyST config only recognizes backtick-fenced directives, so the `:::`-fenced admonitions authored in `operate/inventory.md` rendered as literal text. Enabling `colon_fence` makes both fence styles work; it only affects lines starting with `:::`.

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Refactor (code improvement with no functional changes)
- [X] Documentation update
- [ ] Test update

<!-- 
If this pull request is for work that is behind a feature flag, or for documentation or test updates, most of the details below are not required; The level of attention to each is left to the discretion of the developer.
For all other change types, the developer should attempt to provide as much detail as is reasonable.
-->

## Impact

### Security 

##### Authorization
N/A

##### Appsec
N/A

### Performance
N/A

### Data
N/A

### Backward compatibility
N/A

## Testing
RTD will render the docs for spot review

## Note for reviewers
<!-- Any additional information or direction for reviewers. -->

## Checklist
- [X] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate
