### PR TITLE
ci: harden the haul signature guard against hauler version drift

### DIFF
--- a/.github/actions/install-hauler-oras/action.yaml
+++ b/.github/actions/install-hauler-oras/action.yaml
@@ -1,0 +1,28 @@
+name: 'Install hauler and oras'
+description: >-
+  Installs pinned, sha256-verified hauler and oras binaries into /usr/local/bin
+  for the build-lane haul (ADR 0033). Single source of truth for both tool
+  versions and checksums, shared by the publish-haul job, the bootstrap
+  workflow, and the haul-guard canary so they all run the same pinned binaries.
+runs:
+  using: 'composite'
+  steps:
+    - name: Install hauler and oras
+      shell: bash # default shell is `bash -e` (no pipefail); be explicit
+      env:
+        HAULER_VERSION: '2.0.2'
+        HAULER_SHA256: 'd96ac67cac3c9e4fc2d24c8347fba956b2a165a2237318cc2564e44bbaabc4c3'
+        ORAS_VERSION: '1.2.0'
+        ORAS_SHA256: '5b3f1cbb86d869eee68120b9b45b9be983f3738442f87ee5f06b00edd0bab336'
+      # Binary downloads (not curl | bash), sha256-verified before extract so a
+      # tampered/hijacked release asset can't execute in the job. Bump the
+      # version and its checksum together (from the release's checksums.txt).
+      run: |
+        curl -fsSL -o /tmp/hauler.tar.gz \
+          "https://github.com/hauler-dev/hauler/releases/download/v${HAULER_VERSION}/hauler_${HAULER_VERSION}_linux_amd64.tar.gz"
+        echo "${HAULER_SHA256}  /tmp/hauler.tar.gz" | sha256sum -c -
+        tar -xzf /tmp/hauler.tar.gz -C /usr/local/bin hauler
+        curl -fsSL -o /tmp/oras.tar.gz \
+          "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+        echo "${ORAS_SHA256}  /tmp/oras.tar.gz" | sha256sum -c -
+        tar -xzf /tmp/oras.tar.gz -C /usr/local/bin oras

--- a/.github/workflows/bootstrap-haul.yaml
+++ b/.github/workflows/bootstrap-haul.yaml
@@ -48,24 +48,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Install hauler and oras
-        shell: bash # default shell is `bash -e` (no pipefail); be explicit
-        env:
-          HAULER_VERSION: '2.0.2'
-          HAULER_SHA256: 'd96ac67cac3c9e4fc2d24c8347fba956b2a165a2237318cc2564e44bbaabc4c3'
-          ORAS_VERSION: '1.2.0'
-          ORAS_SHA256: '5b3f1cbb86d869eee68120b9b45b9be983f3738442f87ee5f06b00edd0bab336'
-        # Binary downloads (not curl | bash), sha256-verified before extract so a
-        # tampered/hijacked release asset can't execute in the job. Bump the
-        # version and its checksum together (from the release's checksums.txt).
-        run: |
-          curl -fsSL -o /tmp/hauler.tar.gz \
-            "https://github.com/hauler-dev/hauler/releases/download/v${HAULER_VERSION}/hauler_${HAULER_VERSION}_linux_amd64.tar.gz"
-          echo "${HAULER_SHA256}  /tmp/hauler.tar.gz" | sha256sum -c -
-          tar -xzf /tmp/hauler.tar.gz -C /usr/local/bin hauler
-          curl -fsSL -o /tmp/oras.tar.gz \
-            "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
-          echo "${ORAS_SHA256}  /tmp/oras.tar.gz" | sha256sum -c -
-          tar -xzf /tmp/oras.tar.gz -C /usr/local/bin oras
+        uses: ./.github/actions/install-hauler-oras
       - name: Resolve current image digests, sign, and record as fresh
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1145,6 +1145,27 @@ jobs:
         with:
           image-name: report-viewer
 
+  haul-guard-canary:
+    # publish-haul's sync step fails closed by counting hauler's "signature
+    # verified for image [" log lines; a hauler bump that changed that wording
+    # would silently zero the count and block every publish. Assert the string is
+    # still in the pinned binary here, on every PR, so a bump fails RED up front
+    # instead of surfacing later as a cryptic 0/N-verified on a main build. Runs
+    # unconditionally (cheap) so it always reports and is safe to mark required.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/install-hauler-oras
+      - name: Assert the verification success string is present
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! grep -aqF 'signature verified for image [' "$(command -v hauler)"; then
+            echo "::error::this hauler build lacks the 'signature verified for image [' success string; update the verified-line guard in publish-haul's sync step to match this version"
+            exit 1
+          fi
   publish-haul:
     # Build-lane haul (ADR 0033): after images publish, render the manifest from
     # this run's fresh digests plus the previous build's haul (carry), sync it into
