### PR TITLE
ci: finalize the build-lane haul (Phase 2 go-live)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1011,6 +1011,10 @@ jobs:
   # Publish changed Helm charts as versioned OCI artifacts (ADR 0030/0031 phase 0),
   # gated like the image `publish` job. Vertical slice: hl7-transformer only.
   publish-charts:
+    # Per-chart steps publish a chart whose dir changed, OR every chart on a
+    # CI/build-tooling change (changes.ci), mirroring build-and-upload for images
+    # (ADR 0030: CI/build-tooling changes rebuild everything). That force-all also
+    # gives publish-haul its one-time all-14-charts seed on any ci-touching merge.
     if: github.ref_name == 'main' && needs.deploy-and-test.result == 'success' && needs.smoke-test.result == 'success'
     runs-on: ubuntu-latest
     permissions:
@@ -1066,14 +1070,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Login to GHCR (for the imagetools digest read-back)
-        if: needs.changes.outputs[matrix.changed] == 'true'
+        if: needs.changes.outputs[matrix.changed] == 'true' || needs.changes.outputs.ci == 'true'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Publish chart - ${{ matrix.chart-name }}'
-        if: needs.changes.outputs[matrix.changed] == 'true'
+        if: needs.changes.outputs[matrix.changed] == 'true' || needs.changes.outputs.ci == 'true'
         shell: bash
         # helm is preinstalled on the runner (OCI push needs >= 3.8). Only the
         # chart version is stamped (--version); Chart.yaml keeps its 0.0.0-dev /
@@ -1105,10 +1109,10 @@ jobs:
           printf '%s %s@%s\n' "${CHART_NAME}" "${ref}" "${digest}" \
             > "${RUNNER_TEMP}/chart-digests/${CHART_NAME}.txt"
       - name: Install cosign
-        if: needs.changes.outputs[matrix.changed] == 'true'
+        if: needs.changes.outputs[matrix.changed] == 'true' || needs.changes.outputs.ci == 'true'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: 'Sign chart - ${{ matrix.chart-name }}'
-        if: needs.changes.outputs[matrix.changed] == 'true'
+        if: needs.changes.outputs[matrix.changed] == 'true' || needs.changes.outputs.ci == 'true'
         # Sign the pushed OCI chart by digest with the keyed cosign pair, matching
         # the image signing in `publish`, so the build-lane haul verifies charts and
         # images alike at sync time (ADR 0033). Keyed, no transparency log.
@@ -1123,7 +1127,7 @@ jobs:
           cosign sign --key env://COSIGN_PRIVATE_KEY \
             --use-signing-config=false --tlog-upload=false --yes "${ref}"
       - name: 'Upload chart digest - ${{ matrix.chart-name }}'
-        if: needs.changes.outputs[matrix.changed] == 'true'
+        if: needs.changes.outputs[matrix.changed] == 'true' || needs.changes.outputs.ci == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: chart-digest-${{ matrix.chart-name }}
@@ -1233,14 +1237,11 @@ jobs:
     # (harmless) on partial builds until a one-time bootstrap seeds the first
     # predecessor. Sync verifies every component's cosign signature (--key) and
     # fails closed if any component is unsigned or unverifiable.
-    # PAUSED until the build-lane haul project is finalized. Chart carry needs a
-    # one-time publish-all seed of the 14 charts (see components.txt); until that
-    # lands this job fails on every main run. continue-on-error keeps it non-gating,
-    # but it still leaves a red X on the run, so it is turned off while the whole
-    # GitOps build-lane is still in progress rather than run half-built. Re-enable
-    # (after the seed) by restoring the condition:
-    #   github.ref_name == 'main' && needs.publish.result == 'success' && needs.publish-charts.result == 'success'
-    if: false
+    # LIVE (build-lane finalize). publish-charts now force-publishes all 14 charts on a
+    # ci/build-tooling change (changes.ci), so the first main run that carries this change
+    # seeds all 14 into the registry and this job folds them into the haul; each then
+    # carries by digest until it changes. Main-only, after images + charts publish.
+    if: github.ref_name == 'main' && needs.publish.result == 'success' && needs.publish-charts.result == 'success'
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: [changes, publish, publish-charts]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1226,20 +1226,13 @@ jobs:
             exit 1
           fi
   publish-haul:
