### PR TITLE
fix(ci): publish images with a missing tag, and block releases that lack them

### DIFF
--- a/.github/actions/check-image-exists/action.yaml
+++ b/.github/actions/check-image-exists/action.yaml
@@ -24,6 +24,7 @@ runs:
       id: check-registry
       shell: bash
       env:
+        GH_TOKEN: ${{ github.token }}
         VERSION: ${{ steps.derive-version.outputs.version }}
         IMAGE_NAME: ${{ inputs.image-name }}
       # An ambiguous registry answer exits non-zero rather than reporting a

--- a/.github/actions/check-image-exists/action.yaml
+++ b/.github/actions/check-image-exists/action.yaml
@@ -24,16 +24,14 @@ runs:
       id: check-registry
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
         VERSION: ${{ steps.derive-version.outputs.version }}
         IMAGE_NAME: ${{ inputs.image-name }}
+      # An ambiguous registry answer exits non-zero rather than reporting a
+      # "false" nobody can trust -- a wrong "false" here rebuilds the image and,
+      # in ci.yaml's publish job, pushes it over the tag that is already there.
       run: |
-        # Query GitHub Container Registry API
-        if gh api "/orgs/washu-tag/packages/container/${IMAGE_NAME}/versions" \
-           --jq '.[] | select(.metadata.container.tags[]? == "'"${VERSION}"'")' 2>/dev/null | grep -q .; then
-          echo "exists=true" >> $GITHUB_OUTPUT
-          echo "Image ${IMAGE_NAME}:${VERSION} exists in registry"
-        else
-          echo "exists=false" >> $GITHUB_OUTPUT
-          echo "Image ${IMAGE_NAME}:${VERSION} does not exist in registry"
-        fi
+        set -euo pipefail
+        exists="$(bash "${GITHUB_WORKSPACE}/.github/scripts/ghcr-tag-published.sh" \
+          "${IMAGE_NAME}" "${VERSION}")"
+        echo "exists=${exists}" >> "$GITHUB_OUTPUT"
+        echo "Image ${IMAGE_NAME}:${VERSION} exists=${exists}"

--- a/.github/scripts/ghcr-tag-published.sh
+++ b/.github/scripts/ghcr-tag-published.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Is ghcr.io/washu-tag/<image>:<tag> published?
+#
+# Usage:
+#   ghcr-tag-published.sh <image-name> <tag>   # prints "true" or "false"
+#
+# Prints the answer and exits 0 when the registry gave a definitive one; prints
+# an ::error:: and exits non-zero when it did not, so no caller has to guess
+# from an ambiguous result. Callers decide what a "false" means to them --
+# ci.yaml builds and publishes, release.yaml refuses to cut the release.
+#
+# Asks about the one tag rather than listing package versions: the packages API
+# has no tag filter, and images carry 100+ versions (untagged ones are never
+# pruned), so a list-and-grep only ever saw the newest page.
+set -euo pipefail
+
+IMAGE="${1:?usage: $0 <image-name> <tag>}"
+TAG="${2:?usage: $0 <image-name> <tag>}"
+
+repo="washu-tag/${IMAGE}"
+# Retry first, so a hard failure below means a real problem rather than a blip:
+# curl retries timeouts, connection failures, 408/429/5xx -- never 404.
+retry=(--retry 3 --retry-connrefused --retry-delay 2)
+
+token_body="$(mktemp)"
+trap 'rm -f "${token_body}"' EXIT
+
+# ghcr mints a pull token per repository. An image that has never been pushed
+# has no repository, so the token endpoint answers 403 DENIED instead of issuing
+# one -- that, not a 404 on the manifest, is what a brand-new image looks like.
+token_code="$(curl -sS "${retry[@]}" -o "${token_body}" -w '%{http_code}' \
+  "https://ghcr.io/token?service=ghcr.io&scope=repository:${repo}:pull")" || {
+  echo "::error::could not reach the ghcr token endpoint for ${repo}" >&2
+  exit 1
+}
+case "${token_code}" in
+  200) ;;
+  403)
+    echo false
+    exit 0
+    ;;
+  *)
+    echo "::error::ghcr token endpoint returned HTTP ${token_code} for ${repo}" >&2
+    exit 1
+    ;;
+esac
+
+# A manifest is a few KB of JSON listing layer digests; HEAD transfers no body at
+# all. Layers live under /v2/<repo>/blobs/ and are never touched here.
+manifest_code="$(curl -sS "${retry[@]}" --head -o /dev/null -w '%{http_code}' \
+  -H "Authorization: Bearer $(jq -r '.token' "${token_body}")" \
+  -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+  "https://ghcr.io/v2/${repo}/manifests/${TAG}")" || {
+  echo "::error::could not reach ghcr for ${repo}:${TAG}" >&2
+  exit 1
+}
+case "${manifest_code}" in
+  200) echo true ;;
+  404) echo false ;;
+  *)
+    echo "::error::ghcr returned HTTP ${manifest_code} for ${repo}:${TAG}; refusing to guess whether it is published" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/ghcr-tag-published.sh
+++ b/.github/scripts/ghcr-tag-published.sh
@@ -3,55 +3,57 @@
 # Is ghcr.io/washu-tag/<image>:<tag> published?
 #
 # Usage:
