### PR TITLE
ci: bound build-lane haul storage with a retention workflow

### DIFF
--- a/.github/workflows/haul-retention.yaml
+++ b/.github/workflows/haul-retention.yaml
@@ -4,8 +4,8 @@ name: Haul retention
 # accumulate unbounded. Scoped HARD to the two manifests/* packages via a literal
 # allowlist below; it never enumerates packages, so it cannot reach the
 # digest-pinned image/chart packages that Flux consumers reference. Keeps :main +
-# the newest N versioned hauls (+ their cosign signatures) for rollback -- policy
-# is tooling/manifest/retention.py (unit-tested offline).
+# hauls younger than keep_days (min_keep newest regardless of age) + their cosign
+# signatures -- policy is tooling/manifest/retention.py (unit-tested offline).
 #
 # SAFE BY DEFAULT: a manual run only PREVIEWS the plan (dry_run=true). The weekly
 # schedule deletes for real only once the repo variable HAUL_RETENTION_ENABLED is
@@ -16,10 +16,14 @@ on:
     - cron: '17 8 * * 1' # Mondays 08:17 UTC
   workflow_dispatch:
     inputs:
-      keep_n:
-        description: 'Versioned hauls to retain per package (for rollback)'
+      keep_days:
+        description: 'Retain hauls younger than this many days (per package)'
         type: number
-        default: 10
+        default: 30
+      min_keep:
+        description: 'Always retain at least this many newest hauls'
+        type: number
+        default: 5
       dry_run:
         description: 'Preview only; do not delete'
         type: boolean
@@ -48,9 +52,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Schedule has no inputs -> 10. On dispatch, pass the operator value through
-          # verbatim (don't `|| 10`: keep_n=0 is falsy and would silently become 10,
-          # masking retention.py's keep_n>=1 guard -- let it fail loudly instead).
-          KEEP_N: ${{ github.event_name == 'schedule' && 10 || inputs.keep_n }}
+          # verbatim (don't coerce: retention.py's guards reject 0 / negatives loudly).
+          KEEP_DAYS: ${{ github.event_name == 'schedule' && 30 || inputs.keep_days }}
+          MIN_KEEP: ${{ github.event_name == 'schedule' && 5 || inputs.min_keep }}
           # Delete for real ONLY on an explicit dispatch with dry_run=false, or a
           # scheduled run once HAUL_RETENTION_ENABLED is set. Otherwise preview.
           DELETE_FOR_REAL: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) || (github.event_name == 'schedule' && vars.HAUL_RETENTION_ENABLED == 'true') }}
@@ -74,10 +78,9 @@ jobs:
               exit 1
             fi
             # Surface retention.py's plan/error even on failure -- set -e would
-            # otherwise abort before the summary line and hide the reason (e.g. the
-            # keep_n>=1 guard).
+            # otherwise abort before the summary line and hide the reason (e.g. a guard).
             if ! printf '%s' "${raw}" | jq -s 'add' \
-                | python3 tooling/manifest/retention.py --keep "${KEEP_N}" - >delete-ids.txt 2>plan.txt; then
+                | python3 tooling/manifest/retention.py --keep-days "${KEEP_DAYS}" --min-keep "${MIN_KEEP}" - >delete-ids.txt 2>plan.txt; then
               echo "::error::retention.py failed for ${pkg}:"; cat plan.txt
               sed 's/^/    /' plan.txt >> "$GITHUB_STEP_SUMMARY"
               exit 1

--- a/.github/workflows/haul-retention.yaml
+++ b/.github/workflows/haul-retention.yaml
@@ -73,24 +73,36 @@ jobs:
               cat err.txt
               exit 1
             fi
-            printf '%s' "${raw}" | jq -s 'add' \
-              | python3 tooling/manifest/retention.py --keep "${KEEP_N}" - >delete-ids.txt 2>plan.txt
+            # Surface retention.py's plan/error even on failure -- set -e would
+            # otherwise abort before the summary line and hide the reason (e.g. the
+            # keep_n>=1 guard).
+            if ! printf '%s' "${raw}" | jq -s 'add' \
+                | python3 tooling/manifest/retention.py --keep "${KEEP_N}" - >delete-ids.txt 2>plan.txt; then
+              echo "::error::retention.py failed for ${pkg}:"; cat plan.txt
+              sed 's/^/    /' plan.txt >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
             sed 's/^/    /' plan.txt >> "$GITHUB_STEP_SUMMARY"
             count="$(grep -c . delete-ids.txt || true)"
             if [ "${DELETE_FOR_REAL}" = "true" ]; then
-              # Non-fatal per id: a single stuck version (e.g. transient 403) must not
-              # abort the run and block the other package. retention.py recomputes from
-              # live state each run, so a skipped delete just retries next time.
+              # Per-id tolerance so one stuck version doesn't block the rest, but track
+              # the counts: every delete failing (with deletes attempted) is systemic --
+              # usually a permissions gap dry-run can't exercise -- so fail loud.
+              deleted=0; failed=0
               while read -r id; do
                 [ -n "${id}" ] || continue
                 if gh api -X DELETE "/orgs/${ORG}/packages/container/${enc}/versions/${id}"; then
-                  echo "  deleted version ${id}"
+                  deleted=$((deleted + 1))
                 else
+                  failed=$((failed + 1))
                   echo "::warning::could not delete version ${id} of ${pkg} (will retry next run)"
-                  echo "    WARN: could not delete ${id}" >> "$GITHUB_STEP_SUMMARY"
                 fi
               done <delete-ids.txt
