### PR TITLE
fix(ci): fetch the OPA test binary from GitHub releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -315,7 +315,9 @@ jobs:
         # evaluate under in production keeps test/prod aligned.
         run: |
           OPA_VERSION=$(yq '.opa_image_tag' ansible/group_vars/all/versions.yaml)
-          curl -fsSL -o /tmp/opa "https://openpolicyagent.org/downloads/v${OPA_VERSION}/opa_linux_amd64_static"
+          # openpolicyagent.org/downloads proxies to this asset but has been 502ing; fetch it directly.
+          curl -fsSL --retry 3 --retry-all-errors -o /tmp/opa \
+            "https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_amd64_static"
           chmod +x /tmp/opa
           sudo mv /tmp/opa /usr/local/bin/opa
           opa version


### PR DESCRIPTION
## Description

### Product
None. CI infrastructure fix.

### Technical
`openpolicyagent.org/downloads/v<ver>/opa_linux_amd64_static` is returning **502**, which fails the `Install OPA` step in `ansible-and-python-tests` on every branch. Fetch the same binary from the GitHub release asset instead (keyed off `opa_image_tag`, same version), with `--retry --retry-all-errors` for transient errors.

## Type of change
- [x] Bug fix

## Impact

### Backward compatibility
None. Same OPA version, more reliable source; CI-only, no runtime or API change.

## Testing
Probed both URLs for the pinned version (1.16.2): `openpolicyagent.org/downloads/...` → **502**, the GitHub release asset → **200**. `pre-commit run prettier` passes on the workflow.

## Note for reviewers
Repo-wide breakage (main + every open PR), so worth merging first so the fix propagates before the feature PRs rebase. One line.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project (ran `pre-commit`)
