### PR TITLE
fix: remediate keycloak + hl7-listener trivy CVEs (micrometer-core)

### DIFF
--- a/hl7-listener/build.gradle
+++ b/hl7-listener/build.gradle
@@ -81,6 +81,9 @@ configurations.all {
 		} else if (g == 'org.apache.tomcat.embed') {
 			details.useVersion '10.1.55' // CVE-2026-41293/-43512/-43515 (CRITICAL) + -34483/-41284/-42498/-43513
 			details.because 'Trivy CRITICAL/HIGH'
+		} else if (g == 'io.micrometer' && n.startsWith('micrometer')) {
+			details.useVersion '1.15.12' // CVE-2026-40983/-40984 (micrometer-core); stay on Spring Boot 3.5.16's 1.15.x line
+			details.because 'Trivy HIGH'
 		}
 	}
 }

--- a/keycloak/.trivyignore.yaml
+++ b/keycloak/.trivyignore.yaml
@@ -38,3 +38,8 @@ vulnerabilities:
   # Keycloak base ships the fixed RPMs yet, and 26.6.4 is the latest release.
   - id: CVE-2026-47063 # java-21-openjdk-headless 21.0.11 (base RPM)
   - id: CVE-2026-54369 # libacl 2.3.1-4.el9 (base RPM)
+  # micrometer-core bundled by the Keycloak/Quarkus distribution's metrics
+  # subsystem (not our event-listener provider jar). Fixed in 1.16.6, which
+  # Keycloak 26.6.4 (Quarkus BOM) doesn't bundle yet; drop when a newer base ships it.
+  - id: CVE-2026-40983 # io.micrometer:micrometer-core 1.16.3
+  - id: CVE-2026-40984 # io.micrometer:micrometer-core 1.16.3


### PR DESCRIPTION
## Description
### Product
None. CI/security remediation.

### Technical
`scan-images` is red on `main` (and any PR that rebuilds these images, e.g. anything touching `ci.yaml`) with 2 fixable HIGH each: `CVE-2026-40983` + `CVE-2026-40984` in `io.micrometer:micrometer-core`.
- **hl7-listener**: micrometer-core `1.15.10` arrives transitively via the Spring Boot 3.5.16 BOM. Added a `resolutionStrategy` pin to `1.15.12` (in-line patch, matching the existing netty/jackson/tomcat pins). Rebuilt + rescanned locally: **0 fixable**, all micrometer modules consistent at 1.15.12.
- **keycloak**: micrometer-core `1.16.3` is bundled by the `quay.io/keycloak/keycloak:26.6.4` base distribution (not our event-listener provider jar), fixed in 1.16.6 which 26.6.4 doesn't ship yet. Suppressed both in `keycloak/.trivyignore.yaml` with justification, matching the existing base-distribution entries. Base scan: **0 fixable**.

## Type of change
- [x] Bug fix

## Impact
### Security
hl7-listener now runs the patched micrometer. The keycloak suppressions are for a component bundled in the upstream base image and not loaded by our provider jar; drop them when a newer Keycloak base ships micrometer ≥1.16.6.

## Testing
Local reproduction of the CI scan (same Dockerfiles): keycloak base with the updated ignorefile → 0 fixable HIGH/CRIT; hl7-listener rebuilt with the pin → 0 fixable HIGH/CRIT. CI on this PR confirms against the freshly-built images.

## Note for reviewers
Repo-wide fix off `main`; unblocks `scan-images` on `main` and every open PR (this is why #609 etc. were red, CVE-DB drift surfaced these on all rebuilds, not any feature change).
