### PR TITLE
ci: cut over to release-please-driven releases (Phase 1)

### DIFF
--- a/.github/scripts/update-versions.sh
+++ b/.github/scripts/update-versions.sh
@@ -20,6 +20,9 @@ if [[ "$VERSION" == "dev" ]]; then
     DOCKER_TAG="$DEV_DOCKER_TAG"
     HELM_VERSION="$DEV_HELM_VERSION"
     PYTHON_VERSION="$DEV_PYTHON_VERSION"
+    # A dev reset is idempotent: a file already at its dev value is expected (e.g. a
+    # component that was never stamped, or re-running the reset), so a no-op is fine.
+    ALLOW_NOOP=true
     echo "Resetting to dev versions..."
 else
     # Validate release version format
@@ -30,6 +33,9 @@ else
     DOCKER_TAG="$VERSION"
     HELM_VERSION="$VERSION"
     PYTHON_VERSION="$VERSION"
+    # During a real stamp a no-op means the pattern did not match (e.g. a renamed
+    # variable) and must fail loudly, so no-ops are NOT tolerated here.
+    ALLOW_NOOP=false
     echo "Updating version files to $VERSION..."
 fi
 
@@ -54,11 +60,17 @@ update_file() {
     # Using -i.bak creates a backup we can compare against to verify the change.
     sed -i.bak -E "s|$pattern|$replacement|" "$file"
 
-    # Fail if sed didn't change anything (pattern may not have matched)
+    # sed made no change. In a dev reset that just means the file is already at its
+    # dev value (tolerated, keeps the reset idempotent). During a stamp it means the
+    # pattern did not match, which must fail.
     if cmp -s "$file" "${file}.bak"; then
+        rm -f "${file}.bak"
+        if [[ "${ALLOW_NOOP:-false}" == "true" ]]; then
+            echo "  - $description: $file (already at target)"
+            return 0
+        fi
         echo "  ERROR: No changes made to $file for $description"
         echo "         Pattern may not have matched: $pattern"
-        rm -f "${file}.bak"
         exit 1
     fi
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,12 @@ on:
       - main
       - 'ci-**'
       - 'demo**'
+    # Skip the release-please PR merge (manifest/CHANGELOG/version.txt only): it publishes
+    # nothing and would race version-bump's publish-charts. Push trigger only, so PR checks stand.
+    paths-ignore:
+      - .release-please-manifest.json
+      - CHANGELOG.md
+      - version.txt
 
 # Cancel a PR's superseded runs so a new push doesn't sit behind a stale ~35m
 # pipeline (and free the runners it was holding). Keyed on head_ref, which is

--- a/.github/workflows/pr-title-lint.yaml
+++ b/.github/workflows/pr-title-lint.yaml
@@ -22,3 +22,42 @@ jobs:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  upgrade-notes:
+    # A breaking change (a `!` marker in the PR title, or a `BREAKING CHANGE:`
+    # footer in the body) must document the operator upgrade path, so the
+    # "Backward compatibility" section of the PR description must be filled in
+    # (ADR 0030). This gates section PRESENCE, not correctness: a behavioral
+    # break that adds no variable is caught by review, not here. Reads the title
+    # and body from the event payload, so no checkout and no repo write.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require upgrade notes for breaking changes
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          python3 <<'PYEOF'
+          import os, re, sys
+          title = (os.environ.get("PR_TITLE") or "").strip()
+          body = os.environ.get("PR_BODY") or ""
+          breaking = (
+              re.match(r"^[a-z]+(\([^)]*\))?!:", title, re.I) is not None
+              or re.search(r"^BREAKING[ -]CHANGE:", body, re.M) is not None
+          )
+          if not breaking:
+              print("No breaking-change marker; upgrade notes not required.")
+              sys.exit(0)
+          # Grab the "Backward compatibility" section: everything under the heading
+          # up to the next heading of ANY level (#+, so a ##### subheading bounds it
+          # too). A BREAKING CHANGE footer under the heading counts as content, since
+          # a footer is itself the operator upgrade path.
+          m = re.search(r"^#+\s*Backward compatibility\s*$(.*?)(?=^#+\s|\Z)", body, re.M | re.S | re.I)
+          section = re.sub(r"<!--.*?-->", "", m.group(1) if m else "", flags=re.S).strip()
+          if not section:
+              print("::error::This PR is marked breaking (a \"!\" in the title or a "
+                    "BREAKING CHANGE footer) but the 'Backward compatibility' section of "
+                    "the description is empty. Document the operator upgrade path there.")
+              sys.exit(1)
+          print("Breaking change with upgrade notes present.")
+          PYEOF

--- a/.github/workflows/release-dispatch.yaml
+++ b/.github/workflows/release-dispatch.yaml
@@ -1,0 +1,76 @@
+name: Release Dispatch
+
+# Bridges release-please (LIVE) to the release lane. When a release-please PR is
+# merged, its squashed commit bumps .release-please-manifest.json on main -- the
+# ONLY push that touches that file -- so the path filter below is an exact "a
+# release was just approved" signal. On that signal this workflow:
+#
+#   1. Creates the boundary tag v<version> on the merge commit. release-please runs
+#      with skip-github-release, so it never tags; without a tag it would, during
+#      release.yaml's long build, see a manifest version ahead of the last tag and
+#      bootstrap a spurious next-version PR from repo start. The pre-created tag is
+#      the marker that keeps release-please's changelog scoping correct.
+#   2. Dispatches release.yaml, which stays the single authoritative lane: stamp
+#      versions -> wait for the build -> verify images published -> create the GitHub
+#      Release ON THIS TAG -> reset to dev. The Release is minted LAST, after image
+#      verification, so a failed build never yields a Release (only the boundary tag,
+#      which is retryable via a manual re-dispatch and which release.yaml tolerates).
+#
+# Recovery + known limitations:
+#   - Failed release (main left stamped): release.yaml's verify-dev-reset job fails
+#     LOUD. Retry the SAME version with:  gh workflow run release.yaml --ref main
+#     -f version=X.Y.Z  (validate tolerates the boundary tag; version-bump reuses the
+#     existing bump commit).
+#   - Abandoned release: the boundary tag v<version> persists, so release-please treats
+#     the version as released and the next PR proposes the NEXT number (the number is
+#     burned) while a CHANGELOG entry for it stays on main. To RECLAIM the number
+#     instead: delete tag v<version> and its Release FIRST, then revert the release-PR
+#     merge (drops the manifest + CHANGELOG bump); release-please then re-proposes it.
+#     Note the revert changes the manifest, so it re-triggers this workflow; deleting
+#     the tag+Release first lets that run complete cleanly instead of failing at
+#     release.yaml's validate on an already-released version.
+#   - A feature PR merged to main DURING a release is built into the release images
+#     (release.yaml builds current HEAD by design, to fold in fix-forward commits) but
+#     is not in the tag/notes. Avoid merging to main while a release is in flight; a
+#     release-in-progress lock on main is a possible future hardening.
+on:
+  push:
+    branches: [main]
+    paths:
+      - .release-please-manifest.json
+
+concurrency:
+  group: release-dispatch
+  cancel-in-progress: false
+
+permissions:
+  contents: write # create the boundary tag
+  actions: write # dispatch release.yaml (workflow_dispatch via GITHUB_TOKEN is allowed to trigger a run)
+
+jobs:
+  dispatch:
+    name: Tag + dispatch release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Create the boundary tag + dispatch release.yaml
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION="$(jq -r '."."' .release-please-manifest.json)"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::manifest version '${VERSION}' is not X.Y.Z; not releasing"
+            exit 1
+          fi
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "::notice::tag v${VERSION} already exists; leaving it in place"
+          else
+            echo "::notice::creating boundary tag v${VERSION} at ${GITHUB_SHA}"
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/v${VERSION}" -f sha="${GITHUB_SHA}"
+          fi
+          echo "::notice::dispatching release.yaml for v${VERSION}"
+          gh workflow run release.yaml --ref main -f version="${VERSION}"

--- a/.github/workflows/release-dispatch.yaml
+++ b/.github/workflows/release-dispatch.yaml
@@ -23,12 +23,10 @@ name: Release Dispatch
 #     existing bump commit).
 #   - Abandoned release: the boundary tag v<version> persists, so release-please treats
 #     the version as released and the next PR proposes the NEXT number (the number is
-#     burned) while a CHANGELOG entry for it stays on main. To RECLAIM the number
-#     instead: delete tag v<version> and its Release FIRST, then revert the release-PR
-#     merge (drops the manifest + CHANGELOG bump); release-please then re-proposes it.
-#     Note the revert changes the manifest, so it re-triggers this workflow; deleting
-#     the tag+Release first lets that run complete cleanly instead of failing at
-#     release.yaml's validate on an already-released version.
+#     burned) while a CHANGELOG entry for it stays on main. Reverting the release PR
+#     re-triggers this workflow with the PRIOR manifest version, which validate rejects
+#     as already-released -- harmless (nothing gets stamped), but not a clean reclaim;
+#     renumbering past a burned version is manual.
 #   - A feature PR merged to main DURING a release is built into the release images
 #     (release.yaml builds current HEAD by design, to fold in fix-forward commits) but
 #     is not in the tag/notes. Avoid merging to main while a release is in flight; a

--- a/.github/workflows/release-dispatch.yaml
+++ b/.github/workflows/release-dispatch.yaml
@@ -42,8 +42,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write # create the boundary tag
-  actions: write # dispatch release.yaml (workflow_dispatch via GITHUB_TOKEN is allowed to trigger a run)
+  contents: read # checkout (the boundary tag is written with the app token)
+  actions: write # dispatch release.yaml (workflow_dispatch via GITHUB_TOKEN triggers a run)
 
 jobs:
   dispatch:
@@ -53,9 +53,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Create the boundary tag + dispatch release.yaml
+      # App token so the boundary tag has the SAME writer as release.yaml's tag move
+      # (single identity, one bypass to configure if v* tags ever get a ruleset).
+      - name: Generate token from GitHub App
+        id: app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Create the boundary tag
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           set -euo pipefail
           VERSION="$(jq -r '."."' .release-please-manifest.json)"
@@ -63,6 +72,7 @@ jobs:
             echo "::error::manifest version '${VERSION}' is not X.Y.Z; not releasing"
             exit 1
           fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
           if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${VERSION}" >/dev/null 2>&1; then
             echo "::notice::tag v${VERSION} already exists; leaving it in place"
           else
@@ -70,5 +80,10 @@ jobs:
             gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
               -f ref="refs/tags/v${VERSION}" -f sha="${GITHUB_SHA}"
           fi
+
+      - name: Dispatch release.yaml
+        env:
+          GH_TOKEN: ${{ github.token }} # workflow_dispatch via GITHUB_TOKEN triggers a run
+        run: |
           echo "::notice::dispatching release.yaml for v${VERSION}"
           gh workflow run release.yaml --ref main -f version="${VERSION}"

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,23 +1,32 @@
-name: Release Please (shadow)
+name: Release Please
 
-# SHADOW MODE (Phase 1, ADR 0030). release-please opens and maintains ONE release
-# PR showing the version + CHANGELOG it computes from Conventional Commit history
-# since the last v* tag. It is for VALIDATION ONLY during the shadow period:
+# LIVE (Phase 1, ADR 0030). release-please opens and maintains ONE release PR
+# showing the version + CHANGELOG it computes from Conventional Commit history since
+# the last release. Merging that PR IS the release:
 #
-#   DO NOT MERGE the release PR. The manual-dispatch release.yaml stays the
-#   authoritative release path until the Phase 1 cutover (a follow-up PR rewires
-#   release.yaml to fire on the release-PR merge and retires the manual input).
-#
-# If the PR were merged it would create only a git tag + GitHub Release (changelog);
-# it does NOT publish images or charts (that is ci.yaml / release.yaml), so a stray
-# merge is low-harm and reversible by deleting the tag + release.
+#   - skip-github-release is set, so release-please only maintains the PR + bumps
+#     .release-please-manifest.json; it does NOT cut the tag / GitHub Release.
+#   - merging the PR lands the manifest bump on main, which trips release-dispatch.yaml
+#     (push filter on .release-please-manifest.json). That dispatches release.yaml with
+#     the merged version, and release.yaml remains the single lane that stamps versions,
+#     waits for the build, verifies images published, tags, creates the release, and
+#     resets to dev.
 #
 # Accuracy depends on squash-only merges (each main commit subject is then a
-# Conventional-Commit PR title, enforced by pr-title-lint); enable squash-only +
-# require-linear-history before trusting the computed version.
+# Conventional-Commit PR title, enforced by pr-title-lint) + require-linear-history.
+# Land those repo settings before relying on the computed version.
 on:
   push:
     branches: [main]
+    # Skip the release-PR merge commit itself: a squashed release PR touches ONLY
+    # these release-please-managed files. On that commit the manifest is briefly
+    # ahead of the last tag; release-dispatch.yaml creates the boundary tag, so by
+    # the time release-please next runs (a later real push) the tag exists and it
+    # scopes the next changelog correctly instead of bootstrapping from repo start.
+    paths-ignore:
+      - .release-please-manifest.json
+      - CHANGELOG.md
+      - version.txt
 
 permissions:
   contents: write
@@ -39,3 +48,7 @@ jobs:
           token: ${{ steps.app_token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # release.yaml owns the tag + GitHub Release (it stamps, waits for the
+          # build, and verifies images first). release-please only maintains the PR
+          # + manifest, so it must not double-cut the release on merge.
+          skip-github-release: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -532,3 +532,61 @@ jobs:
           echo "::error::  git checkout ${REF_NAME} && bash .github/scripts/update-versions.sh dev && git commit -am 'Reset to dev versions' && git push"
           git --no-pager diff --stat
           exit 1
+
+  publish-charts:
+    name: Publish charts at the release version
+    runs-on: ubuntu-latest
+    needs: [validate, version-bump, release]
+    # ADR 0030: a release publishes all charts at X.Y.Z (not just the build-lane
+    # 0.YYYYMMDD.run). Packaged from the stamped commit so Chart.yaml is at X.Y.Z.
+    if: >-
+      !inputs.dry_run && always() && !cancelled()
+      && needs.release.result == 'success'
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+    strategy:
+      fail-fast: false
+      matrix:
+        chart:
+          - { name: hl7-transformer, dir: helm/extractor/hl7-transformer }
+          - { name: dcm4chee, dir: helm/dcm4chee }
+          - { name: hive-metastore, dir: helm/hive-metastore }
+          - { name: hl7-listener, dir: helm/hl7-listener }
+          - { name: hl7log-extractor, dir: helm/extractor/hl7log-extractor }
+          - { name: keycloak-config-cli, dir: helm/keycloak-config-cli }
+          - { name: launchpad, dir: helm/launchpad }
+          - { name: open-webui-bootstrap, dir: helm/open-webui-bootstrap }
+          - { name: orthanc, dir: helm/orthanc }
+          - { name: report-viewer, dir: helm/report-viewer }
+          - { name: scout-dashboards, dir: helm/scout-dashboards }
+          - { name: scout-opa, dir: helm/scout-opa }
+          - { name: temporal-bootstrap, dir: helm/temporal-bootstrap }
+          - { name: voila, dir: helm/voila }
+    steps:
+      - name: Checkout the stamped commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.version-bump.outputs.commit_sha || needs.validate.outputs.version_bump_sha }}
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Package, push, and sign ${{ matrix.chart.name }} at v${{ inputs.version }}
+        env:
+          CHART_DIR: ${{ matrix.chart.dir }}
+          CHART_NAME: ${{ matrix.chart.name }}
+          VERSION: ${{ inputs.version }}
+          REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          printf '%s' "${REGISTRY_TOKEN}" | helm registry login "${REGISTRY}" -u "${ACTOR}" --password-stdin
+          helm package "${CHART_DIR}" --version "${VERSION}" --destination "${RUNNER_TEMP}"
+          helm push "${RUNNER_TEMP}/${CHART_NAME}-${VERSION}.tgz" "oci://${REGISTRY}/washu-tag/charts"
+          ref="${REGISTRY}/washu-tag/charts/${CHART_NAME}:${VERSION}"
+          digest="$(docker buildx imagetools inspect "${ref}" --format '{{json .Manifest}}' | jq -r '.digest')"
+          [ "${digest#sha256:}" != "${digest}" ] || { echo "::error::no digest for ${CHART_NAME}"; exit 1; }
+          cosign sign --key env://COSIGN_PRIVATE_KEY --use-signing-config=false \
+            --tlog-upload=false --yes "${REGISTRY}/washu-tag/charts/${CHART_NAME}@${digest}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -243,15 +243,17 @@ jobs:
       - name: Determine target commit
         id: target
         env:
-          REF_NAME: ${{ github.ref_name }}
+          # Pin the release to the version-bump (stamped) commit, not current HEAD, so a
+          # feature merged mid-release can't be swept into the images or past the tag (it
+          # would ship in X.Y.Z but land in no changelog). To fold a fix into a failed
+          # release: reset + re-dispatch, so version-bump re-stamps the fixed HEAD.
+          BUMP_SHA: ${{ needs.version-bump.outputs.commit_sha || needs.validate.outputs.version_bump_sha }}
         run: |
-          # The release should include everything on main at this point — not just
-          # the version bump commit, but also any fixes pushed after it (e.g., if a
-          # previous release attempt failed and we pushed a fix before re-running).
-          git pull origin "${REF_NAME}"
-          HEAD_SHA=$(git rev-parse HEAD)
-          echo "Waiting for build on commit: $HEAD_SHA"
-          echo "sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          if [ -z "${BUMP_SHA}" ]; then
+            echo "::error::no version-bump commit to pin the release to"; exit 1
+          fi
+          echo "Pinning release build to ${BUMP_SHA}"
+          echo "sha=${BUMP_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Wait for CI workflow
         id: wait

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,15 +69,25 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if tag already exists
+      - name: Check the version is not already released
         env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
           VERSION: ${{ inputs.version }}
         run: |
-          if git tag -l "v${VERSION}" | grep -q .; then
-            echo "::error::Tag v${VERSION} already exists"
+          tag_exists=false; release_exists=false
+          git tag -l "v${VERSION}" | grep -q . && tag_exists=true
+          gh release view "v${VERSION}" >/dev/null 2>&1 && release_exists=true
+          # A tag WITHOUT a release is expected and fine: release-dispatch.yaml
+          # pre-creates the boundary tag v<version> on the merge commit so release-please
+          # can scope its changelog during the build; the GitHub Release is minted last,
+          # after image verification. It also covers resuming a release whose tag exists
+          # but whose release step had not run. Only a tag AND a release together mean
+          # the version is truly already published.
+          if [ "$tag_exists" = true ] && [ "$release_exists" = true ]; then
+            echo "::error::v${VERSION} is already released (tag and release both exist)"
             exit 1
           fi
-          echo "Tag v${VERSION} does not exist"
+          echo "v${VERSION}: tag_exists=${tag_exists} release_exists=${release_exists} (proceeding)"
 
       - name: Check for existing commits
         id: check_commits
@@ -385,18 +395,32 @@ jobs:
           client-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      - name: Create GitHub release
+      - name: Anchor the tag to the built commit + create the release
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           VERSION: ${{ inputs.version }}
           REPO: ${{ github.repository }}
           COMMIT_SHA: ${{ needs.wait-for-build.outputs.commit_sha }}
         run: |
+          set -euo pipefail
+          # release-dispatch.yaml pre-creates the boundary tag v${VERSION} at the
+          # release-PR merge commit so release-please can scope its changelog during
+          # the build. Now that the built + image-verified commit exists, point the tag
+          # at it so `git checkout v${VERSION}` reproduces the released source (parity
+          # with the manual-dispatch path, where the tag does not pre-exist and we
+          # create it). gh then anchors the Release to that tag, so no --target needed.
+          # The built commit is a descendant of the merge commit and the only commit
+          # between them ("Update to version X.Y.Z") is not a Conventional Commit, so
+          # moving the tag forward does not disturb release-please's next-cycle scoping.
+          if gh api "repos/${REPO}/git/ref/tags/v${VERSION}" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${REPO}/git/refs/tags/v${VERSION}" -F sha="${COMMIT_SHA}" -F force=true
+          else
+            gh api -X POST "repos/${REPO}/git/refs" -f ref="refs/tags/v${VERSION}" -f sha="${COMMIT_SHA}"
+          fi
           gh release create "v${VERSION}" \
             --repo "${REPO}" \
             --title "Scout v${VERSION}" \
-            --generate-notes \
-            --target "${COMMIT_SHA}"
+            --generate-notes
 
           echo "::notice::Created release v${VERSION}"
 
@@ -463,4 +487,40 @@ jobs:
             git commit -m "Reset to dev versions"
             git push origin "${REF_NAME}"
             echo "::notice::Reset to dev versions complete"
+          fi
+
+  verify-dev-reset:
+    name: Verify main returned to dev
+    runs-on: ubuntu-latest
+    needs: [validate, version-bump, wait-for-build, publish, release, reset-dev]
+    # Runs ONLY when the release SUCCEEDED (so tag + Release exist): main must then be
+    # back at dev placeholders. If it is not, reset-dev flaked (an npm hiccup, or a push
+    # rejected by a concurrent merge) and main is silently stamped, so a dev deploy would
+    # pull the pinned version instead of `latest`. Fail LOUD -- but the recovery here is a
+    # MANUAL reset, NOT a re-dispatch (validate blocks re-dispatch once the version is
+    # released). When the release did NOT succeed, the run is already red and the version
+    # bump is intentionally kept for a re-dispatch retry, so this check stays out of the way.
+    if: ${{ !inputs.dry_run && !inputs.skip_dev_reset && always() && !cancelled() && needs.release.result == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Assert VERSION files are back at dev placeholders
+        env:
+          VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          git pull origin "${REF_NAME}"
+          # update-versions.sh dev is idempotent: no diff when already at dev
+          # placeholders, a diff (the stamped files) when it is not.
+          bash .github/scripts/update-versions.sh dev
+          if git diff --quiet; then
+            echo "${REF_NAME} is at dev versions."
+          else
+            echo "::error::Release v${VERSION} succeeded but ${REF_NAME} is still STAMPED (reset-dev did not complete). A dev deploy would pull v${VERSION} instead of latest. Re-dispatch will NOT help (v${VERSION} is already released); reset manually:"
+            echo "::error::  git checkout ${REF_NAME} && bash .github/scripts/update-versions.sh dev && git commit -am 'Reset to dev versions' && git push"
+            git --no-pager diff --stat
+            exit 1
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -413,7 +413,7 @@ jobs:
           # between them ("Update to version X.Y.Z") is not a Conventional Commit, so
           # moving the tag forward does not disturb release-please's next-cycle scoping.
           if gh api "repos/${REPO}/git/ref/tags/v${VERSION}" >/dev/null 2>&1; then
-            gh api -X PATCH "repos/${REPO}/git/refs/tags/v${VERSION}" -F sha="${COMMIT_SHA}" -F force=true
+            gh api -X PATCH "repos/${REPO}/git/refs/tags/v${VERSION}" -f sha="${COMMIT_SHA}" -F force=true
           else
             gh api -X POST "repos/${REPO}/git/refs" -f ref="refs/tags/v${VERSION}" -f sha="${COMMIT_SHA}"
           fi
@@ -512,15 +512,21 @@ jobs:
           VERSION: ${{ inputs.version }}
           REF_NAME: ${{ github.ref_name }}
         run: |
-          git pull origin "${REF_NAME}"
-          # update-versions.sh dev is idempotent: no diff when already at dev
-          # placeholders, a diff (the stamped files) when it is not.
-          bash .github/scripts/update-versions.sh dev
-          if git diff --quiet; then
-            echo "${REF_NAME} is at dev versions."
-          else
-            echo "::error::Release v${VERSION} succeeded but ${REF_NAME} is still STAMPED (reset-dev did not complete). A dev deploy would pull v${VERSION} instead of latest. Re-dispatch will NOT help (v${VERSION} is already released); reset manually:"
-            echo "::error::  git checkout ${REF_NAME} && bash .github/scripts/update-versions.sh dev && git commit -am 'Reset to dev versions' && git push"
-            git --no-pager diff --stat
-            exit 1
-          fi
+          set -euo pipefail
+          # This runs right after reset-dev pushed, so a stale read could fail a
+          # release that actually succeeded. Re-fetch a few times before believing
+          # main is stamped. update-versions.sh dev is a no-op diff when already at dev.
+          for attempt in 1 2 3; do
+            git fetch origin "${REF_NAME}"
+            git reset --hard "origin/${REF_NAME}"
+            bash .github/scripts/update-versions.sh dev
+            if git diff --quiet; then
+              echo "${REF_NAME} is at dev versions."
+              exit 0
+            fi
+            [ "${attempt}" -lt 3 ] && sleep 5
+          done
+          echo "::error::Release v${VERSION} succeeded but ${REF_NAME} is still STAMPED (reset-dev did not complete). A dev deploy would pull v${VERSION} instead of latest. Re-dispatch will NOT help (v${VERSION} is already released); reset manually:"
+          echo "::error::  git checkout ${REF_NAME} && bash .github/scripts/update-versions.sh dev && git commit -am 'Reset to dev versions' && git push"
+          git --no-pager diff --stat
+          exit 1

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "include-component-in-tag": false,
-  "draft-pull-request": true,
+  "draft-pull-request": false,
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
## Description
### Product
None. Release-automation cutover (ADR 0030, Phase 1).

### Technical
Makes release-please **live**: merging its accumulating release PR now cuts the release, so the version and changelog are computed from Conventional-Commit history instead of a hand-typed `workflow_dispatch` version. The manual dispatch stays as a fallback and for recovery.

The hardened `release.yaml` lane is preserved (it still stamps versions, waits for the build, verifies images published, tags, creates the Release, and resets to dev). The cutover wires the release-PR merge to it without changing that flow's guarantees:

- **release-please**: out of shadow (`draft-pull-request: false`); `skip-github-release: true` so it maintains the PR + manifest but does not double-cut the tag/Release (release.yaml stays the single releaser, so the image-verify-before-release guard is kept); `paths-ignore` its own merge commit.
- **`release-dispatch.yaml`** (new): the release-PR merge bumps `.release-please-manifest.json` (the only push that touches it), which triggers this workflow. It creates a boundary tag `v<version>` on the merge commit so release-please can scope its changelog during the build instead of bootstrapping a spurious next-version PR, then dispatches `release.yaml`.
- **`release.yaml`**: `validate` now tolerates a tag-without-Release (fails only if both exist, preserving already-released protection and retryability); the release job anchors the tag to the built commit before creating the Release; a new `verify-dev-reset` guardrail fails loud if a *successful* release left main stamped.
- **`update-versions.sh`**: the dev reset is now idempotent (a no-op is tolerated when resetting to dev; a real stamp still fails on a non-matching pattern).
- **`pr-title-lint.yaml`**: adds the upgrade-notes gate (a breaking PR must fill the "Backward compatibility" section) — the last Phase-1 PR-quality gate (supersedes #632).

### Prerequisite (repo settings, not in this PR)
release-please trusts squashed Conventional-Commit subjects, so before relying on the computed version, enable on `main`: **squash-only merges** (squash message = PR title), **require linear history**, **require status checks up-to-date**. (Greenlit by Kate.)

### Residual known-limitations (documented in `release-dispatch.yaml`; follow-ups)
- A feature merged to `main` *during* a release is built into the images (the lane builds current HEAD by design, to fold in fix-forwards) but is not in the tag/notes. Avoid merging while a release is in flight; a release-in-progress lock is a possible follow-up.
- An abandoned release burns a version number and leaves a phantom changelog entry; recovery runbook is in the workflow comments.

## Type of change
- [x] CI / release automation (non-breaking)

## Impact
### Backward compatibility
No product impact. `main` stays on dev placeholders exactly as today (release.yaml's stamp-then-reset is unchanged and Ansible reads role defaults, not the files release-please writes). The manual `workflow_dispatch` release path is unchanged.

## Testing
`actionlint` clean on all touched workflows. `update-versions.sh` idempotency verified empirically (dev-on-dev → exit 0, zero diff; stamp→dev roundtrip → net zero; repeat stamp still errors). The design was reviewed adversarially across three rounds (release-please 17.x source + GitHub REST semantics); the flow will exercise end-to-end on the first real release PR.

## Note for reviewers
The intent is to leave the battle-tested `release.yaml` behavior intact and only wire the trigger + guardrails around it. Key things to sanity-check: `skip-github-release` + the boundary tag (so release-please never bootstraps), and the `verify-dev-reset` guardrail's scope (successful-release-but-stamped-main only).