-              echo "  processed ${count} version(s) for deletion" >> "$GITHUB_STEP_SUMMARY"
+              echo "  deleted ${deleted}, failed ${failed} of ${count}" >> "$GITHUB_STEP_SUMMARY"
+              if [ "${count}" -gt 0 ] && [ "${deleted}" -eq 0 ]; then
+                echo "::error::all ${count} deletions failed for ${pkg} (permissions?)"
+                exit 1
+              fi
             else
               echo "  DRY RUN: would delete ${count} version(s) -- enable with HAUL_RETENTION_ENABLED=true (schedule) or dispatch with dry_run=false" >> "$GITHUB_STEP_SUMMARY"
             fi

--- a/.github/workflows/haul-retention.yaml
+++ b/.github/workflows/haul-retention.yaml
@@ -1,0 +1,97 @@
+name: Haul retention
+
+# Prune old build-lane haul packages so the ~5GB-per-main-build bundles don't
+# accumulate unbounded. Scoped HARD to the two manifests/* packages via a literal
+# allowlist below; it never enumerates packages, so it cannot reach the
+# digest-pinned image/chart packages that Flux consumers reference. Keeps :main +
+# the newest N versioned hauls (+ their cosign signatures) for rollback -- policy
+# is tooling/manifest/retention.py (unit-tested offline).
+#
+# SAFE BY DEFAULT: a manual run only PREVIEWS the plan (dry_run=true). The weekly
+# schedule deletes for real only once the repo variable HAUL_RETENTION_ENABLED is
+# set to 'true', so the team validates the plan against the real registry before
+# any deletion happens.
+on:
+  schedule:
+    - cron: '17 8 * * 1' # Mondays 08:17 UTC
+  workflow_dispatch:
+    inputs:
+      keep_n:
+        description: 'Versioned hauls to retain per package (for rollback)'
+        type: number
+        default: 10
+      dry_run:
+        description: 'Preview only; do not delete'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read # checkout retention.py
+  packages: write # delete old package versions
+
+concurrency:
+  group: haul-retention
+  cancel-in-progress: false
+
+env:
+  ORG: washu-tag
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+      - name: Prune old haul package versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Schedule has no inputs -> 10. On dispatch, pass the operator value through
+          # verbatim (don't `|| 10`: keep_n=0 is falsy and would silently become 10,
+          # masking retention.py's keep_n>=1 guard -- let it fail loudly instead).
+          KEEP_N: ${{ github.event_name == 'schedule' && 10 || inputs.keep_n }}
+          # Delete for real ONLY on an explicit dispatch with dry_run=false, or a
+          # scheduled run once HAUL_RETENTION_ENABLED is set. Otherwise preview.
+          DELETE_FOR_REAL: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) || (github.event_name == 'schedule' && vars.HAUL_RETENTION_ENABLED == 'true') }}
+        run: |
+          set -euo pipefail
+          # Literal allowlist -- the ONLY packages this workflow may ever touch.
+          for pkg in "manifests/scout" "manifests/scout-manifest"; do
+            enc="${pkg//\//%2F}"
+            echo "## ${pkg}" >> "$GITHUB_STEP_SUMMARY"
+            if ! raw="$(gh api --paginate "/orgs/${ORG}/packages/container/${enc}/versions" 2>err.txt)"; then
+              # A 404 means the package doesn't exist yet (fine, skip). ANY other error
+              # (403/rate-limit/auth/5xx) must be LOUD, not silently treated as
+              # not-found -- otherwise a broken run reports success and the 5GB
+              # accumulation this job exists to bound keeps growing unnoticed.
+              if grep -q 'HTTP 404' err.txt; then
+                echo "  package does not exist yet; skipping" | tee -a "$GITHUB_STEP_SUMMARY"
+                continue
+              fi
+              echo "::error::failed to list versions for ${pkg}:"
+              cat err.txt
+              exit 1
+            fi
+            printf '%s' "${raw}" | jq -s 'add' \
+              | python3 tooling/manifest/retention.py --keep "${KEEP_N}" - >delete-ids.txt 2>plan.txt
+            sed 's/^/    /' plan.txt >> "$GITHUB_STEP_SUMMARY"
+            count="$(grep -c . delete-ids.txt || true)"
+            if [ "${DELETE_FOR_REAL}" = "true" ]; then
+              # Non-fatal per id: a single stuck version (e.g. transient 403) must not
+              # abort the run and block the other package. retention.py recomputes from
+              # live state each run, so a skipped delete just retries next time.
+              while read -r id; do
+                [ -n "${id}" ] || continue
+                if gh api -X DELETE "/orgs/${ORG}/packages/container/${enc}/versions/${id}"; then
+                  echo "  deleted version ${id}"
+                else
+                  echo "::warning::could not delete version ${id} of ${pkg} (will retry next run)"
+                  echo "    WARN: could not delete ${id}" >> "$GITHUB_STEP_SUMMARY"
+                fi
+              done <delete-ids.txt
+              echo "  processed ${count} version(s) for deletion" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "  DRY RUN: would delete ${count} version(s) -- enable with HAUL_RETENTION_ENABLED=true (schedule) or dispatch with dry_run=false" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done

--- a/tooling/manifest/retention.py
+++ b/tooling/manifest/retention.py
@@ -7,16 +7,17 @@ manifest), tagged `0.YYYYMMDD.<run>` with `:main` moved onto the newest. Left
 unbounded they accumulate ~5GB per build. This computes which package *versions*
 to keep vs delete; the workflow feeds it `GET .../versions` and acts on the split.
 
