### PR TITLE
feat: include the published OCI charts in the build-lane haul

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1173,11 +1173,11 @@ jobs:
     # carry from it. continue-on-error so it never gates a release; it fails closed
     # (harmless) on partial builds until a one-time bootstrap seeds the first
     # predecessor. Sync verifies every component's cosign signature (--key) and
-    # fails closed if any image is unsigned or unverifiable.
-    if: github.ref_name == 'main' && needs.publish.result == 'success'
+    # fails closed if any component is unsigned or unverifiable.
+    if: github.ref_name == 'main' && needs.publish.result == 'success' && needs.publish-charts.result == 'success'
     runs-on: ubuntu-latest
     continue-on-error: true
-    needs: [changes, publish]
+    needs: [changes, publish, publish-charts]
     permissions:
       contents: read
       packages: write
@@ -1212,6 +1212,17 @@ jobs:
         with:
           pattern: image-digest-*
           path: digests
+          merge-multiple: true
+      - name: Download this run's fresh chart digests
+        # Charts go in a SEPARATE subdir: 5 chart names (hl7-transformer,
+        # hl7-listener, hl7log-extractor, launchpad, report-viewer) are also image
+        # names, so their digest files share a basename; a flat merge would clobber
+        # one. build_haul globs digests/**/* and skips dirs, so the subdir is read.
+        # Same no-continue-on-error invariant as the image digests above.
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: chart-digest-*
+          path: digests/charts
           merge-multiple: true
       - name: Render the haul manifest (carry from the predecessor)
         run: |

--- a/tooling/manifest/components.txt
+++ b/tooling/manifest/components.txt
@@ -21,28 +21,23 @@ ghcr.io/washu-tag/report-viewer
 # that name plus a "-chart" suffix. (Phase 2 decision 5 = fold these three lists
 # into one source of truth.)
 #
-# STILL COMMENTED. Chart digest capture (PR #588) is done, but two preconditions
-# remain before a chart can be carried into the haul:
-#   1. It must have been published at least once. publish-charts is changed-only,
-#      so a chart whose files have not changed since the job went live is absent
-#      from the registry and build_haul carry() (a live ghcr lookup) fails closed
-#      on it. Today only hl7-transformer, launchpad, open-webui-bootstrap, and
-#      temporal-bootstrap exist in ghcr.io/washu-tag/charts; full coverage needs
-#      a one-time publish-all (or waiting for each chart to change).
-#   2. First-push ghcr packages are private by default; carrying a private chart
-#      needs a GITHUB_TOKEN bearer wired into build_haul.ghcr_digest (anonymous
-#      today).
-# ghcr.io/washu-tag/charts/hl7-transformer
-# ghcr.io/washu-tag/charts/dcm4chee
-# ghcr.io/washu-tag/charts/hive-metastore
-# ghcr.io/washu-tag/charts/hl7-listener
-# ghcr.io/washu-tag/charts/hl7log-extractor
-# ghcr.io/washu-tag/charts/keycloak-config-cli
-# ghcr.io/washu-tag/charts/launchpad
-# ghcr.io/washu-tag/charts/open-webui-bootstrap
-# ghcr.io/washu-tag/charts/orthanc
-# ghcr.io/washu-tag/charts/report-viewer
-# ghcr.io/washu-tag/charts/scout-dashboards
-# ghcr.io/washu-tag/charts/scout-opa
-# ghcr.io/washu-tag/charts/temporal-bootstrap
-# ghcr.io/washu-tag/charts/voila
+# Each chart must be published to ghcr at least once before it can be carried:
+# publish-charts is changed-only, so a never-published chart is absent from the
+# registry and resolve fails closed on it. The bootstrap workflow seeds all 14
+# fresh for the first haul. (carry reads the previous haul.yaml, not a live ghcr
+# lookup; hauler pulls each chart via the job's GHCR login, and downstream
+# consumers get the self-contained .tar.zst, so ghcr package visibility is moot.)
+ghcr.io/washu-tag/charts/hl7-transformer
+ghcr.io/washu-tag/charts/dcm4chee
+ghcr.io/washu-tag/charts/hive-metastore
+ghcr.io/washu-tag/charts/hl7-listener
+ghcr.io/washu-tag/charts/hl7log-extractor
+ghcr.io/washu-tag/charts/keycloak-config-cli
+ghcr.io/washu-tag/charts/launchpad
+ghcr.io/washu-tag/charts/open-webui-bootstrap
+ghcr.io/washu-tag/charts/orthanc
+ghcr.io/washu-tag/charts/report-viewer
+ghcr.io/washu-tag/charts/scout-dashboards
+ghcr.io/washu-tag/charts/scout-opa
+ghcr.io/washu-tag/charts/temporal-bootstrap
+ghcr.io/washu-tag/charts/voila