@@ -1178,34 +1199,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Install hauler and oras
-        shell: bash # default shell is `bash -e` (no pipefail); be explicit
-        env:
-          HAULER_VERSION: '2.0.2'
-          HAULER_SHA256: 'd96ac67cac3c9e4fc2d24c8347fba956b2a165a2237318cc2564e44bbaabc4c3'
-          ORAS_VERSION: '1.2.0'
-          ORAS_SHA256: '5b3f1cbb86d869eee68120b9b45b9be983f3738442f87ee5f06b00edd0bab336'
-        # Binary downloads (not curl | bash), sha256-verified before extract so a
-        # tampered/hijacked release asset can't execute in the job. Bump the
-        # version and its checksum together (from the release's checksums.txt).
-        run: |
-          curl -fsSL -o /tmp/hauler.tar.gz \
-            "https://github.com/hauler-dev/hauler/releases/download/v${HAULER_VERSION}/hauler_${HAULER_VERSION}_linux_amd64.tar.gz"
-          echo "${HAULER_SHA256}  /tmp/hauler.tar.gz" | sha256sum -c -
-          tar -xzf /tmp/hauler.tar.gz -C /usr/local/bin hauler
-          curl -fsSL -o /tmp/oras.tar.gz \
-            "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
-          echo "${ORAS_SHA256}  /tmp/oras.tar.gz" | sha256sum -c -
-          tar -xzf /tmp/oras.tar.gz -C /usr/local/bin oras
-      - name: Assert hauler's verification success string (guard canary)
-        # The sync step's fail-closed guard counts "signature verified for image ["
-        # log lines; if a hauler bump changed that wording the count would silently
-        # drop to zero and block every publish. Catch a wording change here, up front.
-        run: |
-          set -euo pipefail
-          if ! grep -aqF 'signature verified for image [' "$(command -v hauler)"; then
-            echo "::error::this hauler build lacks the 'signature verified for image [' success string; update the verified-line guard in the sync step to match this version"
-            exit 1
-          fi
+        uses: ./.github/actions/install-hauler-oras
       - name: Download this run's fresh image digests
         # No continue-on-error: a failed/partial download must fail the job (which
         # is job-level continue-on-error, so non-blocking) rather than be swallowed.


### PR DESCRIPTION
## Description

### Product
None. CI-only hardening; no product- or user-facing change.

### Technical
Follow-up to #609. That PR made the `publish-haul` sync step fail closed by counting hauler's per-image `signature verified for image [` log lines. The weakness: that success string is hauler-version-specific, so a future hauler bump that changed the wording would silently drop the count to zero and block every publish, surfacing only as a cryptic `0/N verified` on a main build.

This PR:
- Adds a dedicated **`haul-guard-canary`** job that runs on every PR and push, installs the pinned hauler, and asserts the `signature verified for image [` string is still present in the binary. It fails **red** so a hauler bump is caught at PR time, up front, with a clear message pointing at the guard. It runs unconditionally (checkout + install + grep, a few seconds) so it always reports a status and is safe to mark required without a skipped-required-check deadlock.
- Factors the duplicated, sha256-pinned hauler + oras install (previously inline in both `publish-haul` and the bootstrap workflow) into a **`.github/actions/install-hauler-oras`** composite, so all three call sites (publish, bootstrap, canary) run the same pinned, checksummed binaries from one source of truth.
- Drops the now-redundant in-job canary added in #609 (the PR-level job supersedes it and also covers `push: main`).

## Type of change
- [ ] Work behind a feature flag
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [x] Refactor (code improvement with no functional changes)
- [ ] Documentation update
- [ ] Test update

## Impact

### Security

##### Authorization
No change to user roles or data access. The new job runs with `permissions: contents: read` only.

##### Appsec
Reinforces the supply-chain posture: the canary keeps the fail-closed signature-verification guard working across hauler upgrades, so unverified/unsigned images can't silently slip into a haul after a tooling bump. The composite preserves the sha256-verified-before-extract downloads from #607 unchanged. No new secrets; the canary needs none.

### Performance
The canary is a lightweight job (checkout + two small binary downloads + a grep), a few seconds per run, negligible against the ~35m pipeline.

### Data
N/A. No data handling.

### Backward compatibility
No API, data-model, or dependency changes. Workflow-only. The composite is behavior-identical to the inline install it replaces (byte-identical download, checksum, extract); `publish-haul` and the bootstrap flow install exactly the same binaries as before.

## Testing
YAML parses; `prettier` and `actionlint` clean on all changed files (the only actionlint findings are pre-existing SC2155/SC2086 in unrelated steps). The assertion was verified to pass on the real hauler v2.0.2 binary and to fail on a binary lacking the string. CI on this PR exercises the composite and the canary job end to end.

## Note for reviewers
Stacked on #609 (the guard this canary protects). Merge #609 first; then this diff collapses to just the `install-hauler-oras` composite, the `haul-guard-canary` job, and the two install refactors. Recommend a repo admin add `haul-guard-canary` to the required status checks after merge so a hauler bump can't merge past it (safe to require: the job always runs and reports).

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (and I've run `pre-commit run --all-files`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated user documentation, if appropriate
- [ ] I have added or updated technical documentation, including an architectural decision record, if appropriate
- [ ] I have added unit tests, if appropriate
- [ ] I have added end-to-end tests, if appropriate