-#   ghcr-tag-published.sh <image-name> <tag>   # prints "true" or "false"
+#   GH_TOKEN=<token with packages:read> ghcr-tag-published.sh <image-name> <tag>
 #
-# Prints the answer and exits 0 when the registry gave a definitive one; prints
-# an ::error:: and exits non-zero when it did not, so no caller has to guess
-# from an ambiguous result. Callers decide what a "false" means to them --
-# ci.yaml builds and publishes, release.yaml refuses to cut the release.
+# Prints "true" or "false" and exits 0 when the registry gave a definitive
+# answer; prints an ::error:: and exits non-zero when it did not, so no caller
+# has to guess from an ambiguous result. Callers decide what a "false" means to
+# them -- ci.yaml builds and publishes, release.yaml refuses to cut the release.
 #
 # Asks about the one tag rather than listing package versions: the packages API
 # has no tag filter, and images carry 100+ versions (untagged ones are never
 # pruned), so a list-and-grep only ever saw the newest page.
+#
+# The pull token must be authenticated. A package's default visibility is
+# private, so an anonymous request cannot tell a private image from one that was
+# never pushed and would report every newly published image as missing --
+# which, for release.yaml, would block the release. Authenticated, a repo that
+# does not exist simply 404s on the manifest like any missing tag, so there is no
+# separate "no such repository" case to handle.
 set -euo pipefail
 
 IMAGE="${1:?usage: $0 <image-name> <tag>}"
 TAG="${2:?usage: $0 <image-name> <tag>}"
+: "${GH_TOKEN:?GH_TOKEN must be set to a token with packages:read}"
 
 repo="washu-tag/${IMAGE}"
-# Retry first, so a hard failure below means a real problem rather than a blip:
-# curl retries timeouts, connection failures, 408/429/5xx -- never 404.
-retry=(--retry 3 --retry-connrefused --retry-delay 2)
+
+# --max-time bounds each attempt, NOT the sequence, so --retry-max-time bounds
+# the sequence. curl retries timeouts, connection failures, 408/429/5xx -- never
+# a 404, so a genuine "absent" still returns on the first try.
+curl_opts=(-sS --max-time 10 --retry 3 --retry-connrefused --retry-delay 2 --retry-max-time 30)
 
 token_body="$(mktemp)"
 trap 'rm -f "${token_body}"' EXIT
 
-# ghcr mints a pull token per repository. An image that has never been pushed
-# has no repository, so the token endpoint answers 403 DENIED instead of issuing
-# one -- that, not a 404 on the manifest, is what a brand-new image looks like.
-token_code="$(curl -sS "${retry[@]}" -o "${token_body}" -w '%{http_code}' \
-  "https://ghcr.io/token?service=ghcr.io&scope=repository:${repo}:pull")" || {
+# Credentials go in via stdin config, never argv.
+token_code="$(printf 'user = "x:%s"\n' "${GH_TOKEN}" \
+  | curl "${curl_opts[@]}" -K - -o "${token_body}" -w '%{http_code}' \
+    "https://ghcr.io/token?service=ghcr.io&scope=repository:${repo}:pull")" || {
   echo "::error::could not reach the ghcr token endpoint for ${repo}" >&2
   exit 1
 }