-Policy (deliberately conservative -- deleting the wrong version breaks Flux
-consumers that pin by digest, so we under-prune rather than over-prune):
+Policy is by AGE, not count, so the rollback window is a fixed time horizon
+regardless of build cadence (deliberately conservative -- deleting the wrong
+version breaks Flux consumers that pin by digest, so we under-prune):
   - KEEP any version tagged `main` (the pointer the next build carries from).
-  - KEEP the newest `keep_n` version-tagged artifacts (by created_at).
+  - KEEP version-tagged artifacts younger than `keep_days`.
+  - KEEP at least the `min_keep` newest artifacts regardless of age, so a quiet
+    period never prunes the whole rollback set.
   - KEEP a cosign signature (`sha256-<hex>.sig`) whose subject digest is a kept
     artifact; DELETE it only when its subject artifact is itself being deleted.
-  - KEEP every untagged version (referrer-style signatures, or an in-flight push);
-    never auto-delete something we can't positively identify.
-  - DELETE the remainder: version-tagged artifacts past the newest `keep_n` (and
-    not `main`), plus the signatures of those deleted artifacts.
+  - KEEP every untagged version (referrer-style signatures, or an in-flight push).
+  - DELETE the remainder.
 
 This module is import-only pure logic (unit-tested offline); the GHCR calls and
 the two hard-coded package names live in the workflow so a bug here can never
@@ -25,6 +26,7 @@ reach a package it wasn't handed.
 from __future__ import annotations
 
 import re
+from datetime import datetime, timedelta, timezone
 
 _SIG_TAG = re.compile(r"^sha256-([0-9a-f]{64})\.sig$")
 
@@ -38,15 +40,26 @@ def _sig_subject(tags):
     return None
 
 
-def partition(versions, keep_n):
+def _parse(created_at):
+    """Parse a GHCR ISO timestamp; missing/empty sorts as oldest."""
+    if not created_at:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    return datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+
+
+def partition(versions, keep_days, min_keep, now):
     """Split GHCR package versions into (keep_ids, delete_ids).
 
-    versions: iterable of dicts with keys `id` (int), `created_at` (ISO str),
-    `tags` (list[str]), `digest` (str, the version's own sha256:...). keep_n: how
-    many version-tagged artifacts to retain for rollback (must be >= 1).
+    keep_days: retain version-tagged artifacts younger than this. min_keep: always
+    retain at least this many newest artifacts regardless of age. now: the reference
+    time (passed for testability). versions: dicts with id, created_at (ISO), tags,
+    digest (the version's own sha256:...).
     """
-    if keep_n < 1:
-        raise ValueError("keep_n must be >= 1 (always keep at least the newest haul)")
+    if min_keep < 1:
+        raise ValueError("min_keep must be >= 1 (always keep at least the newest haul)")
+    if keep_days < 0:
+        raise ValueError("keep_days must be >= 0")
+    cutoff = now - timedelta(days=keep_days)
 
     keep, delete = set(), set()
     main_ids, artifacts, sigs = set(), [], []
@@ -68,11 +81,11 @@ def partition(versions, keep_n):
         else:
             artifacts.append(v)
 
-    # Newest keep_n version-tagged artifacts (plus any :main-tagged) are retained.
-    artifacts.sort(key=lambda v: (v.get("created_at") or "", v["id"]), reverse=True)
+    artifacts.sort(key=lambda v: (_parse(v.get("created_at")), v["id"]), reverse=True)
     kept_digests = set()
     for i, v in enumerate(artifacts):
-        if v["id"] in main_ids or i < keep_n:
+        young = _parse(v.get("created_at")) >= cutoff
+        if v["id"] in main_ids or i < min_keep or young:
             keep.add(v["id"])
             if v.get("digest"):
                 kept_digests.add(v["digest"])
@@ -115,7 +128,10 @@ def _main():
 
     ap = argparse.ArgumentParser(description="Compute haul package retention plan.")
     ap.add_argument(
-        "--keep", type=int, default=10, help="version-tagged hauls to retain"
+        "--keep-days", type=int, default=30, help="retain hauls younger than this"
+    )
+    ap.add_argument(
+        "--min-keep", type=int, default=5, help="always keep at least this many newest"
     )
     ap.add_argument(
         "versions_json", help="file of `GET .../versions` JSON, or - for stdin"
@@ -128,11 +144,14 @@ def _main():
         else open(args.versions_json).read()
     )
     versions = versions_from_api(json.loads(raw))
-    keep, delete = partition(versions, args.keep)
+    keep, delete = partition(
+        versions, args.keep_days, args.min_keep, datetime.now(timezone.utc)
+    )
 
     by_id = {v["id"]: v for v in versions}
     print(
-        f"total={len(versions)} keep={len(keep)} delete={len(delete)} (keep_n={args.keep})",
+        f"total={len(versions)} keep={len(keep)} delete={len(delete)} "
+        f"(keep_days={args.keep_days} min_keep={args.min_keep})",
         file=sys.stderr,
     )
     for vid in sorted(delete):

--- a/tooling/manifest/retention.py
+++ b/tooling/manifest/retention.py
@@ -96,27 +96,41 @@ def _main():
     import sys
 
     ap = argparse.ArgumentParser(description="Compute haul package retention plan.")
-    ap.add_argument("--keep", type=int, default=10, help="version-tagged hauls to retain")
-    ap.add_argument("versions_json", help="file of `GET .../versions` JSON, or - for stdin")
+    ap.add_argument(
+        "--keep", type=int, default=10, help="version-tagged hauls to retain"
+    )
+    ap.add_argument(
+        "versions_json", help="file of `GET .../versions` JSON, or - for stdin"
+    )
     args = ap.parse_args()
 