--- a/tooling/manifest/components.txt
+++ b/tooling/manifest/components.txt
@@ -23,10 +23,12 @@ ghcr.io/washu-tag/report-viewer
 #
 # Each chart must be published to ghcr at least once before it can be carried:
 # publish-charts is changed-only, so a never-published chart is absent from the
-# registry and resolve fails closed on it. The bootstrap workflow seeds all 14
-# fresh for the first haul. (carry reads the previous haul.yaml, not a live ghcr
-# lookup; hauler pulls each chart via the job's GHCR login, and downstream
-# consumers get the self-contained .tar.zst, so ghcr package visibility is moot.)
+# registry and resolve fails closed on it. Going live needs a one-time publish of
+# all 14 (a no-op touch of the chart dirs in one main run) so publish-haul folds
+# them in; each then carries until it changes. Bootstrap only seeds the 8 images,
+# not charts. (carry reads the previous haul.yaml, not a live ghcr lookup; hauler
+# pulls each chart via the job's GHCR login, and downstream consumers get the
+# self-contained .tar.zst, so ghcr package visibility is moot.)
 ghcr.io/washu-tag/charts/hl7-transformer
 ghcr.io/washu-tag/charts/dcm4chee
 ghcr.io/washu-tag/charts/hive-metastore


### PR DESCRIPTION
## Description
### Product
None. Build-lane / air-gap plumbing; no user-facing change.

### Technical
The build-lane haul (ADR 0033) carried only the 8 container images. `publish-charts` already packages, pushes, digests (`chart-digest-*` artifacts), and cosign-signs all 14 OCI charts (#588/#599), but `publish-haul` never folded them in. This wires them in with **zero Python changes** (build_haul/resolve/haul are already repo-keyed and render images and OCI charts identically under `kind: Images`):
- `components.txt`: uncomment the 14 `ghcr.io/washu-tag/charts/<name>` repos and correct a stale precondition comment (carry reads the predecessor haul, not a live ghcr lookup).
- `publish-haul`: add `publish-charts` to `needs`/`if`, and download `chart-digest-*` into a **separate `digests/charts` subdir**. Five chart names are also image names (hl7-transformer, hl7-listener, hl7log-extractor, launchpad, report-viewer), so their digest files share a basename; a flat merge would clobber one. `build_haul` globs `digests/**/*` and skips dirs, so the subdir is read and the two families stay distinct.

## Type of change
- [x] Improvement

## Impact
### Security
Charts are already cosign-signed by `publish-charts`, so the existing `--key` sync guard verifies them unchanged (`verified == component count`). No trust or signing change.
### Backward compatibility
No API/data-model changes; build_haul output is a superset (8 images + 14 charts), existing image behavior untouched.

## Testing
Local render (real `components.txt` + fake fresh/predecessor digests) renders 22 components; a same-name image and chart (`hl7-transformer`) both stay fresh with distinct repos (proving the subdir fix); unseeded charts carry from the predecessor. `prettier` + `actionlint` clean.

## Note for reviewers
Stacked on the haul chain: #609 (fail-closed guard) → #616 (canary + install composite) → this. **Go-live** needs a one-time seed of all 14 charts into a predecessor haul (they publish changed-only, so no normal run has all 14 fresh); until seeded the render fails closed harmlessly (`continue-on-error`, `:main` untouched). Seed via a no-op touch of the 14 chart dirs in one main run. The wrapper charts' **upstream images** are a separate follow-up (only 4 of 7 pin their image in-repo).
