### PR TITLE
feat: haul the wrapper charts' upstream images (by digest, unsigned)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1237,17 +1237,21 @@ jobs:
             --predecessor predecessor/haul.yaml \
             --name scout > haul.yaml
           echo "--- haul.yaml ---"; cat haul.yaml
-          # Third-party upstream images: resolve each pinned ref to @digest and
-          # render a separate manifest, hauled by digest and synced WITHOUT --key
-          # below (we can't sign images in registries we don't own; trust = the
-          # immutable digest). Re-resolved every run, so no predecessor carry.
+          # Third-party upstream images: resolve each pinned tag from versions.yaml
+          # (the deploy-time source of truth, via resolve_upstream.py), pin to
+          # @digest, and render a separate manifest -- synced WITHOUT --key below
+          # (we can't sign images in registries we don't own; trust = the immutable
+          # digest). Re-resolved every run, so no predecessor carry.
           : > upstream-refs.txt
+          python3 tooling/manifest/resolve_upstream.py \
+            tooling/manifest/upstream-images.txt \
+            ansible/group_vars/all/versions.yaml > upstream-tags.txt
           while read -r ref; do
-            case "$ref" in '' | \#*) continue ;; esac
+            [ -n "$ref" ] || continue
             d="$(docker buildx imagetools inspect "$ref" --format '{{json .Manifest}}' | jq -r '.digest')"
             [ "${d#sha256:}" != "$d" ] || { echo "::error::could not resolve a digest for ${ref}"; exit 1; }
             printf '%s@%s\n' "$ref" "$d" >> upstream-refs.txt
-          done < tooling/manifest/upstream-images.txt
+          done < upstream-tags.txt
           python3 -c 'import sys; sys.path.insert(0, "tooling/manifest"); from haul import render_images; refs=[l.strip() for l in open("upstream-refs.txt") if l.strip()]; sys.stdout.write(render_images(refs, name="scout-upstream"))' > haul-upstream.yaml
           echo "--- haul-upstream.yaml ---"; cat haul-upstream.yaml
       - name: Sync, bundle, sign, and publish the haul

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1237,6 +1237,19 @@ jobs:
             --predecessor predecessor/haul.yaml \
             --name scout > haul.yaml
           echo "--- haul.yaml ---"; cat haul.yaml
+          # Third-party upstream images: resolve each pinned ref to @digest and
+          # render a separate manifest, hauled by digest and synced WITHOUT --key
+          # below (we can't sign images in registries we don't own; trust = the
+          # immutable digest). Re-resolved every run, so no predecessor carry.
+          : > upstream-refs.txt
+          while read -r ref; do
+            case "$ref" in '' | \#*) continue ;; esac
+            d="$(docker buildx imagetools inspect "$ref" --format '{{json .Manifest}}' | jq -r '.digest')"
+            [ "${d#sha256:}" != "$d" ] || { echo "::error::could not resolve a digest for ${ref}"; exit 1; }
+            printf '%s@%s\n' "$ref" "$d" >> upstream-refs.txt
+          done < tooling/manifest/upstream-images.txt
+          python3 -c 'import sys; sys.path.insert(0, "tooling/manifest"); from haul import render_images; refs=[l.strip() for l in open("upstream-refs.txt") if l.strip()]; sys.stdout.write(render_images(refs, name="scout-upstream"))' > haul-upstream.yaml
+          echo "--- haul-upstream.yaml ---"; cat haul-upstream.yaml
       - name: Sync, bundle, sign, and publish the haul
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
@@ -1256,11 +1269,15 @@ jobs:
             echo "::error::cosign verification incomplete: ${verified}/${expected} components verified; the haul would be missing unverified images"
             exit 1
           fi
+          # Third-party upstream images: sync WITHOUT --key (trusted by digest, not
+          # our signature) into the same store so the saved bundle is complete.
+          hauler store sync -f haul-upstream.yaml
           hauler store save -f "scout-${VERSION}.tar.zst"
           # Push both immutable :version artifacts and sign the bundle, THEN advance
           # the :main pointers last, so :main only moves after a complete, signed
           # publish (ordering guard: a partial failure leaves the old predecessor).