-case "${token_code}" in
-  200) ;;
-  403)
-    echo false
-    exit 0
-    ;;
-  *)
-    echo "::error::ghcr token endpoint returned HTTP ${token_code} for ${repo}" >&2
-    exit 1
-    ;;
-esac
+if [ "${token_code}" != '200' ]; then
+  echo "::error::ghcr token endpoint returned HTTP ${token_code} for ${repo}" >&2
+  exit 1
+fi
 
-# A manifest is a few KB of JSON listing layer digests; HEAD transfers no body at
-# all. Layers live under /v2/<repo>/blobs/ and are never touched here.
-manifest_code="$(curl -sS "${retry[@]}" --head -o /dev/null -w '%{http_code}' \
-  -H "Authorization: Bearer $(jq -r '.token' "${token_body}")" \
-  -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
-  "https://ghcr.io/v2/${repo}/manifests/${TAG}")" || {
+# A manifest is a few KB of JSON listing layer digests, and HEAD transfers no
+# body at all. Layers live under /v2/<repo>/blobs/ and are never touched here.
+manifest_code="$(printf 'header = "Authorization: Bearer %s"\n' "$(jq -r '.token' "${token_body}")" \
+  | curl "${curl_opts[@]}" -K - --head -o /dev/null -w '%{http_code}' \
+    -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+    "https://ghcr.io/v2/${repo}/manifests/${TAG}")" || {
   echo "::error::could not reach ghcr for ${repo}:${TAG}" >&2
   exit 1
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,6 +152,9 @@ jobs:
     needs: changes
     permissions:
       contents: read
+      # check-image-exists reads ghcr to see whether the derived tag is already
+      # published; packages default to private, so that read has to be authenticated.
+      packages: read
       attestations: write
       id-token: write
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -878,50 +878,106 @@ jobs:
 
           echo "Disk space after cleanup:"
           df -h
+      # Publish when the paths changed OR the derived tag is absent from the
+      # registry. build-and-upload already builds on both signals; gating the
+      # push on the paths-filter alone silently discarded the second kind, which
+      # is how v4.1.0 shipped with no 4.1.0 image tags -- its CI had to be fixed
+      # forward on a commit touching only two images, so the rest were built at
+      # 4.1.0, scanned, and dropped. Deliberately NOT gated on `ci`: that
+      # rebuilds everything to re-scan, and publishing there would overwrite
+      # already-published upstream tags (superset, keycloak) with rebuilt bits.
+      - name: 'Check published - hl7log-extractor'
+        id: published-hl7log-extractor
+        uses: ./.github/actions/check-image-exists
+        with:
+          subproject: extractor/hl7log-extractor
+          image-name: hl7log-extractor
       - name: 'Push Image - hl7log-extractor'
-        if: needs.changes.outputs.hl7log-extractor == 'true'
+        if: needs.changes.outputs.hl7log-extractor == 'true' || steps.published-hl7log-extractor.outputs.exists == 'false'
         uses: ./.github/actions/docker-push
         with:
           image-name: hl7log-extractor
           version: ${{ needs.changes.outputs.version }}
+      - name: 'Check published - hl7-transformer'
+        id: published-hl7-transformer
+        uses: ./.github/actions/check-image-exists
+        with:
+          subproject: extractor/hl7-transformer
+          image-name: hl7-transformer
       - name: 'Push Image - hl7-transformer'
-        if: needs.changes.outputs.hl7-transformer == 'true'
+        if: needs.changes.outputs.hl7-transformer == 'true' || steps.published-hl7-transformer.outputs.exists == 'false'
         uses: ./.github/actions/docker-push
         with:
           image-name: hl7-transformer
           version: ${{ needs.changes.outputs.version }}
+      - name: 'Check published - hl7-listener'
+        id: published-hl7-listener
+        uses: ./.github/actions/check-image-exists
+        with:
+          subproject: hl7-listener
+          image-name: hl7-listener
       - name: 'Push Image - hl7-listener'