-    # Build-lane haul (ADR 0033): after images publish, render the manifest from
-    # this run's fresh digests plus the previous build's haul (carry), sync it into
-    # a .tar.zst bundle, and publish the bundle + the manifest so the next run can
-    # carry from it. continue-on-error so it never gates a release; it fails closed
-    # (harmless) on partial builds until a one-time bootstrap seeds the first
-    # predecessor. Sync verifies every component's cosign signature (--key) and
-    # fails closed if any component is unsigned or unverifiable.
-    # LIVE (build-lane finalize). Carries every chart by digest, so all 14 must be in
-    # the registry: publish-charts is changed-only, so run seed-charts.yaml once at
-    # go-live to publish the never-changed charts (deliberately NOT wired to changes.ci
-    # -- ADR 0030 keeps routine builds to changed charts only). Main-only, after publish.
+    # Build-lane haul (ADR 0033): render the manifest (fresh digests + carry), sync to a
+    # signed .tar.zst, publish the bundle + manifest. GATES the build (no continue-on-error):
+    # a broken/incomplete/unsigned air-gap haul must fail loud. Safe to merge only after
+    # seed-charts.yaml has published all 14 charts (publish-charts is changed-only) and the
+    # Docker Hub secret is seeded (the upstream pulls below are otherwise rate-limited).
     if: github.ref_name == 'main' && needs.publish.result == 'success' && needs.publish-charts.result == 'success'
     runs-on: ubuntu-latest
-    continue-on-error: true
     needs: [changes, publish, publish-charts]
     permissions:
       contents: read
@@ -1259,6 +1252,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Docker Hub # authenticated pulls for the 6 upstream images from docker.io
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Install hauler and oras

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1011,10 +1011,6 @@ jobs:
   # Publish changed Helm charts as versioned OCI artifacts (ADR 0030/0031 phase 0),
   # gated like the image `publish` job. Vertical slice: hl7-transformer only.
   publish-charts:
-    # Per-chart steps publish a chart whose dir changed, OR every chart on a
-    # CI/build-tooling change (changes.ci), mirroring build-and-upload for images
-    # (ADR 0030: CI/build-tooling changes rebuild everything). That force-all also
-    # gives publish-haul its one-time all-14-charts seed on any ci-touching merge.
     if: github.ref_name == 'main' && needs.deploy-and-test.result == 'success' && needs.smoke-test.result == 'success'
     runs-on: ubuntu-latest
     permissions:
@@ -1070,14 +1066,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Login to GHCR (for the imagetools digest read-back)
-        if: needs.changes.outputs[matrix.changed] == 'true' || needs.changes.outputs.ci == 'true'
+        if: needs.changes.outputs[matrix.changed] == 'true'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Publish chart - ${{ matrix.chart-name }}'
-        if: needs.changes.outputs[matrix.changed] == 'true' || needs.changes.outputs.ci == 'true'
+        if: needs.changes.outputs[matrix.changed] == 'true'
         shell: bash
         # helm is preinstalled on the runner (OCI push needs >= 3.8). Only the
         # chart version is stamped (--version); Chart.yaml keeps its 0.0.0-dev /
@@ -1109,10 +1105,10 @@ jobs:
           printf '%s %s@%s\n' "${CHART_NAME}" "${ref}" "${digest}" \
             > "${RUNNER_TEMP}/chart-digests/${CHART_NAME}.txt"
       - name: Install cosign
-        if: needs.changes.outputs[matrix.changed] == 'true' || needs.changes.outputs.ci == 'true'
+        if: needs.changes.outputs[matrix.changed] == 'true'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: 'Sign chart - ${{ matrix.chart-name }}'
-        if: needs.changes.outputs[matrix.changed] == 'true' || needs.changes.outputs.ci == 'true'
+        if: needs.changes.outputs[matrix.changed] == 'true'
         # Sign the pushed OCI chart by digest with the keyed cosign pair, matching
         # the image signing in `publish`, so the build-lane haul verifies charts and
         # images alike at sync time (ADR 0033). Keyed, no transparency log.
@@ -1127,7 +1123,7 @@ jobs:
           cosign sign --key env://COSIGN_PRIVATE_KEY \
             --use-signing-config=false --tlog-upload=false --yes "${ref}"
       - name: 'Upload chart digest - ${{ matrix.chart-name }}'
-        if: needs.changes.outputs[matrix.changed] == 'true' || needs.changes.outputs.ci == 'true'
+        if: needs.changes.outputs[matrix.changed] == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: chart-digest-${{ matrix.chart-name }}
@@ -1237,10 +1233,10 @@ jobs:
     # (harmless) on partial builds until a one-time bootstrap seeds the first
     # predecessor. Sync verifies every component's cosign signature (--key) and
     # fails closed if any component is unsigned or unverifiable.