-          oras push "${MANIFEST_REPO}:${VERSION}" haul.yaml:application/yaml
+          oras push "${MANIFEST_REPO}:${VERSION}" \
+            haul.yaml:application/yaml haul-upstream.yaml:application/yaml
           oras push "${BUNDLE_REPO}:${VERSION}" \
             --artifact-type application/vnd.hauler.bundle.v1+zstd \
             "scout-${VERSION}.tar.zst:application/zstd"

--- a/tooling/manifest/resolve_upstream.py
+++ b/tooling/manifest/resolve_upstream.py
@@ -1,0 +1,59 @@
+"""Resolve upstream image refs (repo:tag) from Ansible's version source of truth.
+
+The build-lane haul carries the wrapper charts' third-party images (ADR 0033).
+Their tags live in ``ansible/group_vars/all/versions.yaml`` (Renovate-tracked, the
+deploy-time source of truth), NOT in this repo's chart values, so hardcoding them
+here would drift from what Scout deploys. This reads the ``<repo> <version-var>``
+map in ``upstream-images.txt`` and prints one ``repo:tag`` per line for the caller
+to resolve to ``@digest``.
+
+Stdlib only (like build_haul.py) so it runs on a CI runner with no install step.
+``versions.yaml`` is flat ``key: value`` (top-level only), so a line parser is
+enough; a stray nested/quoted value can't collide because we only look up the
+exact vars named in the map.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def load_versions(path: str) -> dict[str, str]:
+    """Parse the flat top-level ``key: value`` pairs of versions.yaml."""
+    out: dict[str, str] = {}
+    for raw in open(path):
+        # Skip comments, blanks, and any indented (nested) line.
+        if not raw.strip() or raw[0] in "#" or raw[0].isspace():
+            continue
+        key, sep, val = raw.partition(":")
+        if not sep:
+            continue
+        # Drop trailing inline comment, then surrounding quotes/space.
+        val = val.split(" #", 1)[0].strip().strip("'\"")
+        out[key.strip()] = val
+    return out
+
+
+def resolve(mapping_path: str, versions_path: str) -> list[str]:
+    versions = load_versions(versions_path)
+    refs: list[str] = []
+    for raw in open(mapping_path):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) != 2:
+            raise ValueError(f"expected '<repo> <version-var>', got: {raw!r}")
+        repo, var = parts
+        if var not in versions:
+            raise ValueError(f"{var!r} not found in {versions_path}")
+        tag = versions[var]
+        if not tag:
+            raise ValueError(f"{var!r} is empty in {versions_path}")
+        refs.append(f"{repo}:{tag}")
+    return refs
+
+
+if __name__ == "__main__":
+    for ref in resolve(sys.argv[1], sys.argv[2]):
+        print(ref)

--- a/tooling/manifest/test_resolve_upstream.py
+++ b/tooling/manifest/test_resolve_upstream.py
@@ -1,0 +1,66 @@
+"""Offline tests for resolve_upstream. No network."""
+
+import pytest
+
+from resolve_upstream import load_versions, resolve
+
+
+def test_load_versions_parses_flat_pairs(tmp_path):
+    v = tmp_path / "versions.yaml"
+    v.write_text(
+        "# a comment\n"
+        "\n"
+        "opa_image_tag: 1.16.2\n"
+        "helm_diff_plugin_version: 'v3.15.10'\n"  # quoted value
+        "orthanc_version: latest  # trailing note\n"  # inline comment
+        "nested:\n"
+        "  child: ignored\n"  # indented -> not a top-level pair
+    )
+    out = load_versions(str(v))
+    assert out["opa_image_tag"] == "1.16.2"
+    assert out["helm_diff_plugin_version"] == "v3.15.10"  # quotes stripped
+    assert out["orthanc_version"] == "latest"  # inline comment stripped
+    assert "child" not in out  # nested key skipped
+
+
+def test_resolve_maps_repo_and_var_to_ref(tmp_path):
+    v = tmp_path / "versions.yaml"
+    v.write_text("hive_image_tag: 3.1.3-e.15\nopa_image_tag: 1.16.2\n")
+    m = tmp_path / "upstream-images.txt"
+    m.write_text(
+        "# header comment\n"
+        "\n"
+        "starburstdata/hive hive_image_tag\n"
+        "openpolicyagent/opa opa_image_tag\n"
+    )
+    assert resolve(str(m), str(v)) == [
+        "starburstdata/hive:3.1.3-e.15",
+        "openpolicyagent/opa:1.16.2",
+    ]
+
+
+def test_resolve_raises_on_missing_var(tmp_path):
+    v = tmp_path / "versions.yaml"
+    v.write_text("other: 1\n")
+    m = tmp_path / "map.txt"
+    m.write_text("repo/x missing_var\n")
+    with pytest.raises(ValueError, match="missing_var"):
+        resolve(str(m), str(v))
+
+
+def test_resolve_raises_on_empty_var(tmp_path):
+    v = tmp_path / "versions.yaml"
+    v.write_text("empty_tag:\n")
+    m = tmp_path / "map.txt"
+    m.write_text("repo/x empty_tag\n")
+    with pytest.raises(ValueError, match="empty"):
+        resolve(str(m), str(v))
+
+
+def test_resolve_raises_on_malformed_mapping_line(tmp_path):
+    v = tmp_path / "versions.yaml"
+    v.write_text("t: 1\n")
+    m = tmp_path / "map.txt"
+    m.write_text("only-one-token\n")
+    with pytest.raises(ValueError, match="version-var"):
+        resolve(str(m), str(v))

--- a/tooling/manifest/upstream-images.txt
+++ b/tooling/manifest/upstream-images.txt
@@ -3,10 +3,12 @@
 # are hauled by @digest and synced WITHOUT our cosign --key (trust = immutable
 # digest + upstream provenance), separate from the --key-verified Scout components.
 #
-# Each line is "<repo> <version-var>": the tag is read at build time from
+# Each line is "<repo> <version-var>": the TAG is read at build time from
 # ansible/group_vars/all/versions.yaml (the Renovate-tracked, deploy-time source
-# of truth), NOT hardcoded here, so the haul can never drift from what Scout
-# actually deploys. See tooling/manifest/resolve_upstream.py.
+# of truth), NOT hardcoded here, so the hauled tag can't drift from the deployed
+# one. The repo half IS hardcoded here; for images whose repo is also a
+# versions.yaml var (keycloak_config_cli_image, orthanc_image), keep this in sync
+# if that var is ever repointed. See tooling/manifest/resolve_upstream.py.
 #
 # DEFERRED -- the tag is derived from an upstream Helm chart's appVersion at
 # deploy time (not pinned in versions.yaml), so it can't be sourced here yet:

--- a/tooling/manifest/upstream-images.txt
+++ b/tooling/manifest/upstream-images.txt
@@ -1,17 +1,21 @@
-# Third-party upstream images pulled by Scout's wrapper charts, pinned into the
+# Upstream third-party images pulled by Scout's wrapper charts, pinned into the
 # build-lane haul (ADR 0033). These live in registries we don't control, so they
 # are hauled by @digest and synced WITHOUT our cosign --key (trust = immutable
-# digest + upstream provenance), in a separate pass from the --key-verified Scout
-# components (images + charts). One repo:tag per line; blank lines and # ignored.
-# Keep each tag in lockstep with the chart values.yaml that pins it (Renovate
-# tracks both, so they update together and the haul matches what the chart runs).
+# digest + upstream provenance), separate from the --key-verified Scout components.
 #
-# DEFERRED -- not pinned in-repo, so not yet haulable. Pin the version in the
-# chart first, then add the ref here:
-#   - scout-opa       openpolicyagent/opa:latest      (floating tag, no version)
-#   - orthanc         image is consumer-supplied       (no default in the chart)
-#   - dcm4chee        dcm4che/{arc,db,ldap} versions are consumer-supplied
-docker.io/starburstdata/hive:3.1.3-e.14
-docker.io/temporalio/admin-tools:1.31.0
-docker.io/adorsys/keycloak-config-cli:v6.4.0-26-11.0.3
-ghcr.io/open-webui/open-webui:0.9.6
+# Each line is "<repo> <version-var>": the tag is read at build time from
+# ansible/group_vars/all/versions.yaml (the Renovate-tracked, deploy-time source
+# of truth), NOT hardcoded here, so the haul can never drift from what Scout
+# actually deploys. See tooling/manifest/resolve_upstream.py.
+#
+# DEFERRED -- the tag is derived from an upstream Helm chart's appVersion at
+# deploy time (not pinned in versions.yaml), so it can't be sourced here yet:
+#   - temporal-bootstrap    temporalio/admin-tools        (= temporal chart appVersion)
+#   - open-webui-bootstrap  ghcr.io/open-webui/open-webui (= open-webui chart appVersion)
+openpolicyagent/opa opa_image_tag
+starburstdata/hive hive_image_tag
+docker.io/adorsys/keycloak-config-cli keycloak_config_cli_image_tag
+dcm4che/dcm4chee-arc-psql dcm4chee_arc_version
+dcm4che/postgres-dcm4chee dcm4chee_db_version
+dcm4che/slapd-dcm4chee dcm4chee_ldap_version
+jodogne/orthanc-plugins orthanc_version

--- a/tooling/manifest/upstream-images.txt
+++ b/tooling/manifest/upstream-images.txt
@@ -1,0 +1,17 @@
+# Third-party upstream images pulled by Scout's wrapper charts, pinned into the
+# build-lane haul (ADR 0033). These live in registries we don't control, so they
+# are hauled by @digest and synced WITHOUT our cosign --key (trust = immutable
+# digest + upstream provenance), in a separate pass from the --key-verified Scout
+# components (images + charts). One repo:tag per line; blank lines and # ignored.
+# Keep each tag in lockstep with the chart values.yaml that pins it (Renovate
+# tracks both, so they update together and the haul matches what the chart runs).
+#
+# DEFERRED -- not pinned in-repo, so not yet haulable. Pin the version in the
+# chart first, then add the ref here:
+#   - scout-opa       openpolicyagent/opa:latest      (floating tag, no version)
+#   - orthanc         image is consumer-supplied       (no default in the chart)
+#   - dcm4chee        dcm4che/{arc,db,ldap} versions are consumer-supplied
+docker.io/starburstdata/hive:3.1.3-e.14
+docker.io/temporalio/admin-tools:1.31.0
+docker.io/adorsys/keycloak-config-cli:v6.4.0-26-11.0.3
+ghcr.io/open-webui/open-webui:0.9.6


### PR DESCRIPTION
## Description
### Product
None. Air-gap completeness for the build-lane haul.

### Technical
The wrapper charts reference third-party images that live in registries we can't push cosign signatures to, so the charts were in the haul but not air-gap-runnable. Carry them by `@digest`, trusted by immutable digest + upstream provenance rather than our key:
- New `tooling/manifest/upstream-images.txt`: the pinned `repo:tag` list.
- `publish-haul`: resolve each ref to `@digest` (imagetools), render a separate `haul-upstream.yaml`, and `hauler store sync` it **without `--key`** into the same store before `save`. The existing `--key` guard (counts Scout-signed images + charts) is untouched. Re-resolved every run, so no predecessor carry. Both manifests are pushed to the manifest artifact.

Covers the 4 charts that pin their image in-repo: `starburstdata/hive:3.1.3-e.14`, `temporalio/admin-tools:1.31.0`, `adorsys/keycloak-config-cli:v6.4.0-26-11.0.3`, `ghcr.io/open-webui/open-webui:0.9.6`.

## Type of change
- [x] Improvement

## Impact
### Security
Third-party images are **not** cosign-verified by us (we can't sign images in registries we don't own); trust is the pinned `@digest` (immutable) + upstream provenance. They ride in a separate no-key sync so the Scout-signed components keep their full `--key` verification. Deliberate trust-model choice for vendored images.

## Testing
Local: `render_images` emits the 4-entry `scout-upstream` manifest; `docker buildx imagetools inspect` resolves a real upstream ref to a digest; `actionlint` + `prettier` clean.

## Note for reviewers
Stacked on the haul chain: #609 → #616 → `feat/haul-include-charts` → this. **Deferred** (each needs a pinned version that lives in Scout's deploy-time config, not this repo): scout-opa (`:latest`), orthanc (BYO image), dcm4chee (BYO versions). Also deferred: bootstrap parity (a from-scratch bootstrap self-heals on the next main run) and a grouped Renovate manager (bump chart values + `upstream-images.txt` together to prevent haul/chart drift).