-        if: needs.changes.outputs.hl7-listener == 'true'
+        if: needs.changes.outputs.hl7-listener == 'true' || steps.published-hl7-listener.outputs.exists == 'false'
         uses: ./.github/actions/docker-push
         with:
           image-name: hl7-listener
           version: ${{ needs.changes.outputs.version }}
+      - name: 'Check published - scout-notebook'
+        id: published-scout-notebook
+        uses: ./.github/actions/check-image-exists
+        with:
+          subproject: helm/scout-notebook
+          image-name: scout-notebook
       - name: 'Push Image - scout-notebook'
-        if: needs.changes.outputs.scout-notebook == 'true'
+        if: needs.changes.outputs.scout-notebook == 'true' || steps.published-scout-notebook.outputs.exists == 'false'
         uses: ./.github/actions/docker-push
         with:
           image-name: scout-notebook
           version: ${{ needs.changes.outputs.version }}
+      - name: 'Check published - launchpad'
+        id: published-launchpad
+        uses: ./.github/actions/check-image-exists
+        with:
+          subproject: launchpad
+          image-name: launchpad
       - name: 'Push Image - launchpad'
-        if: needs.changes.outputs.launchpad == 'true'
+        if: needs.changes.outputs.launchpad == 'true' || steps.published-launchpad.outputs.exists == 'false'
         uses: ./.github/actions/docker-push
         with:
           image-name: launchpad
           version: ${{ needs.changes.outputs.version }}
+      - name: 'Check published - superset'
+        id: published-superset
+        uses: ./.github/actions/check-image-exists
+        with:
+          subproject: helm/superset
+          image-name: superset
       - name: 'Push Image - superset'
-        if: needs.changes.outputs.superset == 'true'
+        if: needs.changes.outputs.superset == 'true' || steps.published-superset.outputs.exists == 'false'
         uses: ./.github/actions/docker-push
         with:
           image-name: superset
           version: ${{ needs.changes.outputs.version }}
+      - name: 'Check published - keycloak'
+        id: published-keycloak
+        uses: ./.github/actions/check-image-exists
+        with:
+          subproject: keycloak
+          image-name: keycloak
       - name: 'Push Image - keycloak'
-        if: needs.changes.outputs.keycloak == 'true'
+        if: needs.changes.outputs.keycloak == 'true' || steps.published-keycloak.outputs.exists == 'false'
         uses: ./.github/actions/docker-push
         with:
           image-name: keycloak
           version: ${{ needs.changes.outputs.version }}
+      - name: 'Check published - report-viewer'
+        id: published-report-viewer
+        uses: ./.github/actions/check-image-exists
+        with:
+          subproject: report-viewer
+          image-name: report-viewer
       - name: 'Push Image - report-viewer'
-        if: needs.changes.outputs.report-viewer == 'true'
+        if: needs.changes.outputs.report-viewer == 'true' || steps.published-report-viewer.outputs.exists == 'false'
         uses: ./.github/actions/docker-push
         with:
           image-name: report-viewer

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -355,6 +355,7 @@ jobs:
 
       - name: Verify the release images were published
         env:
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
         # wait-for-build only proves CI went green, not that it published
         # anything. On main the images come from ci.yaml's publish job, which

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,13 @@ permissions:
   attestations: write
   id-token: write
 
+env:
+  # The images update-versions.sh stamps, i.e. the ones a release retags. superset
+  # and keycloak are built from a vendored upstream and keep their upstream version,
+  # so they are published but never carry X.Y.Z.
+  SCOUT_VERSIONED_IMAGES: 'hl7log-extractor hl7-transformer hl7-listener scout-notebook launchpad report-viewer'
+  UPSTREAM_VERSIONED_IMAGES: 'superset keycloak'
+
 jobs:
   validate:
     name: Validate
@@ -323,7 +330,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ needs.wait-for-build.outputs.ci_run_id }}
         run: |
-          IMAGES="hl7log-extractor hl7-transformer hl7-listener scout-notebook launchpad superset keycloak report-viewer"
+          IMAGES="${SCOUT_VERSIONED_IMAGES} ${UPSTREAM_VERSIONED_IMAGES}"
           for IMAGE in $IMAGES; do
             echo "=== Publishing $IMAGE ==="
             gh run download "$RUN_ID" --repo "${{ github.repository }}" -n "$IMAGE" -D "${{ runner.temp }}/$IMAGE"
