### PR TITLE
fix(ci): stamp scout-opa and temporal-bootstrap chart versions on release

### DIFF
--- a/.github/scripts/update-versions.sh
+++ b/.github/scripts/update-versions.sh
@@ -194,6 +194,16 @@ update_file "helm/open-webui-bootstrap/Chart.yaml" \
     "\\1 $HELM_VERSION" \
     "open-webui-bootstrap chart version"
 
+update_file "helm/scout-opa/Chart.yaml" \
+    "^(version:) .+$" \
+    "\\1 $HELM_VERSION" \
+    "scout-opa chart version"
+
+update_file "helm/temporal-bootstrap/Chart.yaml" \
+    "^(version:) .+$" \
+    "\\1 $HELM_VERSION" \
+    "temporal-bootstrap chart version"
+
 echo ""
 echo "Helm values.yaml files (image.tag)..."
 update_file "helm/launchpad/values.yaml" \

--- a/docs/internal/versions-and-releases.md
+++ b/docs/internal/versions-and-releases.md
@@ -463,6 +463,9 @@ This section documents all files containing version strings. The Release Workflo
 | `helm/open-webui-bootstrap/Chart.yaml` | `version` only | `0.0.0-dev` | `appVersion` is unused — chart orchestrates a Job against the runtime-discovered OWUI image |
 | `helm/voila/values.yaml` | `image.tag` | `latest` | Uses scout-notebook image (shared with JupyterHub singleuser) |
 | `helm/scout-dashboards/Chart.yaml` | `version` only | `0.0.0-dev` | `appVersion` is unused — chart orchestrates Superset asset imports |
+| `helm/keycloak-config-cli/Chart.yaml` | `version` only | `0.0.0-dev` | `appVersion` tracks the keycloak-config-cli version |
+| `helm/scout-opa/Chart.yaml` | `version` only | `0.0.0-dev` | `appVersion` is unused — chart deploys the upstream `openpolicyagent/opa` image, tagged from `values.yaml` |
+| `helm/temporal-bootstrap/Chart.yaml` | `version` only | `0.0.0-dev` | `appVersion` is unused — chart runs Helm-hook Jobs against `temporalio/admin-tools` |
 
 ### VERSION Files
 

--- a/helm/scout-opa/Chart.yaml
+++ b/helm/scout-opa/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: scout-opa
 description: OPA policy engine enforcing Scout's Trino access-control policy (ADRs 0020/0021)
 type: application
-version: 0.0.0-dev
+version: 4.1.0
 appVersion: "latest"

--- a/helm/temporal-bootstrap/Chart.yaml
+++ b/helm/temporal-bootstrap/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: temporal-bootstrap
 description: "Idempotent Temporal setup applied as Helm hooks (post-install,post-upgrade), mirroring the scout-dashboards import model. Currently enforces the `default` namespace's workflow-history retention (issue #432); a natural home for future Temporal bootstrap such as the scheduled-ingest schedule."
 type: application
-version: 0.0.0-dev
+version: 4.1.0
 appVersion: "latest"


### PR DESCRIPTION
The `scout-opa` and `temporal-bootstrap` helm charts weren't included in the release workflow's version bump task, so they didn't get bumped to a release version on running the workflow.

## Description

### Product
N/A

### Technical
- Add `scout-opa` and `temporal-bootstrap` to the release version bump task
- Manually bump `scout-opa` and `temporal-bootstrap` charts to 4.1.0
