### PR TITLE
feat(ci): haul the two appVersion-derived wrapper-chart upstream images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1246,6 +1246,22 @@ jobs:
           python3 tooling/manifest/resolve_upstream.py \
             tooling/manifest/upstream-images.txt \
             ansible/group_vars/all/versions.yaml > upstream-tags.txt
+          # Two wrapper-chart images take their tag from an upstream chart's
+          # appVersion (helm lookup, not a versions.yaml tag var -- see
+          # upstream-images-helm.txt). Resolve the chart version here, then the
+          # appVersion with `helm show`, and append to the same tag list so they
+          # flow through the digest + no-key sync below, exactly as Scout resolves
+          # them at deploy time. helm is preinstalled on the runner.
+          python3 tooling/manifest/resolve_upstream_helm.py \
+            tooling/manifest/upstream-images-helm.txt \
+            ansible/group_vars/all/versions.yaml > upstream-helm-map.txt
+          while read -r repo url chart ver; do
+            [ -n "$repo" ] || continue
+            appver="$(helm show chart "$chart" --repo "$url" --version "$ver" \
+              | awk '/^appVersion:/ {gsub(/"/,"",$2); print $2}')"
+            [ -n "$appver" ] || { echo "::error::could not resolve appVersion for chart ${chart} ${ver}"; exit 1; }
+            printf '%s:%s\n' "$repo" "$appver" >> upstream-tags.txt
+          done < upstream-helm-map.txt
           while read -r ref; do
             [ -n "$ref" ] || continue
             d="$(docker buildx imagetools inspect "$ref" --format '{{json .Manifest}}' | jq -r '.digest')"