@@ -343,6 +350,33 @@ jobs:
       && (needs.publish.result == 'success' || needs.publish.result == 'skipped')
       && needs.validate.outputs.release_exists != 'true'
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify the release images were published
+        env:
+          VERSION: ${{ inputs.version }}
+        # wait-for-build only proves CI went green, not that it published
+        # anything. On main the images come from ci.yaml's publish job, which
+        # pushes an image only when that image needed pushing -- so a release
+        # fixed forward on a later commit can go green having published nothing.
+        # That is how v4.1.0 got a tag and a release with no 4.1.0 images. Assert
+        # the tags exist before minting a release that claims them.
+        run: |
+          set -euo pipefail
+          missing=()
+          for image in ${SCOUT_VERSIONED_IMAGES}; do
+            published="$(bash .github/scripts/ghcr-tag-published.sh "${image}" "${VERSION}")"
+            echo "${image}:${VERSION} published=${published}"
+            [ "${published}" = 'true' ] || missing+=("${image}")
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::not published at ${VERSION}: ${missing[*]}"
+            echo "::error::refusing to create release v${VERSION}. The version bump commit is preserved, so re-run the release once the images publish."
+            exit 1
+          fi
+          echo "::notice::all ${VERSION} images are published"
+
       - name: Generate token from GitHub App
         id: app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,7 +300,8 @@ a line is growing past one sentence, that is a sign the ADR should be read inste
   `# renovate:` annotation so CVE monitoring picks it up (ADR 0015), then redeploy.
 - **Add a CI-built image or service** — wiring `.github/workflows/ci.yaml` only covers
   `main`. The release path must be wired too (`.github/scripts/update-versions.sh`, the
-  `IMAGES=` list in `.github/workflows/release.yaml`, and the tables in
+  `SCOUT_VERSIONED_IMAGES` / `UPSTREAM_VERSIONED_IMAGES` lists in
+  `.github/workflows/release.yaml`, and the tables in
   `docs/internal/versions-and-releases.md`), or a tagged release ships the image frozen
   at its last `main` build.
 - **Write Ansible tasks using `kubernetes.core`** — follow the kubeconfig conventions in


### PR DESCRIPTION
## Description

### Product

No user-facing change. Release plumbing: a release can no longer be tagged without the images it names.

### Technical

Background: `v4.1.0` was tagged with no `4.1.0` images for five of the six Scout-versioned images. The `build-and-upload` workflow builds when an image's paths changed, when the `ci` filter fires (meaning CI logic itself changed), or if its derived tag is absent from the registry. However, `publish` gated only on the change condition. Because the `v4.1.0` release was fixed forward on a commit touching two images, the other five were built at `4.1.0` and scanned, but then dropped by the publish step. And `release.yaml`, which only waits for CI to be green, went ahead and tagged the commit, despite the publish gap.

Changes:
- **`publish`** now gates each push on `paths changed || tag absent`
- **`release.yaml`** asserts every Scout-versioned tag resolves before `gh release create`
- **The registry probe** in `check-image-exists` now asks about the one tag of interest, instead of paging through all package versions. (The old list-and-grep saw only the newest page — it reports `launchpad:4.0.0` absent today.) An ambiguous answer (500, 429, etc) now fails loudly instead of defaulting to "image missing", which under the new gate would overwrite a live tag.

Both callers share `.github/scripts/ghcr-tag-published.sh`, and `release.yaml`'s hardcoded image roster becomes `SCOUT_VERSIONED_IMAGES` / `UPSTREAM_VERSIONED_IMAGES` so the list exists once.

## Type of change

- [x] Bug fix

## Impact

CI only

## Testing

Exercised against live GHCR: `launchpad:4.0.0` → true (the case the old query gets wrong), `hl7-listener:4.1.0` → true, the five missing `4.1.0` tags → false, never-pushed repo → false, forced network failure → exit 1. The release guard at `VERSION=4.1.0` reproduces the current broken state and blocks.

## Note for reviewers

N/A

## Checklist

- [x] Style guidelines (`pre-commit` on changed files)
- [x] Commented, particularly the non-obvious gating
- [x] Technical documentation (CLAUDE.md image-wiring list)