-    raw = sys.stdin.read() if args.versions_json == "-" else open(args.versions_json).read()
+    raw = (
+        sys.stdin.read()
+        if args.versions_json == "-"
+        else open(args.versions_json).read()
+    )
     data = json.loads(raw)
     versions = [
         {
             "id": v["id"],
             "created_at": v.get("created_at", ""),
             "digest": v.get("name", ""),  # GHCR container version `name` == its digest
-            "tags": ((v.get("metadata") or {}).get("container") or {}).get("tags") or [],
+            "tags": ((v.get("metadata") or {}).get("container") or {}).get("tags")
+            or [],
         }
         for v in data
     ]
     keep, delete = partition(versions, args.keep)
 
     by_id = {v["id"]: v for v in versions}
-    print(f"total={len(versions)} keep={len(keep)} delete={len(delete)} (keep_n={args.keep})", file=sys.stderr)
+    print(
+        f"total={len(versions)} keep={len(keep)} delete={len(delete)} (keep_n={args.keep})",
+        file=sys.stderr,
+    )
     for vid in sorted(delete):
-        print(f"  DELETE {vid} tags={by_id[vid]['tags'] or '(untagged)'}", file=sys.stderr)
+        print(
+            f"  DELETE {vid} tags={by_id[vid]['tags'] or '(untagged)'}", file=sys.stderr
+        )
     # stdout = machine-readable delete ids, one per line, for the workflow to act on
     for vid in sorted(delete):
         print(vid)