--- a/tooling/manifest/resolve_upstream_helm.py
+++ b/tooling/manifest/resolve_upstream_helm.py
@@ -1,0 +1,51 @@
+"""Resolve upstream image refs whose tag is an upstream Helm chart's appVersion.
+
+Two wrapper-chart images take their tag from an UPSTREAM Helm chart's appVersion
+rather than a tag var in versions.yaml (temporalio/admin-tools tracks the Temporal
+chart; ghcr.io/open-webui/open-webui tracks the Open WebUI chart -- see the
+DEFERRED note in upstream-images.txt). versions.yaml pins the CHART version (a
+semver range); the image tag is that chart's *resolved* appVersion, matching what
+Scout deploys.
+
+The appVersion lookup needs ``helm show chart`` (a network call + the helm
+binary), so it can't run here. This stdlib-only resolver just substitutes each
+chart-version var from versions.yaml and prints a TSV row
+``<image-repo>\t<helm-repo-url>\t<chart>\t<chart-version>`` for the workflow to
+feed to ``helm show chart --repo <url> --version <ver> | awk appVersion``.
+
+Reuses resolve_upstream.load_versions so both resolvers parse versions.yaml the
+same way.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from resolve_upstream import load_versions
+
+
+def resolve_helm(mapping_path: str, versions_path: str) -> list[tuple[str, str, str, str]]:
+    versions = load_versions(versions_path)
+    rows: list[tuple[str, str, str, str]] = []
+    for raw in open(mapping_path):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) != 4:
+            raise ValueError(
+                f"expected '<image-repo> <helm-repo-url> <chart> <chart-version-var>', got: {raw!r}"
+            )
+        repo, url, chart, var = parts
+        if var not in versions:
+            raise ValueError(f"{var!r} not found in {versions_path}")
+        ver = versions[var]
+        if not ver:
+            raise ValueError(f"{var!r} is empty in {versions_path}")
+        rows.append((repo, url, chart, ver))
+    return rows
+
+
+if __name__ == "__main__":
+    for repo, url, chart, ver in resolve_helm(sys.argv[1], sys.argv[2]):
+        print(f"{repo}\t{url}\t{chart}\t{ver}")

--- a/tooling/manifest/test_resolve_upstream_helm.py
+++ b/tooling/manifest/test_resolve_upstream_helm.py
@@ -1,0 +1,48 @@
+"""Offline tests for resolve_upstream_helm. No network (no helm lookup here)."""
+
+import pytest
+
+from resolve_upstream_helm import resolve_helm
+
+
+def test_resolve_helm_substitutes_chart_version(tmp_path):
+    v = tmp_path / "versions.yaml"
+    v.write_text("temporal_version: '~1.2.0'\nopen_webui_helm_chart_version: ~15.2.0\n")
+    m = tmp_path / "upstream-images-helm.txt"
+    m.write_text(
+        "# header comment\n"
+        "\n"
+        "temporalio/admin-tools https://temporal.example/ temporal temporal_version\n"
+        "ghcr.io/open-webui/open-webui https://owui.example/ open-webui open_webui_helm_chart_version\n"
+    )
+    assert resolve_helm(str(m), str(v)) == [
+        ("temporalio/admin-tools", "https://temporal.example/", "temporal", "~1.2.0"),
+        ("ghcr.io/open-webui/open-webui", "https://owui.example/", "open-webui", "~15.2.0"),
+    ]
+
+
+def test_resolve_helm_raises_on_missing_var(tmp_path):
+    v = tmp_path / "versions.yaml"
+    v.write_text("other: 1\n")
+    m = tmp_path / "map.txt"
+    m.write_text("repo/x https://h.example/ chart missing_var\n")
+    with pytest.raises(ValueError, match="missing_var"):
+        resolve_helm(str(m), str(v))
+
+
+def test_resolve_helm_raises_on_empty_var(tmp_path):
+    v = tmp_path / "versions.yaml"
+    v.write_text("empty_ver:\n")
+    m = tmp_path / "map.txt"
+    m.write_text("repo/x https://h.example/ chart empty_ver\n")
+    with pytest.raises(ValueError, match="empty"):
+        resolve_helm(str(m), str(v))
+
+
+def test_resolve_helm_raises_on_malformed_mapping_line(tmp_path):
+    v = tmp_path / "versions.yaml"
+    v.write_text("some_var: 1\n")
+    m = tmp_path / "map.txt"
+    m.write_text("repo/x https://h.example/ some_var\n")  # 3 fields, not 4
+    with pytest.raises(ValueError, match="image-repo"):
+        resolve_helm(str(m), str(v))

--- a/tooling/manifest/upstream-images-helm.txt
+++ b/tooling/manifest/upstream-images-helm.txt
@@ -1,0 +1,20 @@
+# Upstream wrapper-chart images whose TAG is an upstream Helm chart's appVersion,
+# resolved at build time via `helm show chart --repo <url> --version <range>`
+# (not a tag var in versions.yaml). Same air-gap rationale + no-key sync as
+# upstream-images.txt; they just need a helm lookup, so they can't be sourced by
+# resolve_upstream.py and live here instead. See resolve_upstream_helm.py.
+#
+# versions.yaml pins the CHART version (a semver range); the image tag is that
+# chart's resolved appVersion, matching what Scout deploys:
+#   - temporalio/admin-tools -> Temporal chart appVersion (roles/temporal/tasks/deploy.yaml)
+#   - ghcr.io/open-webui/open-webui -> OWUI chart appVersion (the chart's single
+#     source of truth for its image tag; the running Pod, and so the bootstrap
+#     Job, inherit it -- roles/open-webui/tasks/configure_admin.yaml)
+#
+# The image-repo half IS hardcoded (admin-tools is a companion image, not the
+# chart's own image, so it can't be derived from chart values); keep it in sync if
+# an upstream ever repoints.
+#
+# Format: <image-repo> <helm-repo-url> <chart-name> <chart-version-var>
+temporalio/admin-tools https://raw.githubusercontent.com/temporalio/helm-charts/refs/heads/gh-pages/ temporal temporal_version
+ghcr.io/open-webui/open-webui https://helm.openwebui.com/ open-webui open_webui_helm_chart_version

--- a/tooling/manifest/upstream-images.txt
+++ b/tooling/manifest/upstream-images.txt
@@ -10,10 +10,9 @@
 # versions.yaml var (keycloak_config_cli_image, orthanc_image), keep this in sync
 # if that var is ever repointed. See tooling/manifest/resolve_upstream.py.
 #
-# DEFERRED -- the tag is derived from an upstream Helm chart's appVersion at
-# deploy time (not pinned in versions.yaml), so it can't be sourced here yet:
-#   - temporal-bootstrap    temporalio/admin-tools        (= temporal chart appVersion)
-#   - open-webui-bootstrap  ghcr.io/open-webui/open-webui (= open-webui chart appVersion)
+# Images whose tag is an upstream Helm chart's appVersion (temporalio/admin-tools,
+# ghcr.io/open-webui/open-webui) can't be sourced here -- they need a helm lookup;
+# see upstream-images-helm.txt + resolve_upstream_helm.py.
 openpolicyagent/opa opa_image_tag
 starburstdata/hive hive_image_tag
 docker.io/adorsys/keycloak-config-cli keycloak_config_cli_image_tag


### PR DESCRIPTION
## Description
### Technical
Follow-up to #619, which folded the wrapper charts' third-party images into the build-lane haul but deferred two: `temporalio/admin-tools` (temporal-bootstrap) and `ghcr.io/open-webui/open-webui` (open-webui-bootstrap). Those two take their image tag from an upstream Helm chart's **appVersion**, not a tag var in `versions.yaml`, so `resolve_upstream.py` couldn't source them.

Resolves them the way Scout does at deploy time: `versions.yaml` pins the *chart* version (a range); a build-time `helm show chart --repo <url> --version <range>` reads that chart's appVersion, which is the image tag. New `resolve_upstream_helm.py` (reuses `resolve_upstream.load_versions`) reads a `<image-repo> <helm-repo-url> <chart> <chart-version-var>` map (`upstream-images-helm.txt`); the `publish-haul` job runs the `helm show` lookup and appends the resolved refs to the same `@digest` pin + no-key upstream sync. Fail-closed: resolver crash aborts via `set -e`, unresolvable appVersion → `exit 1`; job stays `continue-on-error`.

## Type of change
- [x] New feature

## Impact
### Backward compatibility
None. Images pinned by immutable digest exactly as the other upstream images; no new signing surface.

## Testing
New `test_resolve_upstream_helm.py` (4 offline tests); full `tooling/manifest` suite green (35 passed). End-to-end against real `versions.yaml`: resolves `temporalio/admin-tools:1.31.0` and `ghcr.io/open-webui/open-webui:0.11.0`, both inspect to a digest and render through `render_images`.