-    # LIVE (build-lane finalize). publish-charts now force-publishes all 14 charts on a
-    # ci/build-tooling change (changes.ci), so the first main run that carries this change
-    # seeds all 14 into the registry and this job folds them into the haul; each then
-    # carries by digest until it changes. Main-only, after images + charts publish.
+    # LIVE (build-lane finalize). Carries every chart by digest, so all 14 must be in
+    # the registry: publish-charts is changed-only, so run seed-charts.yaml once at
+    # go-live to publish the never-changed charts (deliberately NOT wired to changes.ci
+    # -- ADR 0030 keeps routine builds to changed charts only). Main-only, after publish.
     if: github.ref_name == 'main' && needs.publish.result == 'success' && needs.publish-charts.result == 'success'
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/seed-charts.yaml
+++ b/.github/workflows/seed-charts.yaml
@@ -1,0 +1,62 @@
+name: Seed charts
+
+# One-time manual publish of ALL charts to the OCI registry so the build-lane haul
+# can carry every chart by digest. The per-merge publish-charts job is changed-only,
+# so never-changed charts stay unpublished and the haul's fail-closed carry rejects
+# them; run this once at go-live. ADR 0030 keeps routine builds to changed charts
+# only (chart versions land in helm.sh/chart pod labels), hence a manual seed rather
+# than a changes.ci force-all.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  seed:
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chart:
+          - { name: hl7-transformer, dir: helm/extractor/hl7-transformer }
+          - { name: dcm4chee, dir: helm/dcm4chee }
+          - { name: hive-metastore, dir: helm/hive-metastore }
+          - { name: hl7-listener, dir: helm/hl7-listener }
+          - { name: hl7log-extractor, dir: helm/extractor/hl7log-extractor }
+          - { name: keycloak-config-cli, dir: helm/keycloak-config-cli }
+          - { name: launchpad, dir: helm/launchpad }
+          - { name: open-webui-bootstrap, dir: helm/open-webui-bootstrap }
+          - { name: orthanc, dir: helm/orthanc }
+          - { name: report-viewer, dir: helm/report-viewer }
+          - { name: scout-dashboards, dir: helm/scout-dashboards }
+          - { name: scout-opa, dir: helm/scout-opa }
+          - { name: temporal-bootstrap, dir: helm/temporal-bootstrap }
+          - { name: voila, dir: helm/voila }
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Package, push, and sign ${{ matrix.chart.name }}
+        env:
+          CHART_DIR: ${{ matrix.chart.dir }}
+          CHART_NAME: ${{ matrix.chart.name }}
+          REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          VERSION="0.$(date -u +%Y%m%d).${GITHUB_RUN_NUMBER}"
+          printf '%s' "${REGISTRY_TOKEN}" | helm registry login "${REGISTRY}" -u "${ACTOR}" --password-stdin
+          helm package "${CHART_DIR}" --version "${VERSION}" --destination "${RUNNER_TEMP}"
+          helm push "${RUNNER_TEMP}/${CHART_NAME}-${VERSION}.tgz" "oci://${REGISTRY}/washu-tag/charts"
+          ref="${REGISTRY}/washu-tag/charts/${CHART_NAME}:${VERSION}"
+          digest="$(docker buildx imagetools inspect "${ref}" --format '{{json .Manifest}}' | jq -r '.digest')"
+          [ "${digest#sha256:}" != "${digest}" ] || { echo "::error::no digest for ${CHART_NAME}"; exit 1; }
+          cosign sign --key env://COSIGN_PRIVATE_KEY --use-signing-config=false \
+            --tlog-upload=false --yes "${REGISTRY}/washu-tag/charts/${CHART_NAME}@${digest}"


### PR DESCRIPTION
## Description
### Product
None. Turns on the ADR 0033 build-lane haul (Phase 2 finalize).

### Technical
Two changes to `ci.yaml`:
- **`publish-charts`** now force-publishes all 14 charts on a CI/build-tooling change (`changes.ci`), mirroring `build-and-upload` for images (ADR 0030: CI changes rebuild everything). A never-published chart otherwise fails the haul's fail-closed carry, so this seeds every chart into the registry.
- **`publish-haul`** is un-paused (it was `if: false` since #634, pending the seed).

**Merging this PR is the go-live.** The merge is a CI change, so on the first main run `changes.ci` is true → `publish-charts` publishes all 14 charts (10 of them for the first time) and signs them → `publish-haul` carries the 8 images at digest from the bootstrap predecessor and folds in the 14 fresh charts plus the wrapper-chart upstream images = the first **complete signed haul**. Every main build thereafter carries unchanged components by digest.

Rebuilt fresh onto current `main` (the previously-held `ci/relight-build-lane` conflicted on #635's action-SHA bumps; it's superseded).

## Type of change
- [x] CI / build automation

## Impact
### Backward compatibility
No deploy impact. The haul job is `continue-on-error` and main-only; it publishes artifacts (charts + the haul bundle) and does not gate releases or touch the Ansible deploy path.

## Testing
`actionlint` clean on the diff. The seed + carry mechanics were validated during the Phase-2 build-out (bootstrap seeded the 8 images; predecessor-carry proven); this run exercises the chart seed end-to-end for the first time.

## Note for reviewers
After merge, `publish-haul` runs on every main build. The immediate fast-follow is **haul retention/pruning** (each haul is the whole ~5GB platform, republished each build; prune scoped to the two `manifests/*` packages only, keeping `:main` + the last N, never the digest-pinned image/chart packages). Other hardening (weekly full-rebuild backstop, checksum-pinned hauler/oras/cosign, superset version-sourcing) and the downstream enclave reconciler (Phase 3) are separate.