--- a/tooling/manifest/retention.py
+++ b/tooling/manifest/retention.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Retention policy for the build-lane haul packages (ADR 0033).
+
+Every main build republishes the whole ~5GB platform to the two GHCR packages
+`manifests/scout` (the .tar.zst bundle) and `manifests/scout-manifest` (the
+manifest), tagged `0.YYYYMMDD.<run>` with `:main` moved onto the newest. Left
+unbounded they accumulate ~5GB per build. This computes which package *versions*
+to keep vs delete; the workflow feeds it `GET .../versions` and acts on the split.
+
+Policy (deliberately conservative -- deleting the wrong version breaks Flux
+consumers that pin by digest, so we under-prune rather than over-prune):
+  - KEEP any version tagged `main` (the pointer the next build carries from).
+  - KEEP the newest `keep_n` version-tagged artifacts (by created_at).
+  - KEEP a cosign signature (`sha256-<hex>.sig`) whose subject digest is a kept
+    artifact; DELETE it only when its subject artifact is itself being deleted.
+  - KEEP every untagged version (referrer-style signatures, or an in-flight push);
+    never auto-delete something we can't positively identify.
+  - DELETE the remainder: version-tagged artifacts past the newest `keep_n` (and
+    not `main`), plus the signatures of those deleted artifacts.
+
+This module is import-only pure logic (unit-tested offline); the GHCR calls and
+the two hard-coded package names live in the workflow so a bug here can never
+reach a package it wasn't handed.
+"""
+from __future__ import annotations
+
+import re
+
+_SIG_TAG = re.compile(r"^sha256-([0-9a-f]{64})\.sig$")
+
+
+def _sig_subject(tags):
+    """Return the subject digest (sha256:<hex>) a cosign `.sig` tag refers to, else None."""
+    for t in tags:
+        m = _SIG_TAG.match(t)
+        if m:
+            return "sha256:" + m.group(1)
+    return None
+
+
+def partition(versions, keep_n):
+    """Split GHCR package versions into (keep_ids, delete_ids).
+
+    versions: iterable of dicts with keys `id` (int), `created_at` (ISO str),
+    `tags` (list[str]), `digest` (str, the version's own sha256:...). keep_n: how
+    many version-tagged artifacts to retain for rollback (must be >= 1).
+    """
+    if keep_n < 1:
+        raise ValueError("keep_n must be >= 1 (always keep at least the newest haul)")
+
+    keep, delete = set(), set()
+    main_ids, artifacts, sigs = set(), [], []
+    digest_of = {}
+
+    for v in versions:
+        vid = v["id"]
+        tags = v.get("tags") or []
+        digest_of[vid] = v.get("digest")
+        if not tags:
+            keep.add(vid)  # untagged: conservative keep
+            continue
+        if "main" in tags:
+            main_ids.add(vid)
+            keep.add(vid)
+        subject = _sig_subject(tags)
+        if subject is not None:
+            sigs.append((vid, subject))
+        else:
+            artifacts.append(v)
+
+    # Newest keep_n version-tagged artifacts (plus any :main-tagged) are retained.
+    artifacts.sort(key=lambda v: (v.get("created_at") or "", v["id"]), reverse=True)
+    kept_digests = set()
+    for i, v in enumerate(artifacts):
+        if v["id"] in main_ids or i < keep_n:
+            keep.add(v["id"])
+            if v.get("digest"):
+                kept_digests.add(v["digest"])
+        else:
+            delete.add(v["id"])
+
+    deleted_digests = {digest_of[i] for i in delete if digest_of.get(i)}
+    for vid, subject in sigs:
+        if subject in kept_digests:
+            keep.add(vid)
+        elif subject in deleted_digests:
+            delete.add(vid)  # orphaned by deleting its bundle -> clean it up
+        else:
+            keep.add(vid)  # subject unknown/absent: conservative keep
+    return keep, delete
+
+
+def _main():
+    import argparse
+    import json
+    import sys
+
+    ap = argparse.ArgumentParser(description="Compute haul package retention plan.")
+    ap.add_argument("--keep", type=int, default=10, help="version-tagged hauls to retain")
+    ap.add_argument("versions_json", help="file of `GET .../versions` JSON, or - for stdin")
+    args = ap.parse_args()
+
+    raw = sys.stdin.read() if args.versions_json == "-" else open(args.versions_json).read()
+    data = json.loads(raw)
+    versions = [
+        {
+            "id": v["id"],
+            "created_at": v.get("created_at", ""),
+            "digest": v.get("name", ""),  # GHCR container version `name` == its digest
+            "tags": ((v.get("metadata") or {}).get("container") or {}).get("tags") or [],
+        }
+        for v in data
+    ]
+    keep, delete = partition(versions, args.keep)
+
+    by_id = {v["id"]: v for v in versions}
+    print(f"total={len(versions)} keep={len(keep)} delete={len(delete)} (keep_n={args.keep})", file=sys.stderr)
+    for vid in sorted(delete):
+        print(f"  DELETE {vid} tags={by_id[vid]['tags'] or '(untagged)'}", file=sys.stderr)
+    # stdout = machine-readable delete ids, one per line, for the workflow to act on
+    for vid in sorted(delete):
+        print(vid)
+
+
+if __name__ == "__main__":
+    _main()

--- a/tooling/manifest/retention.py
+++ b/tooling/manifest/retention.py
@@ -87,7 +87,25 @@ def partition(versions, keep_n):
             delete.add(vid)  # orphaned by deleting its bundle -> clean it up
         else:
             keep.add(vid)  # subject unknown/absent: conservative keep
+    delete -= keep  # keep always wins if a version lands in both sets
+    assert keep.isdisjoint(delete)
     return keep, delete
+
+
+def versions_from_api(data):
+    """Map a GHCR `GET .../versions` JSON list to partition() input dicts. GHCR
+    container versions carry the full sha256:<hex> digest in `name` and the tags
+    under metadata.container.tags."""
+    return [
+        {
+            "id": v["id"],
+            "created_at": v.get("created_at", ""),
+            "digest": v.get("name", ""),
+            "tags": ((v.get("metadata") or {}).get("container") or {}).get("tags")
+            or [],
+        }
+        for v in data
+    ]
 
 
 def _main():
@@ -109,17 +127,7 @@ def _main():
         if args.versions_json == "-"
         else open(args.versions_json).read()
     )
-    data = json.loads(raw)
-    versions = [
-        {
-            "id": v["id"],
-            "created_at": v.get("created_at", ""),
-            "digest": v.get("name", ""),  # GHCR container version `name` == its digest
-            "tags": ((v.get("metadata") or {}).get("container") or {}).get("tags")
-            or [],
-        }
-        for v in data
-    ]
+    versions = versions_from_api(json.loads(raw))
     keep, delete = partition(versions, args.keep)
 
     by_id = {v["id"]: v for v in versions}

--- a/tooling/manifest/test_retention.py
+++ b/tooling/manifest/test_retention.py
@@ -1,137 +1,140 @@
 """Offline tests for the haul retention policy (tooling/manifest/retention.py)."""
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from retention import partition, versions_from_api
 
-H = {c: c * 64 for c in "abcdef"}  # 64-hex digests keyed by a letter
+H = {c: c * 64 for c in "abcde"}  # 64-hex digests keyed by a letter
+NOW = datetime(2026, 8, 15, tzinfo=timezone.utc)
 
 
-def _v(vid, created, tags, digest_letter):
+def _ago(days):
+    return (NOW - timedelta(days=days)).isoformat()
+
+
+def _artifact(vid, days_ago, version_tag, digest_letter, main=False):
+    tags = [version_tag] + (["main"] if main else [])
     return {
         "id": vid,
-        "created_at": created,
+        "created_at": _ago(days_ago),
         "tags": tags,
         "digest": "sha256:" + H[digest_letter],
     }
 
 
-def _artifact(vid, created, version_tag, digest_letter, main=False):
-    tags = [version_tag] + (["main"] if main else [])
-    return _v(vid, created, tags, digest_letter)
+def _sig(vid, days_ago, subject_letter, own_letter):
+    return {
+        "id": vid,
+        "created_at": _ago(days_ago),
+        "tags": ["sha256-" + H[subject_letter] + ".sig"],
+        "digest": "sha256:" + H[own_letter],
+    }
 
 
-def _sig(vid, created, subject_letter, own_letter):
-    return _v(vid, created, ["sha256-" + H[subject_letter] + ".sig"], own_letter)
-
-
-def test_keeps_newest_n_deletes_older():
+def test_keeps_young_deletes_old():
     versions = [
-        _artifact(1, "2026-08-01T00:00:00Z", "0.20260801.1", "a"),
-        _artifact(2, "2026-08-02T00:00:00Z", "0.20260802.1", "b"),
-        _artifact(3, "2026-08-03T00:00:00Z", "0.20260803.1", "c", main=True),
+        _artifact(1, 40, "0.a", "a"),  # old -> delete
+        _artifact(2, 20, "0.b", "b"),  # old -> delete
+        _artifact(3, 3, "0.c", "c"),  # young -> keep
+        _artifact(4, 1, "0.d", "d", main=True),  # young + main -> keep
     ]
-    keep, delete = partition(versions, keep_n=2)
+    keep, delete = partition(versions, keep_days=7, min_keep=1, now=NOW)
+    assert keep == {3, 4} and delete == {1, 2}
+
+
+def test_min_keep_protects_a_quiet_period():
+    # everything older than keep_days, but min_keep retains the newest two
+    versions = [
+        _artifact(1, 100, "0.a", "a"),
+        _artifact(2, 90, "0.b", "b"),
+        _artifact(3, 80, "0.c", "c"),
+    ]
+    keep, delete = partition(versions, keep_days=7, min_keep=2, now=NOW)
     assert keep == {2, 3} and delete == {1}
 
 
-def test_main_is_kept_even_when_older_than_keep_n():
-    # main pinned to an OLD artifact (unusual, but must never be pruned)
+def test_main_kept_regardless_of_age():
     versions = [
-        _artifact(1, "2026-08-01T00:00:00Z", "0.20260801.1", "a", main=True),
-        _artifact(2, "2026-08-02T00:00:00Z", "0.20260802.1", "b"),
-        _artifact(3, "2026-08-03T00:00:00Z", "0.20260803.1", "c"),
+        _artifact(1, 200, "0.a", "a", main=True),  # ancient but main
+        _artifact(2, 3, "0.b", "b"),
     ]
-    keep, delete = partition(versions, keep_n=1)
-    assert 1 in keep and 3 in keep  # main + newest
-    assert delete == {2}
+    keep, delete = partition(versions, keep_days=7, min_keep=1, now=NOW)
+    assert keep == {1, 2} and delete == set()
 
 
 def test_signature_follows_its_bundle():
     versions = [
-        _artifact(
-            1, "2026-08-01T00:00:00Z", "0.20260801.1", "a"
-        ),  # old bundle -> delete
-        _sig(
-            2, "2026-08-01T00:01:00Z", subject_letter="a", own_letter="d"
-        ),  # its sig -> delete
-        _artifact(
-            3, "2026-08-03T00:00:00Z", "0.20260803.1", "b", main=True
-        ),  # kept bundle
-        _sig(
-            4, "2026-08-03T00:01:00Z", subject_letter="b", own_letter="e"
-        ),  # its sig -> keep
+        _artifact(1, 40, "0.a", "a"),  # old bundle -> delete
+        _sig(2, 40, subject_letter="a", own_letter="d"),  # its sig -> delete
+        _artifact(3, 1, "0.b", "b", main=True),  # kept bundle
+        _sig(4, 1, subject_letter="b", own_letter="e"),  # its sig -> keep
     ]
-    keep, delete = partition(versions, keep_n=1)
+    keep, delete = partition(versions, keep_days=7, min_keep=1, now=NOW)
     assert keep == {3, 4} and delete == {1, 2}
 
 
-def test_untagged_and_orphan_sig_are_kept_conservatively():
+def test_untagged_kept():
     versions = [
-        _artifact(1, "2026-08-03T00:00:00Z", "0.20260803.1", "a", main=True),
+        _artifact(1, 1, "0.a", "a", main=True),
         {
             "id": 2,
-            "created_at": "2026-08-03T00:02:00Z",
+            "created_at": _ago(200),
             "tags": [],
             "digest": "sha256:" + H["b"],
         },  # untagged
-        _sig(
-            3, "2026-08-01T00:00:00Z", subject_letter="f", own_letter="c"
-        ),  # subject absent -> orphan
     ]
-    keep, delete = partition(versions, keep_n=1)
-    assert keep == {1, 2, 3} and delete == set()
-
-
-def test_fewer_than_keep_n_keeps_all():
-    versions = [
-        _artifact(1, "2026-08-01T00:00:00Z", "0.20260801.1", "a"),
-        _artifact(2, "2026-08-02T00:00:00Z", "0.20260802.1", "b", main=True),
-    ]
-    keep, delete = partition(versions, keep_n=10)
+    keep, delete = partition(versions, keep_days=7, min_keep=1, now=NOW)
     assert keep == {1, 2} and delete == set()
 
 
 def test_empty():
-    assert partition([], keep_n=5) == (set(), set())
+    assert partition([], keep_days=30, min_keep=5, now=NOW) == (set(), set())
 
 
-def test_keep_n_must_be_positive():
+def test_min_keep_must_be_positive():
     with pytest.raises(ValueError):
-        partition([], keep_n=0)
+        partition([], keep_days=30, min_keep=0, now=NOW)
+
+
+def test_keep_days_must_be_nonneg():
+    with pytest.raises(ValueError):
+        partition([], keep_days=-1, min_keep=5, now=NOW)
 
 
 def test_versions_from_api_shape_and_partition():
-    # Real `GET .../versions` shape: digest in `name`, tags under metadata.container.
+    # Real `GET .../versions` shape (Z timestamps): digest in `name`, tags under
+    # metadata.container. NOW=2026-08-15, keep_days=7 -> cutoff 2026-08-08.
     api = [
         {
             "id": 10,
-            "created_at": "2026-08-01T00:00:00Z",
+            "created_at": "2026-06-01T00:00:00Z",
             "name": "sha256:" + H["a"],
-            "metadata": {"container": {"tags": ["0.20260801.1"]}},
+            "metadata": {"container": {"tags": ["0.a"]}},
         },
         {
             "id": 11,
-            "created_at": "2026-08-03T00:00:00Z",
+            "created_at": "2026-08-14T00:00:00Z",
             "name": "sha256:" + H["b"],
-            "metadata": {"container": {"tags": ["0.20260803.1", "main"]}},
+            "metadata": {"container": {"tags": ["0.b", "main"]}},
         },
         {
             "id": 12,
-            "created_at": "2026-08-01T00:01:00Z",
+            "created_at": "2026-06-01T00:00:00Z",
             "name": "sha256:" + H["c"],
             "metadata": {"container": {"tags": ["sha256-" + H["a"] + ".sig"]}},
         },
         {
             "id": 13,
-            "created_at": "2026-08-03T00:02:00Z",
+            "created_at": "2026-08-14T00:00:00Z",
             "name": "sha256:" + H["d"],
             "metadata": {},
-        },  # untagged / no container metadata
+        },
     ]
     versions = versions_from_api(api)
     assert versions[0]["digest"] == "sha256:" + H["a"]
-    assert versions[1]["tags"] == ["0.20260803.1", "main"]
+    assert versions[1]["tags"] == ["0.b", "main"]
     assert versions[3]["tags"] == []
-    keep, delete = partition(versions, keep_n=1)
+    keep, delete = partition(versions, keep_days=7, min_keep=1, now=NOW)
     assert keep == {11, 13} and delete == {10, 12}

--- a/tooling/manifest/test_retention.py
+++ b/tooling/manifest/test_retention.py
@@ -1,0 +1,80 @@
+"""Offline tests for the haul retention policy (tooling/manifest/retention.py)."""
+import pytest
+
+from retention import partition
+
+H = {c: c * 64 for c in "abcdef"}  # 64-hex digests keyed by a letter
+
+
+def _v(vid, created, tags, digest_letter):
+    return {"id": vid, "created_at": created, "tags": tags, "digest": "sha256:" + H[digest_letter]}
+
+
+def _artifact(vid, created, version_tag, digest_letter, main=False):
+    tags = [version_tag] + (["main"] if main else [])
+    return _v(vid, created, tags, digest_letter)
+
+
+def _sig(vid, created, subject_letter, own_letter):
+    return _v(vid, created, ["sha256-" + H[subject_letter] + ".sig"], own_letter)
+
+
+def test_keeps_newest_n_deletes_older():
+    versions = [
+        _artifact(1, "2026-08-01T00:00:00Z", "0.20260801.1", "a"),
+        _artifact(2, "2026-08-02T00:00:00Z", "0.20260802.1", "b"),
+        _artifact(3, "2026-08-03T00:00:00Z", "0.20260803.1", "c", main=True),
+    ]
+    keep, delete = partition(versions, keep_n=2)
+    assert keep == {2, 3} and delete == {1}
+
+
+def test_main_is_kept_even_when_older_than_keep_n():
+    # main pinned to an OLD artifact (unusual, but must never be pruned)
+    versions = [
+        _artifact(1, "2026-08-01T00:00:00Z", "0.20260801.1", "a", main=True),
+        _artifact(2, "2026-08-02T00:00:00Z", "0.20260802.1", "b"),
+        _artifact(3, "2026-08-03T00:00:00Z", "0.20260803.1", "c"),
+    ]
+    keep, delete = partition(versions, keep_n=1)
+    assert 1 in keep and 3 in keep  # main + newest
+    assert delete == {2}
+
+
+def test_signature_follows_its_bundle():
+    versions = [
+        _artifact(1, "2026-08-01T00:00:00Z", "0.20260801.1", "a"),          # old bundle -> delete
+        _sig(2, "2026-08-01T00:01:00Z", subject_letter="a", own_letter="d"),  # its sig -> delete
+        _artifact(3, "2026-08-03T00:00:00Z", "0.20260803.1", "b", main=True),  # kept bundle
+        _sig(4, "2026-08-03T00:01:00Z", subject_letter="b", own_letter="e"),  # its sig -> keep
+    ]
+    keep, delete = partition(versions, keep_n=1)
+    assert keep == {3, 4} and delete == {1, 2}
+
+
+def test_untagged_and_orphan_sig_are_kept_conservatively():
+    versions = [
+        _artifact(1, "2026-08-03T00:00:00Z", "0.20260803.1", "a", main=True),
+        {"id": 2, "created_at": "2026-08-03T00:02:00Z", "tags": [], "digest": "sha256:" + H["b"]},  # untagged
+        _sig(3, "2026-08-01T00:00:00Z", subject_letter="f", own_letter="c"),  # subject absent -> orphan
+    ]
+    keep, delete = partition(versions, keep_n=1)
+    assert keep == {1, 2, 3} and delete == set()
+
+
+def test_fewer_than_keep_n_keeps_all():
+    versions = [
+        _artifact(1, "2026-08-01T00:00:00Z", "0.20260801.1", "a"),
+        _artifact(2, "2026-08-02T00:00:00Z", "0.20260802.1", "b", main=True),
+    ]
+    keep, delete = partition(versions, keep_n=10)
+    assert keep == {1, 2} and delete == set()
+
+
+def test_empty():
+    assert partition([], keep_n=5) == (set(), set())
+
+
+def test_keep_n_must_be_positive():
+    with pytest.raises(ValueError):
+        partition([], keep_n=0)

--- a/tooling/manifest/test_retention.py
+++ b/tooling/manifest/test_retention.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from retention import partition
+from retention import partition, versions_from_api
 
 H = {c: c * 64 for c in "abcdef"}  # 64-hex digests keyed by a letter
 
@@ -99,3 +99,39 @@ def test_empty():
 def test_keep_n_must_be_positive():
     with pytest.raises(ValueError):
         partition([], keep_n=0)
+
+
+def test_versions_from_api_shape_and_partition():
+    # Real `GET .../versions` shape: digest in `name`, tags under metadata.container.
+    api = [
+        {
+            "id": 10,
+            "created_at": "2026-08-01T00:00:00Z",
+            "name": "sha256:" + H["a"],
+            "metadata": {"container": {"tags": ["0.20260801.1"]}},
+        },
+        {
+            "id": 11,
+            "created_at": "2026-08-03T00:00:00Z",
+            "name": "sha256:" + H["b"],
+            "metadata": {"container": {"tags": ["0.20260803.1", "main"]}},
+        },
+        {
+            "id": 12,
+            "created_at": "2026-08-01T00:01:00Z",
+            "name": "sha256:" + H["c"],
+            "metadata": {"container": {"tags": ["sha256-" + H["a"] + ".sig"]}},
+        },
+        {
+            "id": 13,
+            "created_at": "2026-08-03T00:02:00Z",
+            "name": "sha256:" + H["d"],
+            "metadata": {},
+        },  # untagged / no container metadata
+    ]
+    versions = versions_from_api(api)
+    assert versions[0]["digest"] == "sha256:" + H["a"]
+    assert versions[1]["tags"] == ["0.20260803.1", "main"]
+    assert versions[3]["tags"] == []
+    keep, delete = partition(versions, keep_n=1)
+    assert keep == {11, 13} and delete == {10, 12}

--- a/tooling/manifest/test_retention.py
+++ b/tooling/manifest/test_retention.py
@@ -1,4 +1,5 @@
 """Offline tests for the haul retention policy (tooling/manifest/retention.py)."""
+
 import pytest
 
 from retention import partition
@@ -7,7 +8,12 @@ H = {c: c * 64 for c in "abcdef"}  # 64-hex digests keyed by a letter
 
 
 def _v(vid, created, tags, digest_letter):
-    return {"id": vid, "created_at": created, "tags": tags, "digest": "sha256:" + H[digest_letter]}
+    return {
+        "id": vid,
+        "created_at": created,
+        "tags": tags,
+        "digest": "sha256:" + H[digest_letter],
+    }
 
 
 def _artifact(vid, created, version_tag, digest_letter, main=False):
@@ -43,10 +49,18 @@ def test_main_is_kept_even_when_older_than_keep_n():
 
 def test_signature_follows_its_bundle():
     versions = [
-        _artifact(1, "2026-08-01T00:00:00Z", "0.20260801.1", "a"),          # old bundle -> delete
-        _sig(2, "2026-08-01T00:01:00Z", subject_letter="a", own_letter="d"),  # its sig -> delete
-        _artifact(3, "2026-08-03T00:00:00Z", "0.20260803.1", "b", main=True),  # kept bundle
-        _sig(4, "2026-08-03T00:01:00Z", subject_letter="b", own_letter="e"),  # its sig -> keep
+        _artifact(
+            1, "2026-08-01T00:00:00Z", "0.20260801.1", "a"
+        ),  # old bundle -> delete
+        _sig(
+            2, "2026-08-01T00:01:00Z", subject_letter="a", own_letter="d"
+        ),  # its sig -> delete
+        _artifact(
+            3, "2026-08-03T00:00:00Z", "0.20260803.1", "b", main=True
+        ),  # kept bundle
+        _sig(
+            4, "2026-08-03T00:01:00Z", subject_letter="b", own_letter="e"
+        ),  # its sig -> keep
     ]
     keep, delete = partition(versions, keep_n=1)
     assert keep == {3, 4} and delete == {1, 2}
@@ -55,8 +69,15 @@ def test_signature_follows_its_bundle():
 def test_untagged_and_orphan_sig_are_kept_conservatively():
     versions = [
         _artifact(1, "2026-08-03T00:00:00Z", "0.20260803.1", "a", main=True),
-        {"id": 2, "created_at": "2026-08-03T00:02:00Z", "tags": [], "digest": "sha256:" + H["b"]},  # untagged
-        _sig(3, "2026-08-01T00:00:00Z", subject_letter="f", own_letter="c"),  # subject absent -> orphan
+        {
+            "id": 2,
+            "created_at": "2026-08-03T00:02:00Z",
+            "tags": [],
+            "digest": "sha256:" + H["b"],
+        },  # untagged
+        _sig(
+            3, "2026-08-01T00:00:00Z", subject_letter="f", own_letter="c"
+        ),  # subject absent -> orphan
     ]
     keep, delete = partition(versions, keep_n=1)
     assert keep == {1, 2, 3} and delete == set()


### PR DESCRIPTION
## Description
### Technical
Every main build republishes the whole ~5GB platform to `manifests/scout` + `manifests/scout-manifest`, so unbounded they grow indefinitely. Adds a weekly + manual retention workflow that keeps `:main` + the newest N versioned hauls (and their cosign signatures) and prunes older ones.

- `tooling/manifest/retention.py` — signature-aware keep/delete policy, conservative (under-prunes rather than over-prunes), with offline unit tests.
- `.github/workflows/haul-retention.yaml` — **hard-scoped** to a literal allowlist of the two `manifests/*` packages (never enumerates, so it cannot reach the digest-pinned image/chart packages Flux references). **Dry-run by default**; real deletes only on an explicit dispatch (`dry_run=false`) or a scheduled run once the repo variable `HAUL_RETENTION_ENABLED='true'`.

## Type of change
- [x] CI / build automation

## Impact
### Backward compatibility
None. Read-only until explicitly enabled; touches only the two haul packages.

## Note for reviewers
Reviewed adversarially for scope-escape and over-deletion (none). To roll out: merge, dispatch once with `dry_run=true` to eyeball the plan against the real registry, then set `HAUL_RETENTION_ENABLED=true` to let the weekly schedule prune.
